### PR TITLE
feat(settings): Refresh themes action in Preferences (TP-22)

### DIFF
--- a/lib/core/theme/theme_controller.dart
+++ b/lib/core/theme/theme_controller.dart
@@ -63,6 +63,7 @@ class ThemeController extends ChangeNotifier {
   String? _selectedThemeLoadError;
   QueryaTheme? _registryTheme;
   bool _registrySelectionFailed = false;
+  bool _isLoadingAvailableThemes = false;
 
   QueryaTheme? _cachedLightTheme;
   QueryaTheme? _cachedDarkTheme;
@@ -86,6 +87,9 @@ class ThemeController extends ChangeNotifier {
   String? get importedThemeName => _importedThemeName;
 
   List<ThemeDefinition> get availableThemes => List.unmodifiable(_availableThemes);
+
+  /// True while [loadAvailableThemes] is scanning the registry.
+  bool get isLoadingAvailableThemes => _isLoadingAvailableThemes;
 
   String? get selectedThemeId => _selectedThemeId;
 
@@ -215,10 +219,40 @@ class ThemeController extends ChangeNotifier {
   }
 
   Future<void> loadAvailableThemes() async {
-    _availableThemes = _mergeBuiltinThemes(
-      await _registryService.loadThemeDefinitions(),
-    );
+    if (_isLoadingAvailableThemes) return;
+
+    _isLoadingAvailableThemes = true;
     notifyListeners();
+
+    try {
+      final scanned = await _registryService.loadThemeDefinitions();
+      _availableThemes = _mergeBuiltinThemes(scanned);
+      _syncSelectedThemeAfterRefresh();
+    } on Object {
+      // Registry scan skips broken files per entry; keep the prior list on failure.
+    } finally {
+      _isLoadingAvailableThemes = false;
+      notifyListeners();
+    }
+  }
+
+  void _syncSelectedThemeAfterRefresh() {
+    final selectedId = _selectedThemeId;
+    if (selectedId == null) return;
+
+    final stillAvailable = _definitionById(
+      selectedId,
+      path: _selectedThemePath,
+    );
+    if (stillAvailable == null) {
+      _selectedThemeLoadError =
+          'Selected theme "$selectedId" is not available.';
+      return;
+    }
+
+    if (_registryTheme != null) {
+      _selectedThemeLoadError = null;
+    }
   }
 
   Future<void> setThemeById(String id) async {

--- a/lib/features/settings/preferences_appearance_section.dart
+++ b/lib/features/settings/preferences_appearance_section.dart
@@ -94,6 +94,10 @@ class _PreferencesAppearanceSectionState
     if (mounted) setState(() => _importError = null);
   }
 
+  Future<void> _refreshThemes() async {
+    await _controller.loadAvailableThemes();
+  }
+
   Future<void> _setThemeAnimation(bool enabled) async {
     await _controller.setThemeAnimationEnabled(enabled);
   }
@@ -102,6 +106,7 @@ class _PreferencesAppearanceSectionState
   material.Widget build(material.BuildContext context) {
     final c = _controller;
     final themes = c.availableThemes;
+    final refreshingThemes = c.isLoadingAvailableThemes;
 
     return material.Column(
       crossAxisAlignment: material.CrossAxisAlignment.start,
@@ -138,6 +143,7 @@ class _PreferencesAppearanceSectionState
             themes: themes,
             selectedThemeId: c.effectiveSelectedThemeId,
             expandToParent: true,
+            isLoading: refreshingThemes,
             onSelected: (id) => unawaited(_setThemeById(id)),
             onPreviewTheme: _previewThemeById,
           ),
@@ -195,6 +201,14 @@ class _PreferencesAppearanceSectionState
               onPressed:
                   _importing ? null : () => unawaited(_pickAndImportTheme()),
               child: material.Text(_importing ? 'Importing…' : 'Import theme…'),
+            ),
+            OutlineButton(
+              onPressed: (_importing || refreshingThemes)
+                  ? null
+                  : () => unawaited(_refreshThemes()),
+              child: material.Text(
+                refreshingThemes ? 'Refreshing…' : 'Refresh themes',
+              ),
             ),
             OutlineButton(
               onPressed: () => unawaited(_resetAppearance()),

--- a/test/core/theme/theme_controller_test.dart
+++ b/test/core/theme/theme_controller_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -11,6 +12,7 @@ import 'package:querya_desktop/core/theme/querya_theme_preset.dart';
 import 'package:querya_desktop/core/theme/theme_controller.dart';
 import 'package:querya_desktop/core/theme/theme_import_service.dart';
 import 'package:querya_desktop/core/theme/theme_load_result.dart';
+import 'package:querya_desktop/core/theme/theme_definition.dart';
 import 'package:querya_desktop/core/theme/theme_registry_service.dart';
 import 'package:shadcn_flutter/shadcn_flutter.dart';
 
@@ -31,6 +33,21 @@ class _FakePathProvider extends PathProviderPlatform {
 Future<void> _copyFixture(String fixtureName, File destination) async {
   final source = File(p.join('test/fixtures/themes', fixtureName));
   await destination.writeAsString(await source.readAsString());
+}
+
+class _GatedRegistryService extends ThemeRegistryService {
+  _GatedRegistryService({
+    required super.userThemesDirectory,
+    required super.importedThemesDirectory,
+  });
+
+  final gate = Completer<void>();
+
+  @override
+  Future<List<ThemeDefinition>> loadThemeDefinitions() async {
+    await gate.future;
+    return super.loadThemeDefinitions();
+  }
 }
 
 void main() {
@@ -281,6 +298,66 @@ void main() {
         ThemeController.builtinQueryaLightId,
       ]));
       expect(c.effectiveSelectedThemeId, ThemeController.builtinQueryaDarkId);
+    });
+  });
+
+  group('loadAvailableThemes', () {
+    test('picks up newly added filesystem theme', () async {
+      final c = ThemeController.instance;
+      await c.load();
+      final beforeCount = c.availableThemes.length;
+
+      await _copyFixture(
+        'querya_custom_dark.json',
+        File(p.join(themesDir.path, 'querya_custom_dark.json')),
+      );
+      await c.loadAvailableThemes();
+
+      expect(c.availableThemes.length, greaterThan(beforeCount));
+      expect(
+        c.availableThemes.map((theme) => theme.id),
+        contains('fixture-custom-dark'),
+      );
+      expect(c.isLoadingAvailableThemes, isFalse);
+    });
+
+    test('preserves active registry theme without reloading from disk',
+        () async {
+      final c = ThemeController.instance;
+      await _copyFixture(
+        'querya_custom_dark.json',
+        File(p.join(themesDir.path, 'querya_custom_dark.json')),
+      );
+      await c.load();
+      await c.setThemeById('fixture-custom-dark');
+      final before = c.activeTheme;
+
+      await File(p.join(themesDir.path, 'querya_custom_dark.json'))
+          .writeAsString('not valid theme json');
+
+      await c.loadAvailableThemes();
+
+      expect(c.activeTheme, same(before));
+      expect(c.selectedThemeId, 'fixture-custom-dark');
+    });
+
+    test('sets isLoadingAvailableThemes while refresh is in progress', () async {
+      final c = ThemeController.instance;
+      await c.load();
+
+      final gated = _GatedRegistryService(
+        userThemesDirectory: () async => themesDir,
+        importedThemesDirectory: () async => importedDir,
+      );
+      c.setRegistryServiceForTest(gated);
+
+      final refresh = c.loadAvailableThemes();
+      expect(c.isLoadingAvailableThemes, isTrue);
+
+      gated.gate.complete();
+      await refresh;
+
+      expect(c.isLoadingAvailableThemes, isFalse);
     });
   });
 }

--- a/test/features/settings/preferences_appearance_section_test.dart
+++ b/test/features/settings/preferences_appearance_section_test.dart
@@ -63,12 +63,17 @@ void main() {
   });
 
   tearDown(() async {
+    ThemeController.instance.setRegistryServiceForTest(
+      ThemeRegistryService(
+        userThemesDirectory: () async => themesDir,
+        importedThemesDirectory: () async => importedDir,
+      ),
+    );
     await AppSettings.instance.clearThemeSettings();
     await ThemeImportService.deletePersistedImport();
     if (await themesDir.exists()) {
       await themesDir.delete(recursive: true);
     }
-    ThemeController.instance.setRegistryServiceForTest(ThemeRegistryService());
     await ThemeController.instance.load();
   });
 
@@ -107,6 +112,7 @@ void main() {
       await pumpSection(tester);
 
       expect(find.text('Import theme…'), findsOneWidget);
+      expect(find.text('Refresh themes'), findsOneWidget);
       expect(find.text('Reset appearance'), findsOneWidget);
     });
   });


### PR DESCRIPTION
## Summary
- Add `Refresh themes` button next to Import/Reset in Appearance preferences
- Extend `ThemeController.loadAvailableThemes()` with `isLoadingAvailableThemes`, safe rescan, and active-theme preservation (no disk reload on refresh)
- Show non-blocking loading state on `ThemePickerButton` while refresh runs

## Test plan
- [x] `flutter test test/core/theme/theme_controller_test.dart --name loadAvailableThemes`
- [x] `flutter test test/features/settings/preferences_appearance_section_test.dart`
- [x] New filesystem theme appears after refresh
- [x] Active registry theme stays applied when scan skips a broken file
- [x] `isLoadingAvailableThemes` toggles during refresh
- [x] Refresh themes button visible in Preferences

Closes #117