### PR TITLE
docs: theme system epic #37 complete

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,8 +4,11 @@ Living document for planned work. Not a commitment order; adjust as priorities c
 
 ## Theme system
 
-- **Done:** runtime themes, VS Code `colors` import, `tokenColors` syntax highlighting — see [theme.md](theme.md).
-- **Later:** `re_editor` if perf gap; LSP epic only per [code-forge-evaluation.md](code-forge-evaluation.md) (**NO-GO** on `code_forge` for 0.3). Theme animation: Preferences → **Animate theme changes** (off by default).
+- **Done (epic #37, 2026-05-28):** runtime themes, VS Code `colors` + `tokenColors` import, SQL/JSON
+  highlighting, P0 workbench migration, Preferences, tests, docs — [theme.md](theme.md).
+- **Optional:** Preferences → **Animate theme changes** (off by default).
+- **Later:** P2 Mongo/Redis token colors; `re_editor` if perf gap; LSP epic per
+  [code-forge-evaluation.md](code-forge-evaluation.md) (**NO-GO** on `code_forge` for 0.3).
 
 ## Query history and favorites
 

--- a/docs/theme.md
+++ b/docs/theme.md
@@ -3,6 +3,18 @@
 Querya Desktop uses a VS Code–inspired theme pipeline: workbench chrome colors,
 editor syntax tokens, and optional import of community `.json` / `.jsonc` themes.
 
+## Milestone status
+
+**Theme system epic ([#37](https://github.com/QueryaHub/Querya-Desktop/issues/37)) — complete on `dev` (2026-05-28).**
+
+Delivered: models (#38), JSONC parser (#39), `ThemeController` (#40–41), Preferences +
+import (#43–45), `tokenColors` → syntax highlight (#46–47, #49–50), P0 workbench tokens
+(#42, #59–60), tests (#58), `docs/theme.md` (#55), Querya Light (#51), optional theme
+animation (#57), editor package spikes (#48, #52).
+
+**Follow-up (not blocking):** P2 surfaces (Mongo/Redis explorer semantic hues), `re_editor`
+if large-buffer benchmarks fail — see [code-forge-evaluation.md](code-forge-evaluation.md).
+
 ## Architecture
 
 ```mermaid


### PR DESCRIPTION
## Summary
- Documents completion of theme epic #37 in `docs/theme.md` and `roadmap.md`.
- GitHub issues #37–#60 (except already closed) were closed on the tracker with links to merged work.

## Test plan
- [x] Doc-only change