### PR TITLE
chore(release): prepare 0.4.3 and plan 0.4.4 motion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Planned (0.4.3)
+## [0.4.3] - 2026-06-15
 
-Theme and extensions follow-ups — see [docs/planned-0.4.3.md](docs/planned-0.4.3.md): file watcher (TP-F1), marketplace metadata (TP-F2), visual theme editor (TP-F3), remote theme install (TP-F4).
+Theme follow-ups release (TP-F1–TP-F4, GitHub issues **#159–#163**). Git tag **`0.4.3`**.
+
+### Added
+
+- **Theme folder watcher (TP-F1)** — debounced `Directory.watch` on `{appSupport}/themes/` auto-refreshes the registry when files are added, removed, or renamed.
+- **Marketplace metadata (TP-F2)** — optional manifest fields (`homepage`, `license`, `preview`, `tags`); theme picker shows author/tags; `ExtensionManifest` stub in `lib/core/market/` for future Explore UI.
+- **Visual theme editor (TP-F3)** — Preferences section to tweak workbench colors with live preview and export `querya.theme.v1` JSON.
+- **Remote theme install (TP-F4)** — **Install from URL…** (HTTPS-only, public hosts, optional SHA-256); `ThemeRemoteInstallService` with checksum verify before import.
+- **Docs / QA** — remote install section in [theme-import.md](docs/theme-import.md); 0.4.3 items in [release-checklist.md](docs/release-checklist.md).
+- **Tests** — file watcher, remote install policy/service, theme editor and metadata coverage.
 
 ## [0.4.2] - 2026-06-14
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ a clean, dark UI inspired by tools like pgAdmin.
   statement timeouts, query history, and CSV/JSON export.
 - **Object browsing** — connection tree with databases, tables, views, and
   server stats.
-- **Themeable** — dark/light/system, **VS Code theme import**, custom `querya.theme.v1` registry, and bundled themes (0.4.2).
+- **Themeable** — dark/light/system, **VS Code theme import**, custom `querya.theme.v1` registry, visual editor, remote install, and bundled themes (0.4.3).
 - **Scalable UI** — global interface scaling for high-DPI and accessibility.
 - **Secure by default** — passwords and connection strings live in the OS secure
   store, never in plaintext.

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,9 @@ Index of Querya Desktop documentation, grouped by audience.
 ## Planning
 
 - [Roadmap](roadmap.md) — current direction and follow-ups.
-- [Planned 0.4.3](planned-0.4.3.md) — deferred theme/extensions follow-ups after 0.4.2.
+- [Planned 0.4.3](planned-0.4.3.md) — shipped theme follow-ups (TP-F1–TP-F4).
+- [Planned 0.4.4](planned-0.4.4.md) — UI motion polish and high refresh rate.
+- [Motion and high refresh rate](motion-and-high-refresh.md) — 0.4.4 research, audit, and per-platform Hz design.
 - [Custom theme parser requirements](scheme-parcer.md) — JSON theme format and scaling spec.
 - [Theme parser implementation plan](theme-parser-implementation-tasks.md) — task breakdown and architecture.
 - [Theme parser GitHub issues](theme-parser-github-issues.md) — issue templates for epic #96–#125.

--- a/docs/motion-and-high-refresh.md
+++ b/docs/motion-and-high-refresh.md
@@ -1,0 +1,144 @@
+# Motion system and high-refresh-rate support (0.4.4 research)
+
+**Status:** research / design for **0.4.4**.
+**Scope:** Querya Desktop is **desktop-only** (Linux, Windows, macOS — see [`linux/`](../linux), [`windows/`](../windows), [`macos/`](../macos)). Toolchain at time of writing: **Flutter 3.41.6 stable**, Impeller engine.
+
+Goal of 0.4.4: make every animation **smooth and pleasant**, driven by a single motion system, and make the app actually render at the display's **native refresh rate (90/120/144 Hz)** on each OS instead of being capped at 60.
+
+---
+
+## 1. Why this matters
+
+Two independent problems are often confused:
+
+1. **Frame rate (Hz)** — how many frames the engine renders per second. If the app is locked to 60 Hz on a 120 Hz monitor, *every* animation looks half as smooth no matter how good the curves are.
+2. **Motion design** — the durations, curves, and choreography of each animation. Even at 120 Hz, a linear 100 ms snap feels cheap; a well-tuned eased 180 ms feels premium.
+
+0.4.4 must fix **both**. High-Hz is the multiplier; the motion system is the quality.
+
+Important Flutter fact: animations are **vsync/ticker driven and frame-rate independent**. A `Duration(milliseconds: 200)` plays over 200 ms of wall-clock time and is interpolated **per frame**. So at 120 Hz the *same* animation simply gets twice as many in-between frames — no code change to durations is needed for high-Hz smoothness. The only requirement is that the engine is told it may render faster than 60.
+
+---
+
+## 2. Current state audit (codebase)
+
+There is **no central motion system** today. Animations are scattered, with inconsistent durations and curves, and **no reduced-motion / accessibility handling** anywhere (`grep` for `disableAnimations` / `accessibleNavigation` → 0 matches).
+
+| Location | What animates | Duration | Curve |
+|----------|---------------|----------|-------|
+| `lib/shared/widgets/app_dialog.dart` | Dialog fade + scale (0.92→1.0) + backdrop blur (8σ) | 200 ms | `easeOutCubic` |
+| `lib/shared/widgets/querya_dropdown.dart` | Trigger + menu hover background | `QueryaDropdownTokens.hoverAnimationMs` | `easeOut` |
+| `lib/features/settings/theme_picker_button.dart` | Hover containers; preview debounce 120 ms | 120 ms / debounce | `easeOut` |
+| `lib/features/main_screen/workspace_panel.dart` | Tab/area container + `AnimatedScale` | 120 ms / 100 ms | `easeOut` |
+| `lib/features/connections/connections_panel_pg_tree.dart` | Chevron `AnimatedRotation`; tooltip wait 450 ms | 100 ms | (default) |
+| `lib/features/connections/connections_panel_{sidebar,mysql,mongo,redis,postgres_connection}.dart` | Row hover containers | 100 ms | (default/`easeOut`) |
+| `lib/features/{mysql,postgresql}/*_workspace_home.dart` | Card hover containers | 120 ms | `easeOut` |
+| `lib/features/connections/new_connection_dialog.dart` | Type-card hover | 120 ms | `easeOut` |
+| `lib/core/theme/theme_controller.dart` | `ShadcnAnimatedTheme` (theme cross-fade) | engine default | — |
+| `lib/features/main_screen/result_grid_view.dart` | Tooltip wait 400 ms | — | — |
+
+### Findings
+
+- **Inconsistent durations:** 100 ms vs 120 ms vs 200 ms for conceptually similar interactions (hover, expand, dialog).
+- **Curve monoculture:** almost everything is `Curves.easeOut`; no distinction between *enter* (decelerate), *exit* (accelerate), and *emphasized* motion.
+- **No tokens:** magic `Duration(...)` literals repeated ~20 places. Only `QueryaDropdownTokens` partially tokenizes one widget.
+- **No reduced-motion support:** users who set "reduce motion" at the OS level still get all animations.
+- **Theme switch** is the only "big" transition and it is off by default (`themeAnimationEnabled = false`).
+- **No expand/collapse height animation** on tree nodes — they pop in/out (`if (_expanded) ...`), only the chevron rotates.
+
+---
+
+## 3. How high refresh rate works in Flutter (per platform)
+
+Summary of current engine behavior (Flutter 3.24+ / Impeller). Sources in §7.
+
+| Platform | Renders at display Hz by default? | How to unlock > 60 Hz | Notes |
+|----------|-----------------------------------|------------------------|-------|
+| **Windows** | Usually yes (follows monitor via DWM) | No app API needed | Verify on a 120/144 Hz monitor; engine vsyncs to the compositor. |
+| **Linux** | Depends on compositor (GTK embedder) | No app API; compositor-dependent | Wayland compositors with VRR may need monitor config; X11 follows monitor. |
+| **macOS** | Capped to 60 on some setups | macOS 14+ can opt into ProMotion/high-Hz | Historically Flutter macOS did not always hit ProMotion; needs verification. |
+| **iOS** (future) | No — capped to 60 | `CADisableMinimumFrameDurationOnPhone=true` in `Info.plist` | Not applicable today (no `ios/`), document for when mobile lands. |
+| **Android** (future) | No — often picks 60 | `flutter_displaymode` / `Surface.setFrameRate()` | Not applicable today (no `android/`). |
+
+Root cause (engine): per `flutter/flutter#160952`, the engine "can render at 120 Hz (Impeller since 3.24) but never tells the OS compositor it can handle more" on several platforms. Community package **`refresh_rate`** (pub.dev) works around this and additionally provides **query / live FPS overlay / benchmark** on all six platforms, with actual *unlock* on Android, iOS 15+, and macOS 14+.
+
+### Practical implication for Querya (desktop)
+
+- **Windows / Linux:** most likely already render at monitor Hz; the job is to **measure and verify**, then ensure no app-side code caps frames (e.g. heavy `setState`, unbounded rebuilds during animation).
+- **macOS:** the real high-Hz work — confirm ProMotion behavior; unlock via `refresh_rate` if capped at 60.
+- Use `refresh_rate` (or a thin wrapper) primarily for **diagnostics**: a debug-only FPS/Hz overlay and a benchmark to prove smoothness on each machine, plus the macOS unlock call in `main()`.
+
+---
+
+## 4. Proposed motion design system
+
+Introduce `lib/core/motion/` with a single source of truth for durations and curves, scaled by accessibility settings.
+
+### 4.1 Duration tokens (`QueryaMotion`)
+
+| Token | Value | Use |
+|-------|-------|-----|
+| `instant` | 0 ms | reduced-motion / disabled |
+| `fast` | 120 ms | hover, small state changes |
+| `standard` | 200 ms | dialogs, menus, expand/collapse |
+| `slow` | 320 ms | emphasized / large surfaces, theme cross-fade |
+
+### 4.2 Curve tokens
+
+| Token | Curve | Use |
+|-------|-------|-----|
+| `enter` | `easeOutCubic` | elements appearing (decelerate) |
+| `exit` | `easeInCubic` | elements leaving (accelerate) |
+| `standard` | `easeInOutCubic` | move/resize in place |
+| `emphasized` | `Curves.easeInOutCubicEmphasized` | hero / theme transitions |
+
+### 4.3 Reduced motion / accessibility
+
+- Read `MediaQuery.disableAnimationsOf(context)` (OS "reduce motion") and an optional in-app Preferences toggle.
+- When reduced: collapse all durations to `instant` (or a short cross-fade), never fully remove feedback.
+- Provide a helper `context.motion(Token)` that returns the effective duration after applying the reduced-motion factor.
+
+### 4.4 Targeted animation upgrades
+
+- **Dialogs** (`app_dialog.dart`): keep the blur+scale pattern, retune to `standard`/`enter`; ensure backdrop and card share one curve.
+- **Dropdowns / menus**: add an enter scale+fade (currently only hover color), `standard`/`enter`.
+- **Tree expand/collapse**: animate height with `AnimatedSize` (+ chevron rotation already present) instead of pop-in.
+- **Tab / workspace switches**: cross-fade content via `AnimatedSwitcher` with `standard`.
+- **Hover states**: unify all row/card hovers to `fast`/`standard` curve.
+- **Theme switch**: enable a tasteful `emphasized` cross-fade and consider making it on-by-default.
+- **List/grid item insertion** (results, history): subtle staggered fade-in for first paint only (no per-scroll cost).
+
+---
+
+## 5. Implementation plan (proposed issues)
+
+Milestone **0.4.4** (see [planned-0.4.4.md](planned-0.4.4.md)).
+
+1. **UI-A1 — Motion tokens core.** `lib/core/motion/` with `QueryaMotion` durations/curves + `context.motion()` reduced-motion helper. Unit tests.
+2. **UI-A2 — Adopt tokens across widgets.** Replace magic `Duration(...)`/`Curves.easeOut` literals in dialogs, dropdowns, tree, workspace panel, connection forms. No behavior regressions in layout tests.
+3. **UI-A3 — Smoother transitions.** Dialog retune, dropdown enter animation, tree `AnimatedSize` expand/collapse, tab `AnimatedSwitcher`.
+4. **UI-A4 — High-refresh-rate enablement.** Add `refresh_rate` (or wrapper); unlock on macOS 14+ in `main()`; query active Hz; debug-only FPS/Hz overlay behind a flag.
+5. **UI-A5 — Reduced-motion + Preferences.** Honor OS "reduce motion"; add **Preferences → Appearance → Motion** (Full / Reduced / Off) wired to the motion helper.
+6. **UI-A6 — Measurement & docs.** DevTools timeline checklist in [perf-baseline.md](perf-baseline.md); per-OS Hz verification table; update this doc with measured results.
+
+Suggested order: A1 → A2 → A3 in parallel with A4; then A5; A6 closes the milestone.
+
+---
+
+## 6. Testing & measurement
+
+- **DevTools → Performance / Frame chart:** confirm frame build/raster times stay under the budget at the monitor's Hz (8.3 ms @ 120 Hz, 6.9 ms @ 144 Hz).
+- **`refresh_rate` overlay / benchmark:** prove the real on-device Hz before/after; capture numbers per OS.
+- **Reduced-motion test:** widget test that durations collapse when `disableAnimations: true` is injected via `MediaQuery`.
+- **Regression:** existing layout/overflow tests must stay green; animations must not change final layout geometry.
+
+---
+
+## 7. References
+
+- Flutter engine — high refresh rate gap: `flutter/flutter#160952`, `#90675` (ProMotion scrolling), `#94508` (`CADisableMinimumFrameDurationOnPhone` default).
+- `refresh_rate` package (query/unlock/overlay/benchmark, all platforms): https://pub.dev/packages/refresh_rate
+- `flutter_displaymode` (Android high-Hz): https://pub.dev/packages/flutter_displaymode
+- Apple — Optimizing for ProMotion: https://developer.apple.com/documentation/quartzcore/optimizing-iphone-and-ipad-apps-to-support-promotion-displays
+- Flutter blog — iOS variable refresh rate (Flutter 3): https://blog.flutter.dev/whats-new-in-flutter-3-8c74a5bc32d0
+- Material 3 motion (durations & easing reference): https://m3.material.io/styles/motion/overview

--- a/docs/planned-0.4.3.md
+++ b/docs/planned-0.4.3.md
@@ -1,6 +1,6 @@
 # Planned release 0.4.3 — theme and extensions follow-ups
 
-**Status:** planning (GitHub milestone [**0.4.3**](https://github.com/QueryaHub/Querya-Desktop/milestone/2), epic **#159**).  
+**Status:** **shipped in 0.4.3** (GitHub milestone [**0.4.3**](https://github.com/QueryaHub/Querya-Desktop/milestone/2), epic **#159** closed).  
 **Depends on:** **0.4.2** custom theme registry (TP-01–TP-30, shipped).
 
 This document captures work intentionally deferred from the first custom-theme pass.

--- a/docs/planned-0.4.4.md
+++ b/docs/planned-0.4.4.md
@@ -1,0 +1,38 @@
+# Planned release 0.4.4 — UI motion polish and high refresh rate
+
+**Status:** planning.
+**Depends on:** **0.4.3** theme follow-ups (shipped).
+**Design doc:** [motion-and-high-refresh.md](motion-and-high-refresh.md) — research, current-state audit, and per-platform Hz behavior.
+
+Theme: make every animation **smooth and pleasant** through one motion system, and make the app render at the display's **native refresh rate (90/120/144 Hz)** on Linux, Windows, and macOS instead of being capped at 60.
+
+## Why
+
+- Animations today are ad-hoc: inconsistent durations (100 / 120 / 200 ms), a single `easeOut` curve everywhere, ~20 magic `Duration(...)` literals, and **no reduced-motion handling**.
+- Flutter animations are vsync-driven and frame-rate independent, so the smoothness win comes from (a) telling the engine it may exceed 60 Hz and (b) a cohesive motion design — see [motion-and-high-refresh.md §1–3](motion-and-high-refresh.md).
+
+## Scope
+
+| ID | Scope | Summary |
+|----|-------|---------|
+| **UI-A1** | `motion`, `core` | **Motion tokens** — `lib/core/motion/` with `QueryaMotion` durations/curves and a `context.motion()` reduced-motion helper. |
+| **UI-A2** | `motion`, `ui` | **Adopt tokens** — replace magic durations/curves in dialogs, dropdowns, tree, workspace panel, connection forms (no layout regressions). |
+| **UI-A3** | `motion`, `ui` | **Smoother transitions** — dialog retune, dropdown enter animation, `AnimatedSize` tree expand/collapse, `AnimatedSwitcher` tab/content cross-fade. |
+| **UI-A4** | `performance`, `platform` | **High refresh rate** — `refresh_rate` (or wrapper): unlock on macOS 14+ in `main()`, query active Hz, debug-only FPS/Hz overlay. Verify Windows/Linux follow the monitor. |
+| **UI-A5** | `accessibility`, `settings` | **Reduced motion** — honor OS "reduce motion"; **Preferences → Appearance → Motion** (Full / Reduced / Off). |
+| **UI-A6** | `docs`, `performance` | **Measurement & docs** — DevTools budget checklist (8.3 ms @120 Hz), per-OS Hz table, update design doc with measured results. |
+
+## Suggested PR order
+
+1. UI-A1 — motion tokens core (+ tests)
+2. UI-A2 — adopt tokens across widgets
+3. UI-A3 — smoother transitions (parallel with A4)
+4. UI-A4 — high-refresh-rate enablement + debug overlay
+5. UI-A5 — reduced-motion + Preferences toggle
+6. UI-A6 — measurement, perf-baseline update, close milestone
+
+## Out of scope for 0.4.4
+
+- **Extensions sidebar and marketplace Explore UI** — deferred to **0.4.5+** (`ExtensionManifest` stub and `ThemeRemoteInstallService` from 0.4.3 remain the foundation); see [market-tech.md](market-tech.md).
+- Non-theme extension types (drivers, SQL snippets).
+- Mobile (iOS/Android) high-Hz setup — documented for the future in [motion-and-high-refresh.md §3](motion-and-high-refresh.md) but no `ios/`/`android/` targets exist yet.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,6 +1,6 @@
-# Pre-release checklist (release **0.4.2**)
+# Pre-release checklist (release **0.4.3**)
 
-Use this before tagging **`0.4.2`** or running the **Release** workflow.
+Use this before tagging **`0.4.3`** or running the **Release** workflow.
 See [tags-and-releases.md](tags-and-releases.md) and [CHANGELOG.md](../CHANGELOG.md).
 
 ## Product smoke (manual)
@@ -16,7 +16,7 @@ See [tags-and-releases.md](tags-and-releases.md) and [CHANGELOG.md](../CHANGELOG
 Use **Preferences → Appearance** unless noted. Fixtures for copy/import tests live under
 `test/fixtures/themes/`; bundled built-in sample: **Querya Cyberpunk Neon** in the theme picker.
 
-- [ ] **Import valid custom dark** — import `test/fixtures/themes/querya_custom_dark.json` (or copy to themes folder + **Refresh themes**). Theme appears in picker; UI uses custom primary (`#38BDF8`).
+- [ ] **Import valid custom dark** — import `test/fixtures/themes/querya_custom_dark.json` (or copy to themes folder). Theme appears in picker; UI uses custom primary (`#38BDF8`).
 - [ ] **Import valid custom light** — import `test/fixtures/themes/querya_custom_light.json`. App switches to light brightness; readable text on cards and sidebar.
 - [ ] **Import VS Code JSONC** — import `test/fixtures/themes/querya_custom_jsonc.jsonc` or `themes/samples/cyberpunk-neon.jsonc`. Parser accepts comments/trailing commas; theme applies without crash.
 - [ ] **Picker with many themes** — install 50+ themes (copy fixtures with unique ids, or duplicate renamed files) → open theme picker: no overflow, list scrolls, search filters rows.
@@ -24,6 +24,13 @@ Use **Preferences → Appearance** unless noted. Fixtures for copy/import tests 
 - [ ] **Missing file fallback** — with a registry theme selected, delete its file from `{appSupport}/themes/`, restart: app starts on **Querya Dark**, Preferences shows *Selected theme failed to load. Using Querya Dark.*; saved selection id remains until user picks another theme.
 - [ ] **Title bar / window controls** — switch Querya Dark, Querya Light, Cyberpunk Neon, and a custom theme: title bar background and minimize/maximize/close hover colors track the active theme.
 - [ ] **SQL / JSON syntax** — open SQL editor with a theme that defines `tokenColors` (e.g. cyberpunk sample): comments, keywords, and strings use distinct colors; changing theme updates highlighting after editor refresh.
+
+## Theme follow-ups 0.4.3 (manual QA)
+
+- [ ] **File watcher (TP-F1)** — copy a valid theme JSON into `{appSupport}/themes/` via file manager (no **Refresh themes**): new theme appears in picker within a few seconds.
+- [ ] **Marketplace metadata (TP-F2)** — theme with `author` / `tags` in manifest shows subtitle in picker; search matches tag text.
+- [ ] **Visual theme editor (TP-F3)** — open **Theme editor**, change a workbench color, confirm live preview; **Export** writes valid `querya.theme.v1` JSON; import exported file applies the same colors.
+- [ ] **Remote install (TP-F4)** — **Install from URL…** with a public HTTPS theme JSON (optional SHA-256): theme imports and appears in picker; `http://` or localhost URL is rejected with a clear error.
 
 ## Automated
 
@@ -33,8 +40,8 @@ Use **Preferences → Appearance** unless noted. Fixtures for copy/import tests 
 
 ## Versioning and release
 
-- [ ] `pubspec.yaml` on **`dev`** is **`0.4.1+7`** before merging to `main` (auto version-bump sets **`0.4.2+8`** on `main`).
-- [ ] After merge, confirm GitHub Action **Auto Version Bump** committed **`0.4.2+…`** on `main`.
+- [ ] `pubspec.yaml` on **`dev`** is **`0.4.1+7`** before merging to `main` (auto version-bump sets **`0.4.3+9`** on `main`).
+- [ ] After merge, confirm GitHub Action **Auto Version Bump** committed **`0.4.3+…`** on `main`.
 - [ ] **Tag** is placed on the **commit that includes all fixes** you want in binaries (a tag does not auto-include later commits; see [CONTRIBUTING.md](../CONTRIBUTING.md)).
 - [ ] Run the **Release** workflow from GitHub Actions (see [tags-and-releases.md](tags-and-releases.md)).
 - [ ] Verify **Linux** and **Windows** zip artifacts and `SHA256SUMS.txt` on the GitHub Release.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -8,7 +8,9 @@ Living document for planned work. Not a commitment order; adjust as priorities c
   highlighting, P0 workbench migration, Preferences, tests, docs — [theme.md](theme.md).
 - **Shipped in 0.4.1 ([#93](https://github.com/QueryaHub/Querya-Desktop/issues/93)):** UI performance — virtual result grid, lazy connection tree, decoupled scale preview, stats polling, MySQL stats dashboard, local `docker/` dev stack — [perf-baseline.md](perf-baseline.md).
 - **Shipped in 0.4.2 (TP-01–TP-30, #96–#125):** custom theme registry — `querya.theme.v1` + VS Code JSON/JSONC scan, Theme picker (50+), import/refresh, built-in Cyberpunk Neon asset, startup fallback, window chrome sync — [theme-custom-json.md](theme-custom-json.md), [theme-import.md](theme-import.md).
-- **Planned 0.4.3:** theme follow-ups (file watcher, marketplace metadata, visual editor, remote install) — [planned-0.4.3.md](planned-0.4.3.md), epic [#159](https://github.com/QueryaHub/Querya-Desktop/issues/159), milestone [0.4.3](https://github.com/QueryaHub/Querya-Desktop/milestone/2).
+- **Shipped in 0.4.3 (TP-F1–TP-F4, #159–#163):** theme folder watcher, marketplace metadata on manifests, visual theme editor with export, HTTPS remote install with checksum — [planned-0.4.3.md](planned-0.4.3.md).
+- **Planned 0.4.4:** UI motion polish + high refresh rate (90/120/144 Hz) — [planned-0.4.4.md](planned-0.4.4.md), [motion-and-high-refresh.md](motion-and-high-refresh.md).
+- **Planned 0.4.5+:** Extensions sidebar and marketplace Explore UI — [market-tech.md](market-tech.md).
 - **Optional:** Preferences → **Animate theme changes** (off by default).
 - **Later:** P2 Mongo/Redis token colors; `re_editor` if perf gap; LSP epic per
   [archive/code-forge-evaluation.md](archive/code-forge-evaluation.md) (**NO-GO** on `code_forge` for 0.3).

--- a/docs/theme-import.md
+++ b/docs/theme-import.md
@@ -59,7 +59,9 @@ In **Preferences → Appearance**:
 - **Theme mode** — Dark / Light / System
 - **Theme** — built-in presets, bundled themes, and themes from the user themes folder
 - **Import theme…** — pick `.json` / `.jsonc` and copy into the themes folder
-- **Refresh themes** — rescan the themes folder (no live file watcher)
+- **Refresh themes** — rescan the themes folder (also runs automatically when files change; see below)
+- **Install from URL…** — download a theme over HTTPS with optional SHA-256 checksum
+- **Theme editor** — tweak workbench colors with live preview and export `querya.theme.v1`
 - **Open themes folder** — reveal the app support `themes/` directory in the file manager
 - **Reset appearance** — clears overrides and returns to Querya Dark
 
@@ -83,9 +85,9 @@ Querya loads themes from the **application support** directory (see
 | macOS | `~/Library/Application Support/com.example.querya_desktop/themes` |
 | Windows | `%APPDATA%\com.example.querya_desktop\themes` |
 
-**Workflow:** copy or import a theme file into `themes/`, then click **Refresh themes**
-in Preferences. The app does **not** watch the folder; a restart is not required after
-refresh.
+**Workflow:** copy or import a theme file into `themes/`. A **file watcher** (0.4.3+)
+debounces changes under `themes/` and refreshes the registry automatically; use
+**Refresh themes** if the list looks stale. A restart is not required after refresh.
 
 **Accepted extensions:** `.json`, `.jsonc` (comments and trailing commas stripped before parse).
 

--- a/docs/theme-parser-github-issues.md
+++ b/docs/theme-parser-github-issues.md
@@ -1575,7 +1575,7 @@ Add QA checklist:
 ## Optional follow-up issues
 
 These are intentionally out of the first implementation pass (**shipped in 0.4.2**).
-**Target milestone: 0.4.3** ([milestone](https://github.com/QueryaHub/Querya-Desktop/milestone/2), epic **#159**) — see [planned-0.4.3.md](planned-0.4.3.md).
+**Shipped in 0.4.3** ([milestone](https://github.com/QueryaHub/Querya-Desktop/milestone/2), epic **#159**) — see [planned-0.4.3.md](planned-0.4.3.md).
 
 ### TP-F1 — File watcher for user themes folder ([#160](https://github.com/QueryaHub/Querya-Desktop/issues/160))
 


### PR DESCRIPTION
## Summary

- Finalize **0.4.3** release docs: changelog, release checklist, roadmap, theme-import updates
- Mark milestone **0.4.3** / epic **#159** as shipped in planning docs
- Add **0.4.4** motion polish + high refresh rate research (`motion-and-high-refresh.md`, `planned-0.4.4.md`)
- `pubspec.yaml` stays **`0.4.1+7`** on `dev` — Auto Version Bump sets **`0.4.3+9`** on `main` after merge

## Test plan

- [x] `flutter analyze` — clean
- [x] `flutter test --concurrency=1` — 544 tests green