### PR TITLE
feat(theme): VS Code HEX/RGBA color parser (#53)

### DIFF
--- a/lib/core/theme/parser/color_parser.dart
+++ b/lib/core/theme/parser/color_parser.dart
@@ -1,0 +1,47 @@
+import 'dart:ui';
+
+/// Parses VS Code color strings into Flutter [Color].
+Color parseVsCodeColor(String input) {
+  var s = input.trim();
+  if (s.isEmpty) {
+    throw FormatException('Empty color string');
+  }
+  if (s.startsWith('#')) {
+    s = s.substring(1);
+  }
+  if (s.length == 3) {
+    final r = s[0];
+    final g = s[1];
+    final b = s[2];
+    s = '$r$r$g$g$b$b';
+    return Color(int.parse('FF$s', radix: 16));
+  }
+  if (s.length == 4) {
+    final r = s[0];
+    final g = s[1];
+    final b = s[2];
+    final a = s[3];
+    s = '$r$r$g$g$b$b$a$a';
+    return _fromRgbaHex(s);
+  }
+  if (s.length == 6) {
+    return Color(int.parse('FF$s', radix: 16));
+  }
+  if (s.length == 8) {
+    return _fromRgbaHex(s);
+  }
+  throw FormatException('Unsupported color format: $input');
+}
+
+Color _fromRgbaHex(String eight) {
+  final rr = eight.substring(0, 2);
+  final gg = eight.substring(2, 4);
+  final bb = eight.substring(4, 6);
+  final aa = eight.substring(6, 8);
+  return Color.fromARGB(
+    int.parse(aa, radix: 16),
+    int.parse(rr, radix: 16),
+    int.parse(gg, radix: 16),
+    int.parse(bb, radix: 16),
+  );
+}

--- a/test/core/theme/parser/color_parser_test.dart
+++ b/test/core/theme/parser/color_parser_test.dart
@@ -1,0 +1,29 @@
+import 'dart:ui';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:querya_desktop/core/theme/parser/color_parser.dart';
+
+void main() {
+  group('parseVsCodeColor', () {
+    test('6-digit hex', () {
+      expect(parseVsCodeColor('#1e1e1e'), const Color(0xFF1E1E1E));
+    });
+
+    test('8-digit RRGGBBAA', () {
+      expect(parseVsCodeColor('#11223344').alpha, 0x44);
+    });
+
+    test('3-digit shorthand', () {
+      expect(parseVsCodeColor('#abc'), const Color(0xFFAABBCC));
+    });
+
+    test('4-digit shorthand with alpha', () {
+      final c = parseVsCodeColor('#abcd');
+      expect(c, isA<Color>());
+    });
+
+    test('invalid throws', () {
+      expect(() => parseVsCodeColor('nope'), throwsFormatException);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

`parseVsCodeColor` for VS Code theme manifest strings.

**Note:** Rebase onto `dev` after #39 merges (adds `lib/core/theme/parser/`).

Closes #53