### PR TITLE
feat(theme): ThemeController registry integration (#112)

### DIFF
--- a/lib/core/theme/theme_controller.dart
+++ b/lib/core/theme/theme_controller.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart' as material;
 import 'package:querya_desktop/core/storage/app_settings.dart';
 import 'package:querya_desktop/core/theme/querya_material_theme.dart';

--- a/lib/core/theme/theme_controller.dart
+++ b/lib/core/theme/theme_controller.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart' as material;
 import 'package:querya_desktop/core/storage/app_settings.dart';
 import 'package:querya_desktop/core/theme/querya_material_theme.dart';
@@ -10,11 +11,17 @@ import 'parser/vscode_colors_merge.dart';
 import 'parser/vscode_theme_manifest.dart';
 import 'querya_theme.dart';
 import 'querya_theme_preset.dart';
+import 'theme_definition.dart';
 import 'theme_import_service.dart';
+import 'theme_load_result.dart';
+import 'theme_registry_service.dart';
 
 /// Active theme state: preset, optional imported colors, user overrides.
 class ThemeController extends ChangeNotifier {
-  ThemeController._();
+  ThemeRegistryService _registryService;
+
+  ThemeController._({ThemeRegistryService? registryService})
+      : _registryService = registryService ?? ThemeRegistryService();
 
   static final ThemeController instance = ThemeController._();
 
@@ -26,6 +33,13 @@ class ThemeController extends ChangeNotifier {
   String? _importedThemeName;
   bool _loaded = false;
   bool _themeAnimationEnabled = false;
+
+  List<ThemeDefinition> _availableThemes = const [];
+  String? _selectedThemeId;
+  String? _selectedThemePath;
+  String? _selectedThemeLoadError;
+  QueryaTheme? _registryTheme;
+  bool _registrySelectionFailed = false;
 
   QueryaTheme? _cachedLightTheme;
   QueryaTheme? _cachedDarkTheme;
@@ -47,6 +61,14 @@ class ThemeController extends ChangeNotifier {
   bool get hasImportedTheme => _importedColors.isNotEmpty;
 
   String? get importedThemeName => _importedThemeName;
+
+  List<ThemeDefinition> get availableThemes => List.unmodifiable(_availableThemes);
+
+  String? get selectedThemeId => _selectedThemeId;
+
+  String? get selectedThemePath => _selectedThemePath;
+
+  String? get selectedThemeLoadError => _selectedThemeLoadError;
 
   /// User `workbench.colorCustomizations` layer (VS Code keys → hex).
   Map<String, String> get userColorOverrides =>
@@ -81,15 +103,13 @@ class ThemeController extends ChangeNotifier {
 
   /// Workbench + editor tokens for the current preset/mode and overrides.
   QueryaTheme get activeTheme =>
-      _cachedActiveTheme ??= _themeForBrightness(_effectiveBrightness());
+      _resolvedThemeForBrightness(_effectiveBrightness());
 
   ThemeData get lightShadcnTheme => _cachedLightShadcnTheme ??=
-      (_cachedLightTheme ??= _themeForBrightness(Brightness.light))
-          .toShadcnThemeData();
+      _resolvedThemeForBrightness(Brightness.light).toShadcnThemeData();
 
   ThemeData get darkShadcnTheme => _cachedDarkShadcnTheme ??=
-      (_cachedDarkTheme ??= _themeForBrightness(Brightness.dark))
-          .toShadcnThemeData();
+      _resolvedThemeForBrightness(Brightness.dark).toShadcnThemeData();
 
   /// Cached Material theme for dialogs/dropdowns (avoids rebuild churn).
   material.ThemeData materialThemeFor(ColorScheme scheme) {
@@ -100,6 +120,14 @@ class ThemeController extends ChangeNotifier {
     _cachedMaterialThemeScheme = scheme;
     return _cachedMaterialTheme = materialThemeFromQuerya(scheme);
   }
+
+  @visibleForTesting
+  void setRegistryServiceForTest(ThemeRegistryService service) {
+    _registryService = service;
+  }
+
+  @visibleForTesting
+  ThemeRegistryService get registryServiceForTest => _registryService;
 
   void _invalidateThemeCache() {
     _cachedLightTheme = null;
@@ -143,8 +171,64 @@ class ThemeController extends ChangeNotifier {
     _importedColors = Map.unmodifiable(imported);
     _themeAnimationEnabled =
         await AppSettings.instance.getThemeAnimationEnabled();
+
+    _availableThemes = await _registryService.loadThemeDefinitions();
+    await _restoreSelectedRegistryTheme();
+
     _loaded = true;
     _notifyThemeChanged();
+  }
+
+  Future<void> loadAvailableThemes() async {
+    _availableThemes = await _registryService.loadThemeDefinitions();
+    notifyListeners();
+  }
+
+  Future<void> setThemeById(String id) async {
+    final definition = _definitionById(id);
+    if (definition == null) {
+      _selectedThemeLoadError = 'Theme "$id" not found.';
+      notifyListeners();
+      return;
+    }
+
+    final result = await _registryService.loadTheme(definition);
+    switch (result) {
+      case ThemeLoadSuccess(:final theme, :final definition):
+        _registryTheme = theme;
+        _registrySelectionFailed = false;
+        _selectedThemeId = definition.id;
+        _selectedThemePath = definition.path;
+        _selectedThemeLoadError = null;
+        _themeMode = theme.brightness == Brightness.light
+            ? ThemeMode.light
+            : ThemeMode.dark;
+        await AppSettings.instance.setSelectedThemeId(definition.id);
+        await AppSettings.instance.setSelectedThemeSource(definition.source.name);
+        await AppSettings.instance.setSelectedThemePath(definition.path);
+        await AppSettings.instance.setThemeMode(_themeMode);
+        _notifyThemeChanged();
+      case ThemeLoadFailure(:final message):
+        _selectedThemeLoadError = message;
+        notifyListeners();
+    }
+  }
+
+  Future<ThemeLoadResult> previewThemeById(String id) async {
+    final definition = _definitionById(id);
+    if (definition == null) {
+      return ThemeLoadFailure(
+        definition: ThemeDefinition(
+          id: id,
+          name: id,
+          source: ThemeSource.builtin,
+          format: ThemeFormat.queryaCustom,
+          isDark: true,
+        ),
+        message: 'Theme "$id" not found.',
+      );
+    }
+    return _registryService.loadTheme(definition);
   }
 
   Future<void> setThemeAnimationEnabled(bool enabled) async {
@@ -155,7 +239,7 @@ class ThemeController extends ChangeNotifier {
 
   Future<void> setThemeMode(ThemeMode mode) async {
     _themeMode = mode;
-    if (_preset != QueryaThemePreset.imported) {
+    if (_registryTheme == null && _preset != QueryaThemePreset.imported) {
       _preset = mode == ThemeMode.light
           ? QueryaThemePreset.queryaLight
           : QueryaThemePreset.queryaDark;
@@ -169,6 +253,7 @@ class ThemeController extends ChangeNotifier {
     if (preset == QueryaThemePreset.imported && !hasImportedTheme) {
       return;
     }
+    await _clearRegistrySelection();
     _preset = preset;
     if (preset == QueryaThemePreset.imported) {
       await AppSettings.instance.setThemePreset(preset);
@@ -193,6 +278,7 @@ class ThemeController extends ChangeNotifier {
           :final tokenColors,
           :final storedPath,
         ):
+        await _clearRegistrySelection();
         _importedColors = Map.unmodifiable(colors);
         _importedTokenColors = List.unmodifiable(tokenColors);
         _importedThemeName = name;
@@ -203,6 +289,7 @@ class ThemeController extends ChangeNotifier {
         await AppSettings.instance.setThemeImportPath(storedPath);
         await AppSettings.instance.setThemePreset(QueryaThemePreset.imported);
         await AppSettings.instance.setThemeMode(_themeMode);
+        _availableThemes = await _registryService.loadThemeDefinitions();
         _notifyThemeChanged();
         return result;
       case ThemeImportFailure():
@@ -238,11 +325,13 @@ class ThemeController extends ChangeNotifier {
     _importedTokenColors = const [];
     _importedThemeName = null;
     if (_preset == QueryaThemePreset.imported) {
+      await _clearRegistrySelection();
       _preset = QueryaThemePreset.queryaDark;
       _themeMode = ThemeMode.dark;
       await AppSettings.instance.setThemePreset(_preset);
       await AppSettings.instance.setThemeMode(_themeMode);
     }
+    _availableThemes = await _registryService.loadThemeDefinitions();
     _notifyThemeChanged();
   }
 
@@ -256,7 +345,93 @@ class ThemeController extends ChangeNotifier {
     _userOverrides = const {};
     _importedThemeName = null;
     _themeAnimationEnabled = false;
+    _availableThemes = const [];
+    _selectedThemeId = null;
+    _selectedThemePath = null;
+    _selectedThemeLoadError = null;
+    _registryTheme = null;
+    _registrySelectionFailed = false;
     _notifyThemeChanged();
+  }
+
+  Future<void> _restoreSelectedRegistryTheme() async {
+    _selectedThemeId = await AppSettings.instance.getSelectedThemeId();
+    _selectedThemePath = await AppSettings.instance.getSelectedThemePath();
+    final selectedSource = await AppSettings.instance.getSelectedThemeSource();
+    _selectedThemeLoadError = null;
+    _registryTheme = null;
+    _registrySelectionFailed = false;
+
+    if (_selectedThemeId == null) return;
+
+    final definition = _definitionById(
+      _selectedThemeId!,
+      source: selectedSource,
+      path: _selectedThemePath,
+    );
+    if (definition == null) {
+      _registrySelectionFailed = true;
+      _selectedThemeLoadError =
+          'Selected theme "${_selectedThemeId!}" is not available.';
+      return;
+    }
+
+    final result = await _registryService.loadTheme(definition);
+    switch (result) {
+      case ThemeLoadSuccess(:final theme, :final definition):
+        _registryTheme = theme;
+        _selectedThemeId = definition.id;
+        _selectedThemePath = definition.path;
+        _themeMode = theme.brightness == Brightness.light
+            ? ThemeMode.light
+            : ThemeMode.dark;
+      case ThemeLoadFailure(:final message):
+        _registrySelectionFailed = true;
+        _selectedThemeLoadError = message;
+    }
+  }
+
+  Future<void> _clearRegistrySelection() async {
+    _registryTheme = null;
+    _registrySelectionFailed = false;
+    _selectedThemeId = null;
+    _selectedThemePath = null;
+    _selectedThemeLoadError = null;
+    await AppSettings.instance.clearSelectedThemeRegistry();
+  }
+
+  ThemeDefinition? _definitionById(
+    String id, {
+    String? source,
+    String? path,
+  }) {
+    final matches = _availableThemes.where((definition) => definition.id == id);
+    if (matches.isEmpty) return null;
+
+    if (source != null && source.isNotEmpty) {
+      final bySource =
+          matches.where((definition) => definition.source.name == source);
+      if (bySource.isNotEmpty) return bySource.first;
+    }
+    if (path != null && path.isNotEmpty) {
+      final byPath = matches.where((definition) => definition.path == path);
+      if (byPath.isNotEmpty) return byPath.first;
+    }
+    return matches.first;
+  }
+
+  QueryaTheme _resolvedThemeForBrightness(Brightness brightness) {
+    if (_registryTheme != null) return _registryTheme!;
+    if (_registrySelectionFailed && _selectedThemeId != null) {
+      return QueryaTheme.darkDefault;
+    }
+    if (brightness == Brightness.light) {
+      return _cachedLightTheme ??= _themeForBrightness(Brightness.light);
+    }
+    if (brightness == Brightness.dark) {
+      return _cachedDarkTheme ??= _themeForBrightness(Brightness.dark);
+    }
+    return _cachedActiveTheme ??= _themeForBrightness(brightness);
   }
 
   Brightness _effectiveBrightness() {

--- a/test/core/theme/theme_controller_test.dart
+++ b/test/core/theme/theme_controller_test.dart
@@ -1,13 +1,17 @@
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 import 'package:querya_desktop/core/storage/app_settings.dart';
 import 'package:querya_desktop/core/storage/local_db.dart';
+import 'package:querya_desktop/core/theme/parser/color_parser.dart';
 import 'package:querya_desktop/core/theme/querya_theme.dart';
 import 'package:querya_desktop/core/theme/querya_theme_preset.dart';
 import 'package:querya_desktop/core/theme/theme_controller.dart';
 import 'package:querya_desktop/core/theme/theme_import_service.dart';
+import 'package:querya_desktop/core/theme/theme_load_result.dart';
+import 'package:querya_desktop/core/theme/theme_registry_service.dart';
 import 'package:shadcn_flutter/shadcn_flutter.dart';
 
 class _FakePathProvider extends PathProviderPlatform {
@@ -24,16 +28,35 @@ class _FakePathProvider extends PathProviderPlatform {
   Future<String?> getApplicationDocumentsPath() async => _root;
 }
 
+Future<void> _copyFixture(String fixtureName, File destination) async {
+  final source = File(p.join('test/fixtures/themes', fixtureName));
+  await destination.writeAsString(await source.readAsString());
+}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   late Directory tempDir;
+  late Directory themesDir;
+  late Directory importedDir;
+  late ThemeRegistryService registry;
 
   setUpAll(() async {
     tempDir =
         await Directory.systemTemp.createTemp('querya_theme_controller_test_');
     PathProviderPlatform.instance = _FakePathProvider(tempDir.path);
     await LocalDb.initFfi();
+  });
+
+  setUp(() async {
+    themesDir = Directory(p.join(tempDir.path, 'themes'));
+    importedDir = Directory(p.join(themesDir.path, 'imported'));
+    await importedDir.create(recursive: true);
+    registry = ThemeRegistryService(
+      userThemesDirectory: () async => themesDir,
+      importedThemesDirectory: () async => importedDir,
+    );
+    ThemeController.instance.setRegistryServiceForTest(registry);
   });
 
   tearDownAll(() async {
@@ -45,6 +68,11 @@ void main() {
 
   tearDown(() async {
     await AppSettings.instance.clearThemeSettings();
+    await ThemeImportService.deletePersistedImport();
+    if (await themesDir.exists()) {
+      await themesDir.delete(recursive: true);
+    }
+    ThemeController.instance.setRegistryServiceForTest(ThemeRegistryService());
     await ThemeController.instance.load();
   });
 
@@ -138,5 +166,79 @@ void main() {
     await c.clearColorOverrides();
     expect(c.themeMode, ThemeMode.light);
     expect(c.activeTheme, QueryaTheme.lightDefault);
+  });
+
+  group('registry integration', () {
+    test('setThemeById applies registry theme and persists selection', () async {
+      final c = ThemeController.instance;
+      await _copyFixture(
+        'querya_custom_dark.json',
+        File(p.join(themesDir.path, 'querya_custom_dark.json')),
+      );
+      await c.load();
+
+      await c.setThemeById('fixture-custom-dark');
+
+      expect(c.selectedThemeId, 'fixture-custom-dark');
+      expect(c.selectedThemeLoadError, isNull);
+      expect(c.activeTheme.colorScheme.primary, parseQueryaThemeColor('#38BDF8'));
+      expect(await AppSettings.instance.getSelectedThemeId(), 'fixture-custom-dark');
+      expect(
+        await AppSettings.instance.getSelectedThemeSource(),
+        'filesystem',
+      );
+    });
+
+    test('previewThemeById does not change activeTheme', () async {
+      final c = ThemeController.instance;
+      await _copyFixture(
+        'querya_custom_dark.json',
+        File(p.join(themesDir.path, 'querya_custom_dark.json')),
+      );
+      await c.load();
+
+      final before = c.activeTheme;
+      final preview = await c.previewThemeById('fixture-custom-dark');
+
+      expect(preview, isA<ThemeLoadSuccess>());
+      expect(c.activeTheme, same(before));
+      expect(c.selectedThemeId, isNull);
+    });
+
+    test('broken selected id falls back to Querya Dark without clearing settings',
+        () async {
+      final c = ThemeController.instance;
+      await AppSettings.instance.setSelectedThemeId('missing-theme');
+      await AppSettings.instance.setSelectedThemeSource('filesystem');
+      await AppSettings.instance.setSelectedThemePath('/tmp/missing-theme.json');
+      await AppSettings.instance.setThemePreset(QueryaThemePreset.queryaLight);
+
+      await c.load();
+
+      expect(c.activeTheme, QueryaTheme.darkDefault);
+      expect(c.selectedThemeLoadError, isNotNull);
+      expect(await AppSettings.instance.getSelectedThemeId(), 'missing-theme');
+      expect(
+        await AppSettings.instance.getThemePreset(),
+        QueryaThemePreset.queryaLight,
+      );
+    });
+
+    test('setPreset clears registry selection', () async {
+      final c = ThemeController.instance;
+      await _copyFixture(
+        'querya_custom_dark.json',
+        File(p.join(themesDir.path, 'querya_custom_dark.json')),
+      );
+      await c.load();
+      await c.setThemeById('fixture-custom-dark');
+      expect(c.selectedThemeId, 'fixture-custom-dark');
+
+      await c.setPreset(QueryaThemePreset.queryaLight);
+
+      expect(c.selectedThemeId, isNull);
+      expect(c.activeTheme, QueryaTheme.lightDefault);
+      expect(await AppSettings.instance.getSelectedThemeId(), isNull);
+    });
   });
 }


### PR DESCRIPTION
## Summary

- `ThemeController` loads registry definitions on `load()` and restores persisted `theme_selected_*` settings.
- Add `availableThemes`, `selectedThemeId`, `selectedThemeLoadError`, `loadAvailableThemes`, `setThemeById`, and `previewThemeById`.
- Broken selected themes fall back to Querya Dark at runtime without clearing stored settings; `setPreset` clears registry selection.

## Test plan

- [x] `flutter test test/core/theme/theme_controller_test.dart`
- [x] `flutter test test/core/theme/`

Closes #112