### PR TITLE
feat(theme): parseQueryaThemeColor wrapper (#99)

### DIFF
--- a/lib/core/theme/parser/color_parser.dart
+++ b/lib/core/theme/parser/color_parser.dart
@@ -33,6 +33,41 @@ Color parseVsCodeColor(String input) {
   throw FormatException('Unsupported color format: $input');
 }
 
+/// Parses Querya custom theme hex strings into Flutter [Color].
+///
+/// Accepts `#RRGGBB`, `RRGGBB`, `#AARRGGBB`, and `AARRGGBB`. Shorthand `#RGB` /
+/// `#RGBA` and 6-digit values delegate to [parseVsCodeColor]. Eight-digit values
+/// use alpha-first `AARRGGBB` (Querya custom), not VS Code `RRGGBBAA`.
+Color parseQueryaThemeColor(String raw) {
+  final trimmed = raw.trim();
+  if (trimmed.isEmpty) {
+    throw FormatException('Invalid Querya theme color: $raw');
+  }
+
+  var s = trimmed;
+  if (s.startsWith('#')) {
+    s = s.substring(1);
+  }
+
+  if (s.length == 8) {
+    try {
+      final aa = int.parse(s.substring(0, 2), radix: 16);
+      final rr = int.parse(s.substring(2, 4), radix: 16);
+      final gg = int.parse(s.substring(4, 6), radix: 16);
+      final bb = int.parse(s.substring(6, 8), radix: 16);
+      return Color.fromARGB(aa, rr, gg, bb);
+    } on FormatException {
+      throw FormatException('Invalid Querya theme color: $raw');
+    }
+  }
+
+  try {
+    return parseVsCodeColor(trimmed.startsWith('#') ? trimmed : '#$s');
+  } on FormatException {
+    throw FormatException('Invalid Querya theme color: $raw');
+  }
+}
+
 /// Encodes a [Color] as a VS Code hex string (`#RRGGBB` or `#RRGGBBAA`).
 String formatVsCodeColor(Color color) {
   String channel(double component) =>

--- a/test/core/theme/parser/color_parser_test.dart
+++ b/test/core/theme/parser/color_parser_test.dart
@@ -2,7 +2,7 @@ import 'dart:ui';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:querya_desktop/core/theme/parser/color_parser.dart'
-    show formatVsCodeColor, parseVsCodeColor;
+    show formatVsCodeColor, parseQueryaThemeColor, parseVsCodeColor;
 
 void main() {
   group('parseVsCodeColor', () {
@@ -32,6 +32,72 @@ void main() {
       const c = Color(0xFF1E1E1E);
       expect(formatVsCodeColor(c), '#1e1e1e');
       expect(parseVsCodeColor(formatVsCodeColor(c)), c);
+    });
+  });
+
+  group('parseQueryaThemeColor', () {
+    test('parses hash-prefixed RRGGBB', () {
+      expect(parseQueryaThemeColor('#1E1E1E'), const Color(0xFF1E1E1E));
+    });
+
+    test('parses bare RRGGBB', () {
+      expect(parseQueryaThemeColor('1E1E1E'), const Color(0xFF1E1E1E));
+    });
+
+    test('parses hash-prefixed AARRGGBB', () {
+      expect(parseQueryaThemeColor('#801E1E1E'), const Color(0x801E1E1E));
+    });
+
+    test('parses bare AARRGGBB', () {
+      expect(parseQueryaThemeColor('FF1E1E1E'), const Color(0xFF1E1E1E));
+    });
+
+    test('accepts lowercase hex', () {
+      expect(parseQueryaThemeColor('#ff1e1e1e'), const Color(0xFF1E1E1E));
+      expect(parseQueryaThemeColor('1e1e1e'), const Color(0xFF1E1E1E));
+    });
+
+    test('delegates shorthand RGB to parseVsCodeColor', () {
+      expect(parseQueryaThemeColor('#abc'), const Color(0xFFAABBCC));
+    });
+
+    test('invalid length mentions value', () {
+      expect(
+        () => parseQueryaThemeColor('12345'),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            'Invalid Querya theme color: 12345',
+          ),
+        ),
+      );
+    });
+
+    test('invalid characters mention value', () {
+      expect(
+        () => parseQueryaThemeColor('GGHHII'),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            'Invalid Querya theme color: GGHHII',
+          ),
+        ),
+      );
+    });
+
+    test('empty string mentions value', () {
+      expect(
+        () => parseQueryaThemeColor('   '),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            'Invalid Querya theme color:    ',
+          ),
+        ),
+      );
     });
   });
 }


### PR DESCRIPTION
## Summary

- Add `parseQueryaThemeColor` for Querya custom theme hex strings.
- Support `#RRGGBB`, `RRGGBB`, `#AARRGGBB`, `AARRGGBB`, plus shorthand `#RGB` via `parseVsCodeColor`.
- Eight-digit values use alpha-first `AARRGGBB` (Querya custom), distinct from VS Code `RRGGBBAA`.

## Test plan

- [x] `flutter test test/core/theme/parser/color_parser_test.dart`

Closes #99