### PR TITLE
Feat: Implement File -> Exit

### DIFF
--- a/lib/features/main_screen/querya_window_title_bar.dart
+++ b/lib/features/main_screen/querya_window_title_bar.dart
@@ -84,7 +84,8 @@ class QueryaWindowTitleBar extends StatelessWidget {
                                 onPressed: (_) {}, child: const Text('Save')),
                             const MenuDivider(),
                             MenuButton(
-                                onPressed: (_) {}, child: const Text('Exit')),
+                                onPressed: (_) => appWindow.close(),
+                                child: const Text('Exit')),
                           ],
                           child: const Text('File'),
                         ),


### PR DESCRIPTION
Closes #223. Binds the Exit menu button to appWindow.close() from bitsdojo_window.