### PR TITLE
test(theme): querya.theme.v1 parser fixtures (#97)

### DIFF
--- a/test/fixtures/themes/querya_custom_dark.json
+++ b/test/fixtures/themes/querya_custom_dark.json
@@ -1,0 +1,81 @@
+{
+  "schema": "querya.theme.v1",
+  "id": "fixture-custom-dark",
+  "name": "Fixture Custom Dark",
+  "type": "dark",
+  "description": "Full dark custom theme fixture for parser tests.",
+  "author": "QueryaHub",
+  "version": "1.0.0",
+  "shadcn_colors": {
+    "background": "#101014",
+    "foreground": "#E2E8F0",
+    "card": "#18181F",
+    "cardForeground": "#E2E8F0",
+    "popover": "#18181F",
+    "popoverForeground": "#E2E8F0",
+    "primary": "#38BDF8",
+    "primaryForeground": "#020617",
+    "secondary": "#1F2937",
+    "secondaryForeground": "#E2E8F0",
+    "muted": "#1F2937",
+    "mutedForeground": "#94A3B8",
+    "accent": "#6366F1",
+    "accentForeground": "#F8FAFC",
+    "destructive": "#F87171",
+    "destructiveForeground": "#F8FAFC",
+    "border": "#334155",
+    "input": "#334155",
+    "ring": "#38BDF8",
+    "chart1": "#38BDF8",
+    "chart2": "#6366F1",
+    "chart3": "#F472B6",
+    "chart4": "#A78BFA",
+    "chart5": "#34D399"
+  },
+  "editor_colors": {
+    "background": "#0F1117",
+    "foreground": "#E2E8F0",
+    "lineHighlight": "#1A1D27",
+    "selection": "#264F78",
+    "lineNumber": "#64748B",
+    "bracketMatch": "#38BDF833",
+    "widgetBorder": "#38BDF866",
+    "comment": "#6A9955",
+    "keyword": "#569CD6",
+    "string": "#CE9178",
+    "number": "#B5CEA8",
+    "operator": "#D4D4D4",
+    "function": "#DCDCAA",
+    "type": "#4EC9B0",
+    "canvas": "#09090B",
+    "surface": "#111827",
+    "sidebarBackground": "#0B0F19",
+    "editorBackground": "#0F1117",
+    "mutedForeground": "#94A3B8",
+    "accent": "#38BDF8",
+    "onAccent": "#020617",
+    "borderSubtle": "#334155",
+    "destructive": "#F87171",
+    "success": "#34D399",
+    "warning": "#FBBF24",
+    "gitModified": "#FBBF24",
+    "gitUntracked": "#34D399"
+  },
+  "tokenColors": [
+    {
+      "name": "Comments",
+      "scope": ["comment", "comment.line"],
+      "settings": { "foreground": "#6A9955", "fontStyle": "italic" }
+    },
+    {
+      "name": "Keywords",
+      "scope": ["keyword", "keyword.control"],
+      "settings": { "foreground": "#569CD6", "fontStyle": "bold" }
+    },
+    {
+      "name": "Strings",
+      "scope": ["string"],
+      "settings": { "foreground": "#CE9178" }
+    }
+  ]
+}

--- a/test/fixtures/themes/querya_custom_invalid_color.json
+++ b/test/fixtures/themes/querya_custom_invalid_color.json
@@ -1,0 +1,14 @@
+{
+  "schema": "querya.theme.v1",
+  "id": "fixture-invalid-color",
+  "name": "Fixture Invalid Color",
+  "type": "dark",
+  "shadcn_colors": {
+    "primary": "not-a-color",
+    "background": "#101014"
+  },
+  "editor_colors": {
+    "background": "#0F1117",
+    "selection": "ZZZZZZ"
+  }
+}

--- a/test/fixtures/themes/querya_custom_invalid_missing_id.json
+++ b/test/fixtures/themes/querya_custom_invalid_missing_id.json
@@ -1,0 +1,7 @@
+{
+  "schema": "querya.theme.v1",
+  "name": "Missing Id Fixture",
+  "type": "dark",
+  "shadcn_colors": {},
+  "editor_colors": {}
+}

--- a/test/fixtures/themes/querya_custom_jsonc.jsonc
+++ b/test/fixtures/themes/querya_custom_jsonc.jsonc
@@ -1,0 +1,22 @@
+{
+  // JSONC fixture: comments and trailing commas are stripped before parse.
+  "schema": "querya.theme.v1",
+  "id": "fixture-custom-jsonc",
+  "name": "Fixture Custom JSONC",
+  "type": "light",
+  "shadcn_colors": {
+    "background": "#FAFAFA",
+    "primary": "#0EA5E9",
+  },
+  "editor_colors": {
+    "background": "#FFFFFF",
+    "foreground": "#111827",
+  },
+  "tokenColors": [
+    {
+      "name": "Comments",
+      "scope": ["comment"],
+      "settings": { "foreground": "#6B7280" },
+    },
+  ],
+}

--- a/test/fixtures/themes/querya_custom_light.json
+++ b/test/fixtures/themes/querya_custom_light.json
@@ -1,0 +1,81 @@
+{
+  "schema": "querya.theme.v1",
+  "id": "fixture-custom-light",
+  "name": "Fixture Custom Light",
+  "type": "light",
+  "description": "Full light custom theme fixture for parser tests.",
+  "author": "QueryaHub",
+  "version": "1.0.0",
+  "shadcn_colors": {
+    "background": "#F8FAFC",
+    "foreground": "#0F172A",
+    "card": "#FFFFFF",
+    "cardForeground": "#0F172A",
+    "popover": "#FFFFFF",
+    "popoverForeground": "#0F172A",
+    "primary": "#0284C7",
+    "primaryForeground": "#F8FAFC",
+    "secondary": "#E2E8F0",
+    "secondaryForeground": "#0F172A",
+    "muted": "#E2E8F0",
+    "mutedForeground": "#64748B",
+    "accent": "#CBD5E1",
+    "accentForeground": "#0F172A",
+    "destructive": "#DC2626",
+    "destructiveForeground": "#F8FAFC",
+    "border": "#CBD5E1",
+    "input": "#CBD5E1",
+    "ring": "#0284C7",
+    "chart1": "#0284C7",
+    "chart2": "#0891B2",
+    "chart3": "#EA580C",
+    "chart4": "#7C3AED",
+    "chart5": "#DB2777"
+  },
+  "editor_colors": {
+    "background": "#FFFFFF",
+    "foreground": "#1E293B",
+    "lineHighlight": "#F1F5F9",
+    "selection": "#ADD6FF",
+    "lineNumber": "#64748B",
+    "bracketMatch": "#0284C733",
+    "widgetBorder": "#0284C766",
+    "comment": "#008000",
+    "keyword": "#0000FF",
+    "string": "#A31515",
+    "number": "#098658",
+    "operator": "#1E293B",
+    "function": "#795E26",
+    "type": "#267F99",
+    "canvas": "#F8FAFC",
+    "surface": "#FFFFFF",
+    "sidebarBackground": "#F1F5F9",
+    "editorBackground": "#FFFFFF",
+    "mutedForeground": "#64748B",
+    "accent": "#0284C7",
+    "onAccent": "#F8FAFC",
+    "borderSubtle": "#CBD5E1",
+    "destructive": "#DC2626",
+    "success": "#16A34A",
+    "warning": "#D97706",
+    "gitModified": "#D97706",
+    "gitUntracked": "#16A34A"
+  },
+  "tokenColors": [
+    {
+      "name": "Comments",
+      "scope": ["comment", "comment.line"],
+      "settings": { "foreground": "#008000", "fontStyle": "italic" }
+    },
+    {
+      "name": "Keywords",
+      "scope": ["keyword", "keyword.control"],
+      "settings": { "foreground": "#0000FF", "fontStyle": "bold" }
+    },
+    {
+      "name": "Strings",
+      "scope": ["string"],
+      "settings": { "foreground": "#A31515" }
+    }
+  ]
+}

--- a/test/fixtures/themes/querya_custom_minimal.json
+++ b/test/fixtures/themes/querya_custom_minimal.json
@@ -1,0 +1,12 @@
+{
+  "schema": "querya.theme.v1",
+  "id": "fixture-custom-minimal",
+  "name": "Fixture Custom Minimal",
+  "type": "dark",
+  "shadcn_colors": {
+    "primary": "#FF00AA"
+  },
+  "editor_colors": {
+    "background": "#010203"
+  }
+}


### PR DESCRIPTION
## Summary

- Add stable test fixtures for the custom theme parser epic:
  - `querya_custom_dark.json` / `querya_custom_light.json` — full themes with distinct values
  - `querya_custom_minimal.json` — small required-field subset
  - `querya_custom_invalid_missing_id.json` — missing `id`
  - `querya_custom_invalid_color.json` — invalid optional colors
  - `querya_custom_jsonc.jsonc` — comments and trailing commas

## Test plan

- [x] All `.json` fixtures parse with `json.loads`
- [x] JSONC fixture follows existing JSONC test pattern (stripped before parse in code)

Depends on #127 (TP-01 docs). Merge #127 first, then re-target this PR to `dev` if needed.

Closes #97