### PR TITLE
feat(theme): persist selected theme in AppSettings (#110)

### DIFF
--- a/lib/core/storage/app_settings.dart
+++ b/lib/core/storage/app_settings.dart
@@ -106,6 +106,9 @@ abstract final class AppSettingsKeys {
   static const themeImportPath = 'theme_import_path';
   static const themeImportName = 'theme_import_name';
   static const themeImportedColorsJson = 'theme_imported_colors_json';
+  static const themeSelectedId = 'theme_selected_id';
+  static const themeSelectedSource = 'theme_selected_source';
+  static const themeSelectedPath = 'theme_selected_path';
   static const themeAnimationEnabled = 'theme_animation_enabled';
   static const uiScale = 'ui_scale';
 }
@@ -327,6 +330,68 @@ class AppSettings {
     AppSettingsRevision.bump();
   }
 
+  Future<String?> getSelectedThemeId() async {
+    final v = await LocalDb.instance.getAppSetting(AppSettingsKeys.themeSelectedId);
+    if (v == null || v.isEmpty) return null;
+    return v;
+  }
+
+  Future<void> setSelectedThemeId(String? id) async {
+    if (id == null || id.isEmpty) {
+      await LocalDb.instance.deleteAppSetting(AppSettingsKeys.themeSelectedId);
+    } else {
+      await LocalDb.instance.setAppSetting(AppSettingsKeys.themeSelectedId, id);
+    }
+    AppSettingsRevision.bump();
+  }
+
+  Future<String?> getSelectedThemeSource() async {
+    final v =
+        await LocalDb.instance.getAppSetting(AppSettingsKeys.themeSelectedSource);
+    if (v == null || v.isEmpty) return null;
+    return v;
+  }
+
+  Future<void> setSelectedThemeSource(String? source) async {
+    if (source == null || source.isEmpty) {
+      await LocalDb.instance.deleteAppSetting(
+        AppSettingsKeys.themeSelectedSource,
+      );
+    } else {
+      await LocalDb.instance.setAppSetting(
+        AppSettingsKeys.themeSelectedSource,
+        source,
+      );
+    }
+    AppSettingsRevision.bump();
+  }
+
+  Future<String?> getSelectedThemePath() async {
+    final v =
+        await LocalDb.instance.getAppSetting(AppSettingsKeys.themeSelectedPath);
+    if (v == null || v.isEmpty) return null;
+    return v;
+  }
+
+  Future<void> setSelectedThemePath(String? path) async {
+    if (path == null || path.isEmpty) {
+      await LocalDb.instance.deleteAppSetting(AppSettingsKeys.themeSelectedPath);
+    } else {
+      await LocalDb.instance.setAppSetting(
+        AppSettingsKeys.themeSelectedPath,
+        path,
+      );
+    }
+    AppSettingsRevision.bump();
+  }
+
+  Future<void> clearSelectedThemeRegistry() async {
+    await LocalDb.instance.deleteAppSetting(AppSettingsKeys.themeSelectedId);
+    await LocalDb.instance.deleteAppSetting(AppSettingsKeys.themeSelectedSource);
+    await LocalDb.instance.deleteAppSetting(AppSettingsKeys.themeSelectedPath);
+    AppSettingsRevision.bump();
+  }
+
   Future<Map<String, String>> getThemeImportedColors() async {
     final v = await LocalDb.instance.getAppSetting(
       AppSettingsKeys.themeImportedColorsJson,
@@ -453,6 +518,9 @@ class AppSettings {
     await LocalDb.instance.deleteAppSetting(AppSettingsKeys.themePreset);
     await LocalDb.instance.deleteAppSetting(AppSettingsKeys.themeOverridesJson);
     await LocalDb.instance.deleteAppSetting(AppSettingsKeys.themeAnimationEnabled);
+    await LocalDb.instance.deleteAppSetting(AppSettingsKeys.themeSelectedId);
+    await LocalDb.instance.deleteAppSetting(AppSettingsKeys.themeSelectedSource);
+    await LocalDb.instance.deleteAppSetting(AppSettingsKeys.themeSelectedPath);
     await deleteThemeImportKeys();
     AppSettingsRevision.bump();
   }

--- a/test/core/storage/app_settings_test.dart
+++ b/test/core/storage/app_settings_test.dart
@@ -227,6 +227,55 @@ void main() {
       await AppSettings.instance.clearThemeColorOverrides();
       expect(await AppSettings.instance.getThemeColorOverrides(), isEmpty);
     });
+
+    test('selected theme registry id/source/path roundtrip', () async {
+      expect(await AppSettings.instance.getSelectedThemeId(), isNull);
+      expect(await AppSettings.instance.getSelectedThemeSource(), isNull);
+      expect(await AppSettings.instance.getSelectedThemePath(), isNull);
+
+      await AppSettings.instance.setSelectedThemeId('fixture-custom-dark');
+      await AppSettings.instance.setSelectedThemeSource('filesystem');
+      await AppSettings.instance.setSelectedThemePath(
+        '/data/themes/fixture-custom-dark.json',
+      );
+
+      expect(
+        await AppSettings.instance.getSelectedThemeId(),
+        'fixture-custom-dark',
+      );
+      expect(
+        await AppSettings.instance.getSelectedThemeSource(),
+        'filesystem',
+      );
+      expect(
+        await AppSettings.instance.getSelectedThemePath(),
+        '/data/themes/fixture-custom-dark.json',
+      );
+    });
+
+    test('clearSelectedThemeRegistry clears registry selection', () async {
+      await AppSettings.instance.setSelectedThemeId('fixture-custom-dark');
+      await AppSettings.instance.setSelectedThemeSource('imported');
+      await AppSettings.instance.setSelectedThemePath('/tmp/theme.json');
+
+      await AppSettings.instance.clearSelectedThemeRegistry();
+
+      expect(await AppSettings.instance.getSelectedThemeId(), isNull);
+      expect(await AppSettings.instance.getSelectedThemeSource(), isNull);
+      expect(await AppSettings.instance.getSelectedThemePath(), isNull);
+    });
+
+    test('clearThemeSettings clears selected registry theme', () async {
+      await AppSettings.instance.setSelectedThemeId('fixture-custom-light');
+      await AppSettings.instance.setSelectedThemeSource('filesystem');
+      await AppSettings.instance.setSelectedThemePath('/tmp/light.json');
+
+      await AppSettings.instance.clearThemeSettings();
+
+      expect(await AppSettings.instance.getSelectedThemeId(), isNull);
+      expect(await AppSettings.instance.getSelectedThemeSource(), isNull);
+      expect(await AppSettings.instance.getSelectedThemePath(), isNull);
+    });
   });
 
   group('ui scale', () {


### PR DESCRIPTION
## Summary

- Add `theme_selected_id`, `theme_selected_source`, and `theme_selected_path` settings keys.
- Expose getters/setters plus `clearSelectedThemeRegistry()`; include keys in `clearThemeSettings`.
- Legacy preset/import settings remain unchanged; theme writes still bump `AppSettingsRevision` only.

## Test plan

- [x] `flutter test test/core/storage/app_settings_test.dart`

Closes #110