### PR TITLE
enhancement(ui): coming soon state for placeholder workspace tabs

### DIFF
--- a/lib/features/main_screen/workspace_panel.dart
+++ b/lib/features/main_screen/workspace_panel.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/material.dart' as material
     show
         Alignment,
+        Align,
         Axis,
+        Column,
         Container,
+        ConstrainedBox,
         EdgeInsets,
         BoxDecoration,
         GestureDetector,
@@ -261,7 +264,11 @@ class _WorkspacePanelState extends State<WorkspacePanel> {
                 index: _editorTabIndex,
                 children: const [
                   QueryEditorTab(),
-                  _PlaceholderTab(message: 'Query history'),
+                  _ComingSoonTab(
+                    title: 'Query History',
+                    description:
+                        'Browse recently executed SQL queries and re-run them from one place. Coming in a future release.',
+                  ),
                 ],
               ),
             ),
@@ -282,8 +289,16 @@ class _WorkspacePanelState extends State<WorkspacePanel> {
                 index: _outputTabIndex,
                 children: const [
                   ResultsTab(),
-                  _PlaceholderTab(message: 'Messages'),
-                  _PlaceholderTab(message: 'Notifications'),
+                  _ComingSoonTab(
+                    title: 'Messages',
+                    description:
+                        'Connection logs and query execution messages will appear here. Coming in a future release.',
+                  ),
+                  _ComingSoonTab(
+                    title: 'Notifications',
+                    description:
+                        'System alerts and background task notifications will appear here. Coming in a future release.',
+                  ),
                 ],
               ),
             ),
@@ -427,13 +442,42 @@ class _RunButton extends StatelessWidget {
   }
 }
 
-class _PlaceholderTab extends StatelessWidget {
-  const _PlaceholderTab({required this.message});
+class _ComingSoonTab extends StatelessWidget {
+  const _ComingSoonTab({
+    required this.title,
+    required this.description,
+  });
 
-  final String message;
+  final String title;
+  final String description;
 
   @override
   Widget build(BuildContext context) {
-    return material.Center(child: Text(message).muted());
+    final theme = Theme.of(context);
+    return material.Center(
+      child: material.Padding(
+        padding: const material.EdgeInsets.all(32),
+        child: material.ConstrainedBox(
+          constraints: const material.BoxConstraints(maxWidth: 420),
+          child: material.Column(
+            mainAxisSize: material.MainAxisSize.min,
+            children: [
+              material.Icon(
+                material.Icons.hourglass_empty_rounded,
+                size: 36,
+                color: theme.colorScheme.mutedForeground,
+              ),
+              const material.SizedBox(height: 16),
+              Text(title).semiBold(),
+              const material.SizedBox(height: 8),
+              material.Align(
+                alignment: material.Alignment.center,
+                child: Text(description).muted().small(),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
   }
 }

--- a/test/features/main_screen/workspace_coming_soon_tabs_test.dart
+++ b/test/features/main_screen/workspace_coming_soon_tabs_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart' as material;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:querya_desktop/core/storage/local_db.dart';
+import 'package:querya_desktop/features/main_screen/workspace_panel.dart';
+
+import '../../support/querya_theme_test_shell.dart';
+
+ConnectionRow _stubConnection({required String type}) => ConnectionRow(
+      id: 1,
+      type: type,
+      name: 'Stub',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    );
+
+void main() {
+  testWidgets('placeholder tabs render coming soon state', (tester) async {
+    await tester.pumpWidget(
+      queryaThemeTestShell(
+        child: material.SizedBox(
+          width: 900,
+          height: 700,
+          child: WorkspacePanel(
+            activeConnection: _stubConnection(type: '_layout_test_split'),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Query History'), findsWidgets);
+    expect(find.text('Messages'), findsWidgets);
+    expect(find.text('Notifications'), findsWidgets);
+    expect(find.textContaining('Coming in a future release'), findsNWidgets(3));
+    expect(find.byIcon(material.Icons.hourglass_empty_rounded), findsNWidgets(3));
+  });
+}


### PR DESCRIPTION
## Summary
- Replace bare placeholder text on Query History, Messages, and Notifications tabs with informative coming soon panels (icon, title, description).
- Keeps tabs visible while setting clear expectations until those features ship.

Fixes #267

## Test plan
- [x] `flutter test test/features/main_screen/workspace_coming_soon_tabs_test.dart`
- [ ] Open workspace with an active connection and verify coming soon copy on each placeholder tab