### PR TITLE
feat(editor): JSON syntax highlighting in Mongo document editor (#50)

### DIFF
--- a/lib/core/editor/highlighter_theme_from_querya.dart
+++ b/lib/core/editor/highlighter_theme_from_querya.dart
@@ -41,8 +41,26 @@ HighlighterTheme highlighterThemeFromQueryaEditor(QueryaEditorTheme editor) {
         'settings': {'foreground': _hex(editor.string)},
       },
       {
-        'scope': ['constant.numeric', 'number'],
+        'scope': [
+          'constant.numeric',
+          'constant.numeric.json',
+          'number',
+        ],
         'settings': {'foreground': _hex(editor.number)},
+      },
+      {
+        'scope': [
+          'support.type.property-name',
+          'support.type.property-name.json',
+        ],
+        'settings': {'foreground': _hex(editor.type)},
+      },
+      {
+        'scope': [
+          'constant.language',
+          'constant.language.json',
+        ],
+        'settings': {'foreground': _hex(editor.keyword)},
       },
       {
         'scope': ['entity.name.function', 'support.function'],

--- a/lib/features/mongodb/mongo_document_editor.dart
+++ b/lib/features/mongodb/mongo_document_editor.dart
@@ -5,6 +5,7 @@ import 'package:querya_desktop/core/database/mongodb_connection.dart';
 import 'package:querya_desktop/core/editor/querya_code_editor.dart';
 import 'package:querya_desktop/core/editor/querya_code_language.dart';
 import 'package:querya_desktop/core/database/mongodb_service.dart';
+import 'package:querya_desktop/core/theme/querya_theme_scope.dart';
 import 'package:querya_desktop/shared/widgets/widgets.dart';
 import 'package:shadcn_flutter/shadcn_flutter.dart' as shadcn;
 
@@ -215,6 +216,9 @@ class _MongoDocumentEditorState extends material.State<MongoDocumentEditor> {
   material.Widget build(material.BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final shadcnCs = shadcn.Theme.of(context).colorScheme;
+    final workbench = context.workbench;
+    final editorTheme = context.editorTheme;
+    final success = workbench.success;
     final idStr = widget.document['_id']?.toString() ?? 'New Document';
 
     return material.Column(
@@ -310,16 +314,16 @@ class _MongoDocumentEditorState extends material.State<MongoDocumentEditor> {
           material.Container(
             padding: const material.EdgeInsets.symmetric(
                 horizontal: 16, vertical: 8),
-            color: const Color(0xFF4CAF50).withValues(alpha: 0.1),
+            color: success.withValues(alpha: 0.1),
             child: Row(
               children: [
-                const material.Icon(material.Icons.check_circle_rounded,
-                    size: 14, color: Color(0xFF4CAF50)),
+                material.Icon(material.Icons.check_circle_rounded,
+                    size: 14, color: success),
                 const Gap(8),
                 material.Expanded(
                   child: Text(_success!,
-                      style: const material.TextStyle(
-                          color: Color(0xFF4CAF50), fontSize: 12)),
+                      style: material.TextStyle(
+                          color: success, fontSize: 12)),
                 ),
               ],
             ),
@@ -327,7 +331,7 @@ class _MongoDocumentEditorState extends material.State<MongoDocumentEditor> {
         // Editor
         material.Expanded(
           child: material.Container(
-            color: cs.card,
+            color: editorTheme.background,
             child: QueryaCodeEditor(
               controller: _controller,
               language: QueryaCodeLanguage.json,

--- a/test/core/editor/highlighter_theme_from_querya_test.dart
+++ b/test/core/editor/highlighter_theme_from_querya_test.dart
@@ -17,4 +17,13 @@ void main() {
     expect(span.children, isNotNull);
     expect(span.children!.length, greaterThan(1));
   });
+
+  test('highlighterThemeFromQueryaEditor produces JSON spans', () {
+    final theme = highlighterThemeFromQueryaEditor(QueryaTheme.darkDefault.editor);
+    final highlighter = Highlighter(language: 'json', theme: theme);
+    const sample = '{"name": "x", "count": 1, "ok": true, "nil": null}';
+    final span = highlighter.highlight(sample);
+    expect(span.children, isNotNull);
+    expect(span.children!.length, greaterThan(3));
+  });
 }

--- a/test/features/mongodb/mongo_document_editor_test.dart
+++ b/test/features/mongodb/mongo_document_editor_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart' as material;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:querya_desktop/core/database/mongodb_connection.dart';
+import 'package:querya_desktop/core/editor/querya_code_editor.dart';
+import 'package:querya_desktop/core/editor/syntax_highlight_service.dart';
+import 'package:querya_desktop/core/theme/querya_theme.dart';
+import 'package:querya_desktop/features/mongodb/mongo_document_editor.dart';
+
+import '../../support/querya_theme_test_shell.dart';
+
+void main() {
+  setUpAll(() async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    await SyntaxHighlightService.ensureInitialized();
+  });
+
+  final connection = MongoConnection(id: 1, name: 'test', host: 'localhost');
+
+  Future<void> pumpEditor(
+    WidgetTester tester, {
+    QueryaTheme? theme,
+    Map<String, dynamic> document = const {'_id': 'abc', 'a': 1},
+  }) async {
+    await tester.pumpWidget(
+      queryaThemeTestShell(
+        data: theme ?? QueryaTheme.darkDefault,
+        child: material.SizedBox(
+          width: 800,
+          height: 600,
+          child: MongoDocumentEditor(
+            connection: connection,
+            database: 'db',
+            collection: 'items',
+            document: document,
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('Format pretty-prints valid JSON', (tester) async {
+    await pumpEditor(tester);
+    await tester.enterText(
+      find.byType(material.EditableText),
+      '{"a":1,"b":"x"}',
+    );
+    await tester.pump();
+    await tester.tap(find.text('Format'));
+    await tester.pump();
+
+    final editable = tester.widget<material.EditableText>(
+      find.byType(material.EditableText),
+    );
+    expect(editable.controller.text, contains('\n'));
+    expect(editable.controller.text, contains('  "a"'));
+    expect(find.textContaining('Invalid JSON'), findsNothing);
+  });
+
+  testWidgets('invalid JSON shows error banner without breaking editor', (tester) async {
+    await pumpEditor(tester);
+    await tester.enterText(find.byType(material.EditableText), '{not json');
+    await tester.pump();
+    await tester.tap(find.text('Format'));
+    await tester.pump();
+
+    expect(find.textContaining('Invalid JSON'), findsOneWidget);
+    expect(find.byType(material.EditableText), findsOneWidget);
+  });
+
+  testWidgets('editor uses Querya editor background token', (tester) async {
+    const bg = material.Color(0xFF112233);
+    final theme = QueryaTheme.darkDefault.copyWith(
+      editor: QueryaTheme.darkDefault.editor.copyWith(background: bg),
+    );
+    await pumpEditor(tester, theme: theme);
+
+    final editorFinder = find.byType(QueryaCodeEditor);
+    final container = tester.widget<material.Container>(
+      find.ancestor(
+        of: editorFinder,
+        matching: find.byType(material.Container),
+      ).first,
+    );
+    expect(container.color, bg);
+  });
+}


### PR DESCRIPTION
## Summary
- Extends `HighlighterTheme` with JSON scopes (keys, numbers, `true`/`false`/`null`, strings).
- `MongoDocumentEditor` uses `QueryaCodeEditor` highlighting with `editorTheme.background` and `workbench.success` for the save banner.
- Tests: JSON span unit test, Format/invalid JSON widget tests, editor background token.

## Test plan
- [x] `flutter analyze`
- [x] `flutter test` (333 tests)
- [ ] Manual: open Mongo document, verify key/string/number/boolean colors; Format; invalid JSON error banner; save success banner color follows theme.

Closes #50