### PR TITLE
fix(core): log swallowed errors in connection drivers and folders storage (#272)

### DIFF
--- a/lib/core/database/mysql_connection.dart
+++ b/lib/core/database/mysql_connection.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:mysql_client/mysql_client.dart';
 import 'package:querya_desktop/core/storage/local_db.dart';
 
@@ -192,7 +193,9 @@ class MysqlConnection {
       if (c != null && c.connected) {
         await c.close();
       }
-    } catch (_) {}
+    } catch (e) {
+      debugPrint('MysqlConnection.disconnect: $e');
+    }
   }
 
   /// Best-effort close. The `mysql_client` driver may not allow graceful [close]
@@ -206,7 +209,9 @@ class MysqlConnection {
       if (c.connected) {
         await c.close();
       }
-    } catch (_) {}
+    } catch (e) {
+      debugPrint('MysqlConnection.forceClose: $e');
+    }
   }
 
   /// Session hint for read-only browsing (MySQL 8+ / MariaDB — semantics differ from PostgreSQL).

--- a/lib/core/database/postgres_connection.dart
+++ b/lib/core/database/postgres_connection.dart
@@ -1,4 +1,6 @@
 import 'dart:io' show SecurityContext;
+
+import 'package:flutter/foundation.dart';
 import 'package:postgres/postgres.dart';
 import 'package:querya_desktop/core/storage/local_db.dart';
 
@@ -197,7 +199,9 @@ class PostgresConnection {
     _conn = null;
     try {
       await c?.close();
-    } catch (_) {}
+    } catch (e) {
+      debugPrint('PostgresConnection.disconnect: $e');
+    }
   }
 
   /// Drops the TCP session immediately (kills pending client I/O). Used when
@@ -208,7 +212,9 @@ class PostgresConnection {
     _conn = null;
     try {
       await c?.close(force: true);
-    } catch (_) {}
+    } catch (e) {
+      debugPrint('PostgresConnection.forceClose: $e');
+    }
   }
 
   /// Session-level default for transactions (browse vs SQL editor).
@@ -419,14 +425,18 @@ class PostgresConnection {
         "SELECT extract(epoch from (now() - pg_postmaster_start_time()))::bigint",
       );
       stats['uptime_seconds'] = uptime.first[0];
-    } catch (_) {}
+    } catch (e) {
+      debugPrint('PostgresConnection.getServerStats uptime: $e');
+    }
 
     try {
       final dbSize = await _conn!.execute(
         "SELECT pg_database_size(current_database())",
       );
       stats['current_db_size'] = dbSize.first[0];
-    } catch (_) {}
+    } catch (e) {
+      debugPrint('PostgresConnection.getServerStats database size: $e');
+    }
 
     return stats;
   }

--- a/lib/core/database/redis_connection.dart
+++ b/lib/core/database/redis_connection.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:redis/redis.dart' as redis;
 
 /// Redis connection using the Dart redis package (no Java/JRE).
@@ -333,7 +334,9 @@ class RedisConnectionTestFake extends RedisConnection {
     _command = null;
     try {
       await c?.close();
-    } catch (_) {}
+    } catch (e) {
+      debugPrint('RedisConnection.disconnect: $e');
+    }
   }
 
   @override

--- a/lib/core/database/sqlite_connection.dart
+++ b/lib/core/database/sqlite_connection.dart
@@ -1,4 +1,6 @@
 import 'dart:async';
+
+import 'package:flutter/foundation.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 import 'package:querya_desktop/core/storage/local_db.dart';
 
@@ -62,7 +64,9 @@ class SqliteConnection {
     _db = null;
     try {
       await d?.close();
-    } catch (_) {}
+    } catch (e) {
+      debugPrint('SqliteConnection.disconnect: $e');
+    }
   }
 
   Future<void> forceClose() => disconnect();

--- a/lib/core/storage/folders_storage.dart
+++ b/lib/core/storage/folders_storage.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:path_provider/path_provider.dart';
 
 import 'local_db.dart';
@@ -25,7 +26,8 @@ class FoldersStorage {
     try {
       await _migrateFromLegacyIfNeeded();
       _folders = await LocalDb.instance.getFolders();
-    } catch (_) {
+    } catch (e) {
+      debugPrint('FoldersStorage.load: $e');
       _folders = [];
     }
     _loaded = true;
@@ -56,7 +58,9 @@ class FoldersStorage {
         }
       }
       await file.delete();
-    } catch (_) {}
+    } catch (e) {
+      debugPrint('FoldersStorage._migrateFromLegacyIfNeeded: $e');
+    }
   }
 
   Future<void> save(List<String> folders) async {


### PR DESCRIPTION
## Summary
- Replace silent `catch (_) {}` in Postgres/MySQL/SQLite/Redis `disconnect` and `forceClose` with `debugPrint` so close failures are visible in logs.
- Log Postgres stats probe failures (`pg_postmaster_start_time`, `pg_database_size`) instead of returning partial stats silently.
- Log `FoldersStorage.load` and legacy migration errors instead of swallowing them.

Fixes #272.

## Test plan
- [x] `flutter test test/core/database/postgres_connection_test.dart test/core/database/mysql_connection_test.dart test/core/database/sqlite_connection_test.dart test/core/database/redis_connection_test.dart`
- [ ] Trigger a disconnect failure or stats permission error and confirm `debugPrint` output appears in console/log