### PR TITLE
feat(theme): ThemePaths directory helpers (#106)

### DIFF
--- a/lib/core/theme/theme_paths.dart
+++ b/lib/core/theme/theme_paths.dart
@@ -1,0 +1,47 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+/// Centralizes theme file locations under app support and legacy paths.
+abstract final class ThemePaths {
+  static const _themesSegment = 'themes';
+  static const _importedSegment = 'imported';
+
+  /// App support `themes/` directory. Does not create the directory.
+  static Future<Directory> userThemesDirectory() async {
+    final support = await getApplicationSupportDirectory();
+    return Directory(p.join(support.path, _themesSegment));
+  }
+
+  /// App support `themes/imported/` directory. Does not create the directory.
+  static Future<Directory> importedThemesDirectory() async {
+    final themes = await userThemesDirectory();
+    return Directory(p.join(themes.path, _importedSegment));
+  }
+
+  /// Creates app support `themes/` if missing.
+  static Future<Directory> ensureUserThemesDirectory() async {
+    final dir = await userThemesDirectory();
+    if (!await dir.exists()) {
+      await dir.create(recursive: true);
+    }
+    return dir;
+  }
+
+  /// Creates app support `themes/imported/` if missing.
+  static Future<Directory> ensureImportedThemesDirectory() async {
+    final dir = await importedThemesDirectory();
+    if (!await dir.exists()) {
+      await dir.create(recursive: true);
+    }
+    return dir;
+  }
+
+  /// Optional legacy `~/.querya/themes`. Does not create the directory.
+  static Future<Directory?> legacyDotQueryaThemesDirectory() async {
+    final home = Platform.environment['HOME'];
+    if (home == null || home.isEmpty) return null;
+    return Directory(p.join(home, '.querya', _themesSegment));
+  }
+}

--- a/test/core/theme/theme_paths_test.dart
+++ b/test/core/theme/theme_paths_test.dart
@@ -1,0 +1,84 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:querya_desktop/core/theme/theme_paths.dart';
+
+class _FakePathProvider extends PathProviderPlatform {
+  _FakePathProvider(this._root);
+  final String _root;
+
+  @override
+  Future<String?> getApplicationSupportPath() async => _root;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempDir;
+
+  setUpAll(() async {
+    tempDir = await Directory.systemTemp.createTemp('querya_theme_paths_test_');
+    PathProviderPlatform.instance = _FakePathProvider(tempDir.path);
+  });
+
+  tearDownAll(() async {
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  group('ThemePaths', () {
+    test('userThemesDirectory resolves under app support', () async {
+      final dir = await ThemePaths.userThemesDirectory();
+
+      expect(dir.path, p.join(tempDir.path, 'themes'));
+    });
+
+    test('importedThemesDirectory resolves under user themes', () async {
+      final dir = await ThemePaths.importedThemesDirectory();
+
+      expect(dir.path, p.join(tempDir.path, 'themes', 'imported'));
+    });
+
+    test('path getters do not create directories', () async {
+      await ThemePaths.userThemesDirectory();
+      await ThemePaths.importedThemesDirectory();
+
+      expect(await Directory(p.join(tempDir.path, 'themes')).exists(), isFalse);
+      expect(
+        await Directory(p.join(tempDir.path, 'themes', 'imported')).exists(),
+        isFalse,
+      );
+    });
+
+    test('ensureUserThemesDirectory creates themes folder', () async {
+      final dir = await ThemePaths.ensureUserThemesDirectory();
+
+      expect(dir.path, p.join(tempDir.path, 'themes'));
+      expect(await dir.exists(), isTrue);
+    });
+
+    test('ensureImportedThemesDirectory creates imported folder', () async {
+      final dir = await ThemePaths.ensureImportedThemesDirectory();
+
+      expect(dir.path, p.join(tempDir.path, 'themes', 'imported'));
+      expect(await dir.exists(), isTrue);
+    });
+
+    test('legacyDotQueryaThemesDirectory resolves ~/.querya/themes', () async {
+      final home = Platform.environment['HOME'];
+      if (home == null || home.isEmpty) {
+        expect(await ThemePaths.legacyDotQueryaThemesDirectory(), isNull);
+        return;
+      }
+
+      final dir = await ThemePaths.legacyDotQueryaThemesDirectory();
+
+      expect(dir, isNotNull);
+      expect(dir!.path, p.join(home, '.querya', 'themes'));
+      expect(await dir.exists(), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Add `ThemePaths` with `userThemesDirectory`, `importedThemesDirectory`, and optional `legacyDotQueryaThemesDirectory`.
- Path getters do not create directories; `ensureUserThemesDirectory` / `ensureImportedThemesDirectory` create when missing.

## Test plan

- [x] `flutter test test/core/theme/theme_paths_test.dart`

Closes #106