### PR TITLE
chore(release): prepare 0.4.2 and plan 0.4.3 theme follow-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Planned (0.4.3)
+
+Theme and extensions follow-ups — see [docs/planned-0.4.3.md](docs/planned-0.4.3.md): file watcher (TP-F1), marketplace metadata (TP-F2), visual theme editor (TP-F3), remote theme install (TP-F4).
+
+## [0.4.2] - 2026-06-14
+
+Custom theme registry release (parser epic TP-01–TP-30, GitHub issues **#96–#125**). Git tag **`0.4.2`**.
+
 ### Added
 
-- **Custom theme registry** — scan `{appSupport}/themes/` for `querya.theme.v1` and VS Code JSON/JSONC; **Theme** picker with search, preview, refresh, and **Open themes folder** (Preferences → Appearance).
-- **Built-in bundled themes** — e.g. **Querya Cyberpunk Neon** from `assets/themes/` (no manual install).
-- **Theme import** — **Import theme…** copies into the user themes directory with hash/id deduplication; selection persists across restarts.
-- **Startup safety** — missing or broken selected theme falls back to Querya Dark with a Preferences error; settings are not auto-deleted.
+- **Custom theme registry** — scan `{appSupport}/themes/` for `querya.theme.v1` and VS Code JSON/JSONC; **Theme** picker with search, hover preview, **Refresh themes**, and **Open themes folder** (Preferences → Appearance).
+- **Built-in bundled themes** — **Querya Cyberpunk Neon** from `assets/themes/` (no manual install).
+- **Theme import** — **Import theme…** copies into the user themes directory with content-hash and id deduplication; selection persists across restarts.
+- **Startup safety** — missing or broken selected theme falls back to Querya Dark with a Preferences error; saved theme id is kept until the user picks another theme.
 - **Window chrome** — title bar and window controls follow active `QueryaThemeScope` workbench tokens.
 - **Docs / QA** — [theme-custom-json.md](docs/theme-custom-json.md), updated [theme-import.md](docs/theme-import.md), custom-theme section in [release-checklist.md](docs/release-checklist.md).
 - **Tests** — registry/parser/controller coverage, 60-theme picker performance guard, end-to-end import flow (`theme_import_flow_test.dart`).

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ a clean, dark UI inspired by tools like pgAdmin.
   statement timeouts, query history, and CSV/JSON export.
 - **Object browsing** — connection tree with databases, tables, views, and
   server stats.
-- **Themeable** — runtime dark/light/system modes and **VS Code theme import**.
+- **Themeable** — dark/light/system, **VS Code theme import**, custom `querya.theme.v1` registry, and bundled themes (0.4.2).
 - **Scalable UI** — global interface scaling for high-DPI and accessibility.
 - **Secure by default** — passwords and connection strings live in the OS secure
   store, never in plaintext.

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@ Index of Querya Desktop documentation, grouped by audience.
 ## Planning
 
 - [Roadmap](roadmap.md) — current direction and follow-ups.
+- [Planned 0.4.3](planned-0.4.3.md) — deferred theme/extensions follow-ups after 0.4.2.
 - [Custom theme parser requirements](scheme-parcer.md) — JSON theme format and scaling spec.
 - [Theme parser implementation plan](theme-parser-implementation-tasks.md) — task breakdown and architecture.
 - [Theme parser GitHub issues](theme-parser-github-issues.md) — issue templates for epic #96–#125.

--- a/docs/planned-0.4.3.md
+++ b/docs/planned-0.4.3.md
@@ -1,0 +1,44 @@
+# Planned release 0.4.3 — theme and extensions follow-ups
+
+**Status:** planning (not started).  
+**Depends on:** **0.4.2** custom theme registry (TP-01–TP-30, shipped).
+
+This document captures work intentionally deferred from the first custom-theme pass.
+See also [theme-parser-github-issues.md](theme-parser-github-issues.md) (TP-F1–TP-F4) and
+[market-tech.md](market-tech.md) for the broader extensions marketplace direction.
+
+## Theme folder and discovery
+
+| ID | Scope | Summary |
+|----|--------|---------|
+| **TP-F1** | `theme`, `filesystem` | **File watcher** for `{appSupport}/themes/` — auto-refresh the registry when files are added, removed, or renamed. Deferred: OS-specific watcher APIs and app lifecycle edge cases. |
+
+## Theme distribution and metadata
+
+| ID | Scope | Summary |
+|----|--------|---------|
+| **TP-F2** | `theme`, `marketplace` | **Marketplace metadata** on `ThemeDefinition` / manifests — preview image, tags, homepage, license, author. Prerequisite for listing themes in a future Extensions UI. |
+| **TP-F4** | `theme`, `network` | **Remote theme install** — download from URL with checksum/trust policy. Requires security review (HTTPS, signatures, user consent). |
+
+## Authoring UX
+
+| ID | Scope | Summary |
+|----|--------|---------|
+| **TP-F3** | `theme`, `settings` | **Visual theme editor** in Preferences — tweak colors, export `querya.theme.v1`. Larger than parser/import; likely multiple PRs. |
+
+## Extensions marketplace (optional overlap)
+
+If **0.4.3** also starts the extensions shell from [market-tech.md](market-tech.md), align **TP-F2** theme metadata with `ExtensionManifest` so themes can appear as a category in **Explore**. Keep `lib/core/market/` isolated from theme parser internals.
+
+## Suggested PR order (draft)
+
+1. TP-F1 — watcher + debounced `loadAvailableThemes()`
+2. TP-F2 — manifest fields + docs (no remote API yet)
+3. TP-F3 — minimal editor MVP (export only) or split to **0.4.4**
+4. TP-F4 — install-from-URL behind explicit user action
+
+## Out of scope for 0.4.3
+
+- Full marketplace backend and **Extensions** sidebar UI (may land in **0.5.0** per market-tech.md)
+- P2 Mongo/Redis semantic token colors ([roadmap.md](roadmap.md))
+- `re_editor` / LSP editor replacement

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,6 +1,7 @@
-# Pre-release checklist (toward 1.0)
+# Pre-release checklist (release **0.4.2**)
 
-Use this before tagging or running the **Release** workflow.
+Use this before tagging **`0.4.2`** or running the **Release** workflow.
+See [tags-and-releases.md](tags-and-releases.md) and [CHANGELOG.md](../CHANGELOG.md).
 
 ## Product smoke (manual)
 
@@ -32,7 +33,7 @@ Use **Preferences → Appearance** unless noted. Fixtures for copy/import tests 
 
 ## Versioning and release
 
-- [ ] `pubspec.yaml` `version` matches the release you intend to ship.
+- [ ] `pubspec.yaml` `version` is **`0.4.2+…`** (semver matches intended tag **`0.4.2`**).
 - [ ] **Tag** is placed on the **commit that includes all fixes** you want in binaries (a tag does not auto-include later commits; see [CONTRIBUTING.md](../CONTRIBUTING.md)).
 - [ ] Run the **Release** workflow from GitHub Actions (see [tags-and-releases.md](tags-and-releases.md)).
 - [ ] Verify **Linux** and **Windows** zip artifacts and `SHA256SUMS.txt` on the GitHub Release.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -7,6 +7,8 @@ Living document for planned work. Not a commitment order; adjust as priorities c
 - **Shipped in 0.4.0 (epic #37):** runtime themes, VS Code `colors` + `tokenColors` import, SQL/JSON
   highlighting, P0 workbench migration, Preferences, tests, docs — [theme.md](theme.md).
 - **Shipped in 0.4.1 ([#93](https://github.com/QueryaHub/Querya-Desktop/issues/93)):** UI performance — virtual result grid, lazy connection tree, decoupled scale preview, stats polling, MySQL stats dashboard, local `docker/` dev stack — [perf-baseline.md](perf-baseline.md).
+- **Shipped in 0.4.2 (TP-01–TP-30, #96–#125):** custom theme registry — `querya.theme.v1` + VS Code JSON/JSONC scan, Theme picker (50+), import/refresh, built-in Cyberpunk Neon asset, startup fallback, window chrome sync — [theme-custom-json.md](theme-custom-json.md), [theme-import.md](theme-import.md).
+- **Planned 0.4.3:** theme follow-ups (file watcher, marketplace metadata, visual editor, remote install) — [planned-0.4.3.md](planned-0.4.3.md).
 - **Optional:** Preferences → **Animate theme changes** (off by default).
 - **Later:** P2 Mongo/Redis token colors; `re_editor` if perf gap; LSP epic per
   [archive/code-forge-evaluation.md](archive/code-forge-evaluation.md) (**NO-GO** on `code_forge` for 0.3).

--- a/docs/theme-parser-github-issues.md
+++ b/docs/theme-parser-github-issues.md
@@ -1574,7 +1574,8 @@ Add QA checklist:
 
 ## Optional follow-up issues
 
-These are intentionally out of the first implementation pass.
+These are intentionally out of the first implementation pass (**shipped in 0.4.2**).
+**Target milestone: 0.4.3** — see [planned-0.4.3.md](planned-0.4.3.md).
 
 ### TP-F1 — File watcher for user themes folder
 
@@ -1594,33 +1595,33 @@ Install theme from URL. Requires network, trust/security decisions, and probably
 
 ## Master checklist
 
-- [ ] TP-01 docs schema
-- [ ] TP-02 fixtures
-- [ ] TP-03 manifest model
-- [ ] TP-04 color parser wrapper
-- [ ] TP-05 shadcn color scheme mapping
-- [ ] TP-06 editor theme mapping
-- [ ] TP-07 workbench theme mapping
-- [ ] TP-08 QueryaTheme factory
-- [ ] TP-09 load result types
-- [ ] TP-10 ThemeDefinition
-- [ ] TP-11 theme paths
-- [ ] TP-12 filesystem scan
-- [ ] TP-13 load selected definition
-- [ ] TP-14 parsed theme cache
-- [ ] TP-15 AppSettings selected theme
-- [ ] TP-16 legacy imported migration
-- [ ] TP-17 ThemeController registry integration
-- [ ] TP-18 ThemePickerButton shell
-- [ ] TP-19 picker search/filter
-- [ ] TP-20 safe preview card
-- [ ] TP-21 Preferences integration
-- [ ] TP-22 refresh themes action
-- [ ] TP-23 multi-theme import
-- [ ] TP-24 built-in theme assets
-- [ ] TP-25 user theme folder docs
-- [ ] TP-26 window chrome sync
-- [ ] TP-27 startup fallback
-- [ ] TP-28 50+ themes performance test
-- [ ] TP-29 end-to-end import test
-- [ ] TP-30 release QA docs
+- [x] TP-01 docs schema
+- [x] TP-02 fixtures
+- [x] TP-03 manifest model
+- [x] TP-04 color parser wrapper
+- [x] TP-05 shadcn color scheme mapping
+- [x] TP-06 editor theme mapping
+- [x] TP-07 workbench theme mapping
+- [x] TP-08 QueryaTheme factory
+- [x] TP-09 load result types
+- [x] TP-10 ThemeDefinition
+- [x] TP-11 theme paths
+- [x] TP-12 filesystem scan
+- [x] TP-13 load selected definition
+- [x] TP-14 parsed theme cache
+- [x] TP-15 AppSettings selected theme
+- [x] TP-16 legacy imported migration
+- [x] TP-17 ThemeController registry integration
+- [x] TP-18 ThemePickerButton shell
+- [x] TP-19 picker search/filter
+- [x] TP-20 safe preview card
+- [x] TP-21 Preferences integration
+- [x] TP-22 refresh themes action
+- [x] TP-23 multi-theme import
+- [x] TP-24 built-in theme assets
+- [x] TP-25 user theme folder docs
+- [x] TP-26 window chrome sync
+- [x] TP-27 startup fallback
+- [x] TP-28 50+ themes performance test
+- [x] TP-29 end-to-end import test
+- [x] TP-30 release QA docs

--- a/docs/theme-parser-implementation-tasks.md
+++ b/docs/theme-parser-implementation-tasks.md
@@ -579,13 +579,13 @@ flutter:
 
 ## Acceptance checklist
 
-- [ ] Querya custom JSON импортируется и применяется.
-- [ ] VS Code JSON/JSONC import продолжает работать.
-- [ ] 50+ тем в Preferences не вызывают overflow и заметные лаги.
-- [ ] Hover в списке не перестраивает весь app.
-- [ ] Повторное переключение на уже открытую тему мгновенное.
-- [ ] Сломанная выбранная тема не ломает запуск приложения.
-- [ ] Выбранная тема сохраняется после рестарта.
-- [ ] Window title bar синхронизирован с background/canvas темы.
-- [ ] `flutter analyze` clean.
-- [ ] `flutter test` green.
+- [x] Querya custom JSON импортируется и применяется.
+- [x] VS Code JSON/JSONC import продолжает работать.
+- [x] 50+ тем в Preferences не вызывают overflow и заметные лаги.
+- [x] Hover в списке не перестраивает весь app.
+- [x] Повторное переключение на уже открытую тему мгновенное.
+- [x] Сломанная выбранная тема не ломает запуск приложения.
+- [x] Выбранная тема сохраняется после рестарта.
+- [x] Window title bar синхронизирован с background/canvas темы.
+- [x] `flutter analyze` clean.
+- [x] `flutter test` green.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: querya_desktop
 description: Lightweight desktop SQL/NoSQL client. Flutter (Dart).
-version: 0.4.1+7
+version: 0.4.2+1
 
 
 


### PR DESCRIPTION
## Summary

- Bump `pubspec.yaml` to **0.4.2+1**
- Finalize **CHANGELOG** for the custom theme registry epic (TP-01–TP-30, #96–#125)
- Add [docs/planned-0.4.3.md](docs/planned-0.4.3.md) for deferred follow-ups (TP-F1–F4)
- Update roadmap, release checklist, README, and theme epic checklists

## Test plan

- [x] `flutter analyze` — clean
- [x] `flutter test --concurrency=1` — green

## After merge

Merge `dev` → `main`, then tag **`0.4.2`** on the merge commit (before auto version-bump lands) and push the tag for the Release workflow.