### PR TITLE
ci(release): publish artifacts on version tag push; drop v prefix in …

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,16 @@
-# Release: ручной запуск сборки артефактов и публикация релиза с тегом v<version>.
-# Триггер: Actions -> Release -> Run workflow
+# Сборка Windows/Linux zip + GitHub Release.
+#
+# Автоматически: push тега X.Y.Z или vX.Y.Z (совпадает с semver в pubspec без +build).
+# Вручную: Actions → Release → Run workflow (создаёт тег из pubspec, если его ещё нет).
 
 name: Release
 
 on:
   workflow_dispatch:
+  push:
+    tags:
+      - '*.*.*'
+      - 'v*'
 
 permissions:
   contents: write
@@ -14,8 +20,27 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  release-gate:
+    name: Version check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify tag matches pubspec (tag push only)
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          set -euo pipefail
+          VER=$(grep '^version:' pubspec.yaml | sed 's/^version: //' | sed 's/+.*//')
+          RAW="${{ github.ref_name }}"
+          TAG="${RAW#v}"
+          if [ "$VER" != "$TAG" ]; then
+            echo "::error::pubspec has version $VER but tag is $RAW — align pubspec and tag (e.g. 0.1.2+1 and tag 0.1.2 or v0.1.2)."
+            exit 1
+          fi
+
   build-windows:
     name: Build Windows
+    needs: [release-gate]
     runs-on: windows-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
@@ -50,18 +75,19 @@ jobs:
 
       - name: Zip Windows artifact
         run: |
-          $tag = "v${{ steps.version.outputs.version }}"
+          $v = "${{ steps.version.outputs.version }}"
           $dir = "build\windows\x64\runner\Release"
-          Compress-Archive -Path "$dir\*" -DestinationPath "Querya-Desktop-$tag-windows.zip"
+          Compress-Archive -Path "$dir\*" -DestinationPath "Querya-Desktop-$v-windows.zip"
 
       - uses: actions/upload-artifact@v4
         with:
           name: bundle-windows
-          path: Querya-Desktop-v${{ steps.version.outputs.version }}-windows.zip
+          path: Querya-Desktop-${{ steps.version.outputs.version }}-windows.zip
           if-no-files-found: error
 
   build-linux:
     name: Build Linux
+    needs: [release-gate]
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
@@ -96,12 +122,12 @@ jobs:
       - name: Zip Linux artifact
         run: |
           cd build/linux/x64/release/bundle
-          zip -r "${GITHUB_WORKSPACE}/Querya-Desktop-v${{ steps.version.outputs.version }}-linux.zip" .
+          zip -r "${GITHUB_WORKSPACE}/Querya-Desktop-${{ steps.version.outputs.version }}-linux.zip" .
 
       - uses: actions/upload-artifact@v4
         with:
           name: bundle-linux
-          path: Querya-Desktop-v${{ steps.version.outputs.version }}-linux.zip
+          path: Querya-Desktop-${{ steps.version.outputs.version }}-linux.zip
           if-no-files-found: error
 
   publish:
@@ -128,22 +154,32 @@ jobs:
           cd dist
           sha256sum *.zip | tee SHA256SUMS.txt
 
+      - name: Release tag name
+        id: rel
+        run: |
+          if [ "${{ github.ref_type }}" = "tag" ]; then
+            echo "tag=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${{ needs.build-windows.outputs.version }}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: v${{ needs.build-windows.outputs.version }}
-          name: Release v${{ needs.build-windows.outputs.version }}
+          tag_name: ${{ steps.rel.outputs.tag }}
+          name: Querya Desktop ${{ needs.build-windows.outputs.version }}
           body: |
-            ## Querya Desktop v${{ needs.build-windows.outputs.version }}
+            ## Querya Desktop ${{ needs.build-windows.outputs.version }}
 
             ### Downloads
-            - **Linux**: Querya-Desktop-v${{ needs.build-windows.outputs.version }}-linux.zip
-            - **Windows**: Querya-Desktop-v${{ needs.build-windows.outputs.version }}-windows.zip
+            - **Linux**: `Querya-Desktop-${{ needs.build-windows.outputs.version }}-linux.zip`
+            - **Windows**: `Querya-Desktop-${{ needs.build-windows.outputs.version }}-windows.zip`
 
-            ### Build Info
-            - Version: ${{ needs.build-windows.outputs.full_version }}
-            - Build Number: ${{ needs.build-windows.outputs.build_number }}
-            - Commit: ${{ github.sha }}
+            Verify checksums: `SHA256SUMS.txt`
+
+            ### Build info
+            - **pubspec**: ${{ needs.build-windows.outputs.full_version }}
+            - **Commit**: ${{ github.sha }}
           fail_on_unmatched_files: true
           files: |
             dist/*.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2026-04-24
+
+### Changed
+
+- **Releases** — pushing a version **git tag** matching `pubspec` (e.g. `0.1.1` after `version: 0.1.1+1`) runs the **Release** workflow: Windows/Linux zips, `SHA256SUMS.txt`, and a GitHub Release (no `v` prefix in tag or artifact names). Manual **Actions → Release** still works.
+
 ## [0.1.0] - 2026-04-24
 
 ### Added
@@ -27,4 +33,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Linux desktop build/install layout no longer targets `/usr/local` when building the app bundle.
 
+[0.1.1]: https://github.com/QueryaHub/Querya-Desktop/compare/0.1.0...0.1.1
 [0.1.0]: https://github.com/QueryaHub/Querya-Desktop/compare/0.0.1...0.1.0

--- a/docs/tags-and-releases.md
+++ b/docs/tags-and-releases.md
@@ -2,11 +2,28 @@
 
 Кратко: как выставить версию и опубликовать бинарники через GitHub Actions.
 
-## Как устроен релиз сейчас
+## Рекомендуемый способ: тег → всё само
 
-- Workflow **[Release](../.github/workflows/release.yml)** запускается **вручную** (**Actions → Release → Run workflow**), а не автоматически при пуше тега.
-- Версия для артефактов и имени тега берётся из поля **`version`** в [pubspec.yaml](../pubspec.yaml) (например `0.9.0+42` → тег `v0.9.0`, build number в метаданных релиза).
-- Собираются артефакты **Windows** и **Linux** (zip), публикуется **`SHA256SUMS.txt`**, создаётся **GitHub Release** с фиксированным телом (описание из workflow, не git-cliff в CI).
+1. В [pubspec.yaml](../pubspec.yaml) выставьте **`version: X.Y.Z+N`** (semver до `+`, build number после).
+2. Закоммитьте и запушьте в **`main`** (или в ветку, откуда мержите в `main`).
+3. Создайте **аннотированный тег** с **той же semver-частью**, что в pubspec (без `+N`):
+   - либо `0.1.1`, если в pubspec `0.1.1+1`;
+   - либо `v0.1.1` — тоже допустимо, CI сравнивает с pubspec без префикса `v`.
+4. Запушьте тег: `git push origin 0.1.1`
+
+После этого workflow **[Release](../.github/workflows/release.yml)** запустится **автоматически**: соберёт **Windows** и **Linux** (zip), **`SHA256SUMS.txt`**, создаст или обновит **GitHub Release** с этими файлами.
+
+Если тег **не совпадает** с semver в pubspec (например, в pubspec `0.1.0`, а тег `0.1.1`), первая job **Version check** упадёт с понятной ошибкой — так и задумано.
+
+## Ручной запуск (как раньше)
+
+- **Actions → Release → Run workflow** на нужном ref (обычно `main`).
+- Workflow возьмёт semver из **pubspec** на этом коммите, соберёт zip и создаст **GitHub Release** с тегом **`X.Y.Z`** (как в pubspec до `+`), если тега ещё нет.
+
+## Что внутри релиза
+
+- Имена архивов: `Querya-Desktop-X.Y.Z-linux.zip`, `Querya-Desktop-X.Y.Z-windows.zip`.
+- Версия для имён и тега — **semver из pubspec**; build `+N` попадает в текст релиза как **полный pubspec version**.
 
 ## Changelog (git-cliff)
 
@@ -18,37 +35,18 @@
 
 - Генерация changelog **не подключена** к `release.yml`; при необходимости вставьте вывод git-cliff в описание релиза вручную на GitHub или расширьте workflow.
 
-## Имя тега
-
-- Workflow создаёт тег вида **`v` + semver из pubspec** (например `v0.9.0`).
-- Чтобы не путаться с другими схемами, придерживайтесь **`v*`** для релизных тегов.
-
-## Перед запуском Release
-
-1. Обновите `version` в `pubspec.yaml`, закоммитьте в ветку по вашему процессу.
-2. Убедитесь, что **CI** (тесты + analyze) зелёные на этом коммите.
-3. Запустите workflow **Release** на нужном коммите (обычно `main`).
-
-## Локальная проверка changelog (опционально)
-
-```bash
-git-cliff --latest --strip header
-```
-
-С токеном GitHub (PR, авторы) см. историческую секцию в предыдущих версиях этого файла или документацию git-cliff.
-
 ## Где смотреть настройки
 
 | Файл | Назначение |
 |------|------------|
-| [.github/workflows/release.yml](../.github/workflows/release.yml) | Ручной релиз, сборка, GitHub Release |
+| [.github/workflows/release.yml](../.github/workflows/release.yml) | Сборка + GitHub Release: **push тегов** `X.Y.Z` / `v*` или **ручной** запуск |
 | [.github/workflows/ci.yml](../.github/workflows/ci.yml) | Тесты, analyze, smoke-сборка Linux при push тегов `X.Y.Z` или `v*` |
-| [.github/workflows/version-bump.yml](../.github/workflows/version-bump.yml) | Автоподнятие patch/build при merge в `main` |
+| [.github/workflows/version-bump.yml](../.github/workflows/version-bump.yml) | Автоподнятие patch/build при merge PR в `main` |
 | [cliff.toml](../cliff.toml) | Правила changelog (локально) |
 
 ## Версия в приложении
 
-Поле **`version`** в `pubspec.yaml` должно соответствовать тому, что вы ожидаете увидеть в имени zip и в GitHub Release. Тег создаётся workflow’ом из этой версии.
+Поле **`version`** в `pubspec.yaml` должно совпадать с ожидаемыми именами zip и тегом (semver до `+`).
 
 ## Платформы
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: querya_desktop
 description: Lightweight desktop SQL/NoSQL client. Flutter (Dart).
-version: 0.1.0+1
+version: 0.1.1+1
 
 environment:
   sdk: ^3.5.0


### PR DESCRIPTION
…zips

- Trigger Release workflow on push tags *.*.* and v* (plus workflow_dispatch)
- Gate: tag semver must match pubspec (v prefix allowed on tag only)
- Artifact names Querya-Desktop-X.Y.Z-{linux,windows}.zip
- Bump pubspec to 0.1.1+1; document flow in tags-and-releases.md