### PR TITLE
feat(theme): map editor_colors to QueryaWorkbenchTheme (#102)

### DIFF
--- a/lib/core/theme/parser/querya_workbench_theme_from_manifest.dart
+++ b/lib/core/theme/parser/querya_workbench_theme_from_manifest.dart
@@ -1,0 +1,71 @@
+import 'dart:ui';
+
+import 'package:flutter/foundation.dart';
+
+import '../querya_workbench_theme.dart';
+import 'color_parser.dart';
+
+/// Workbench keys accepted in Querya custom `editor_colors`.
+///
+/// Editor syntax/surface keys are mapped separately by [editorThemeFromQueryaColors].
+/// The generic `background` key is intentionally not mapped to canvas/editorBackground.
+const _knownWorkbenchColorKeys = {
+  'canvas',
+  'surface',
+  'sidebarBackground',
+  'editorBackground',
+  'mutedForeground',
+  'accent',
+  'onAccent',
+  'borderSubtle',
+  'destructive',
+  'success',
+  'warning',
+  'gitModified',
+  'gitUntracked',
+};
+
+/// Builds [QueryaWorkbenchTheme] from Querya custom `editor_colors`.
+///
+/// Missing keys and invalid optional colors fall back to [fallback].
+QueryaWorkbenchTheme workbenchThemeFromQueryaColors({
+  required Map<String, String> colors,
+  required QueryaWorkbenchTheme fallback,
+}) {
+  if (kDebugMode) {
+    for (final key in colors.keys) {
+      if (!_knownWorkbenchColorKeys.contains(key)) {
+        debugPrint('Querya theme: ignored editor_colors workbench key "$key"');
+      }
+    }
+  }
+
+  Color pick(String key, Color defaultValue) {
+    final raw = colors[key];
+    if (raw == null) return defaultValue;
+    try {
+      return parseQueryaThemeColor(raw);
+    } on FormatException {
+      if (kDebugMode) {
+        debugPrint('Querya theme: invalid editor_colors."$key": $raw');
+      }
+      return defaultValue;
+    }
+  }
+
+  return fallback.copyWith(
+    canvas: pick('canvas', fallback.canvas),
+    surface: pick('surface', fallback.surface),
+    sidebarBackground: pick('sidebarBackground', fallback.sidebarBackground),
+    editorBackground: pick('editorBackground', fallback.editorBackground),
+    mutedForeground: pick('mutedForeground', fallback.mutedForeground),
+    accent: pick('accent', fallback.accent),
+    onAccent: pick('onAccent', fallback.onAccent),
+    borderSubtle: pick('borderSubtle', fallback.borderSubtle),
+    destructive: pick('destructive', fallback.destructive),
+    success: pick('success', fallback.success),
+    warning: pick('warning', fallback.warning),
+    gitModified: pick('gitModified', fallback.gitModified),
+    gitUntracked: pick('gitUntracked', fallback.gitUntracked),
+  );
+}

--- a/test/core/theme/parser/querya_workbench_theme_from_manifest_test.dart
+++ b/test/core/theme/parser/querya_workbench_theme_from_manifest_test.dart
@@ -1,0 +1,72 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:querya_desktop/core/theme/parser/color_parser.dart';
+import 'package:querya_desktop/core/theme/parser/querya_theme_manifest.dart';
+import 'package:querya_desktop/core/theme/parser/querya_workbench_theme_from_manifest.dart';
+import 'package:querya_desktop/core/theme/querya_theme.dart';
+
+void main() {
+  group('workbenchThemeFromQueryaColors', () {
+    test('full fixture maps custom workbench values', () {
+      final raw =
+          File('test/fixtures/themes/querya_custom_dark.json').readAsStringSync();
+      final manifest = QueryaThemeManifest.fromJsonString(raw);
+      final workbench = workbenchThemeFromQueryaColors(
+        colors: manifest.editorColors,
+        fallback: QueryaTheme.darkDefault.workbench,
+      );
+
+      expect(workbench.canvas, parseQueryaThemeColor('#09090B'));
+      expect(workbench.surface, parseQueryaThemeColor('#111827'));
+      expect(workbench.sidebarBackground, parseQueryaThemeColor('#0B0F19'));
+      expect(workbench.editorBackground, parseQueryaThemeColor('#0F1117'));
+      expect(workbench.accent, parseQueryaThemeColor('#38BDF8'));
+      expect(workbench.gitModified, parseQueryaThemeColor('#FBBF24'));
+      expect(workbench.gitUntracked, parseQueryaThemeColor('#34D399'));
+    });
+
+    test('minimal fixture falls back for missing workbench fields', () {
+      final raw = File('test/fixtures/themes/querya_custom_minimal.json')
+          .readAsStringSync();
+      final manifest = QueryaThemeManifest.fromJsonString(raw);
+      final fallback = QueryaTheme.darkDefault.workbench;
+      final workbench = workbenchThemeFromQueryaColors(
+        colors: manifest.editorColors,
+        fallback: fallback,
+      );
+
+      expect(workbench.canvas, fallback.canvas);
+      expect(workbench.surface, fallback.surface);
+      expect(workbench.accent, fallback.accent);
+      expect(workbench.gitModified, fallback.gitModified);
+    });
+
+    test('invalid optional color uses fallback value', () {
+      final fallback = QueryaTheme.darkDefault.workbench;
+      final workbench = workbenchThemeFromQueryaColors(
+        colors: const {
+          'canvas': '#09090B',
+          'accent': 'not-a-color',
+          'gitModified': 'ZZZZZZ',
+        },
+        fallback: fallback,
+      );
+
+      expect(workbench.canvas, parseQueryaThemeColor('#09090B'));
+      expect(workbench.accent, fallback.accent);
+      expect(workbench.gitModified, fallback.gitModified);
+    });
+
+    test('does not map editor background key to workbench canvas', () {
+      final fallback = QueryaTheme.darkDefault.workbench;
+      final workbench = workbenchThemeFromQueryaColors(
+        colors: const {'background': '#010203'},
+        fallback: fallback,
+      );
+
+      expect(workbench.canvas, fallback.canvas);
+      expect(workbench.editorBackground, fallback.editorBackground);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Add `workbenchThemeFromQueryaColors` for workbench/chrome keys in `editor_colors`.
- Map canvas, surface, sidebar, accent, git decorations, success/warning, etc.
- Editor syntax keys are ignored; generic `background` is not mapped to canvas.

## Test plan

- [x] `flutter test test/core/theme/parser/querya_workbench_theme_from_manifest_test.dart`

Closes #102