### PR TITLE
feat(theme): migrate P0 workbench off QueryaColors (#42)

### DIFF
--- a/lib/features/main_screen/main_screen.dart
+++ b/lib/features/main_screen/main_screen.dart
@@ -17,7 +17,7 @@ import 'package:flutter/material.dart' as material
         RepaintBoundary;
 import 'package:querya_desktop/core/storage/local_db.dart';
 import 'package:querya_desktop/core/theme/app_theme.dart';
-import 'package:querya_desktop/core/theme/querya_colors.dart';
+import 'package:querya_desktop/core/theme/querya_theme_scope.dart';
 import 'package:querya_desktop/features/connections/connection_creation_flow.dart';
 import 'package:querya_desktop/features/connections/connections_panel.dart';
 import 'package:querya_desktop/shared/widgets/widgets.dart';
@@ -369,10 +369,10 @@ class _CustomTitleBarState extends State<_CustomTitleBar> {
                 child: Row(
                   children: [
                     const SizedBox(width: 16),
-                    const material.Icon(
+                    material.Icon(
                       material.Icons.search_rounded,
                       size: 18,
-                      color: QueryaColors.accentCyan,
+                      color: context.workbench.accent,
                     ),
                     const Gap(8),
                     const Text('Querya').semiBold().small(),

--- a/lib/features/main_screen/sql_editor_chrome.dart
+++ b/lib/features/main_screen/sql_editor_chrome.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart' as material;
-import 'package:querya_desktop/core/theme/querya_colors.dart';
 import 'package:shadcn_flutter/shadcn_flutter.dart';
 
 /// Outer chrome for SQL editors: subtle border, surface fill, soft cyan glow.
@@ -18,7 +17,7 @@ class SqlEditorChrome extends StatelessWidget {
       ),
       boxShadow: [
         material.BoxShadow(
-          color: QueryaColors.accentCyan.withValues(alpha: 0.07),
+          color: cs.primary.withValues(alpha: 0.07),
           blurRadius: 18,
           offset: const material.Offset(0, 6),
         ),
@@ -30,7 +29,7 @@ class SqlEditorChrome extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final cs = theme.colorScheme;
-    final glow = QueryaColors.accentCyan.withValues(alpha: 0.1);
+    final glow = cs.primary.withValues(alpha: 0.1);
     return material.Container(
       decoration: material.BoxDecoration(
         borderRadius: material.BorderRadius.circular(14),

--- a/lib/features/main_screen/workspace_empty_hero.dart
+++ b/lib/features/main_screen/workspace_empty_hero.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart' as material;
 import 'package:querya_desktop/core/layout/window_layout.dart';
-import 'package:querya_desktop/core/theme/querya_colors.dart';
 import 'package:querya_desktop/core/theme/querya_typography.dart';
 import 'package:querya_desktop/shared/widgets/widgets.dart';
 
@@ -137,7 +136,7 @@ class _HeroBadge extends StatelessWidget {
         color: colorScheme.background,
         borderRadius: material.BorderRadius.circular(999),
         border: material.Border.all(
-          color: QueryaColors.accentCyan.withValues(alpha: 0.45),
+          color: colorScheme.primary.withValues(alpha: 0.45),
         ),
       ),
       child: material.Row(
@@ -179,7 +178,7 @@ class _MockAppWindow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final glow = QueryaColors.accentCyan.withValues(alpha: 0.14);
+    final glow = colorScheme.primary.withValues(alpha: 0.14);
     final sidebarW = compact ? 58.0 : 72.0;
     final blur = compact ? 28.0 : 40.0;
     final radius = compact ? 12.0 : 16.0;


### PR DESCRIPTION
## Summary

Replace direct `QueryaColors.accentCyan` usage in P0 workbench surfaces with theme tokens:

- `MainScreen` title bar icon → `context.workbench.accent`
- `WorkspaceEmptyHero` badge/mock window → `colorScheme.primary`
- `SqlEditorChrome` glow → `colorScheme.primary`

## Test plan

- [x] `flutter analyze` clean
- [x] `flutter test` green
- [ ] Visual: title bar, empty hero, SQL editor chrome follow active theme

Closes #42