### PR TITLE
fix(core): log remaining silent catches in database drivers

### DIFF
--- a/lib/core/database/mongodb_connection.dart
+++ b/lib/core/database/mongodb_connection.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:mongo_dart/mongo_dart.dart';
 import 'package:querya_desktop/features/connections/ssl_certificate_support.dart';
 
@@ -166,8 +167,8 @@ class MongoConnection {
     _db = null;
     try {
       await db?.close();
-    } catch (_) {
-      // Connection may already be closed — ignore.
+    } catch (e) {
+      debugPrint('MongoConnection.disconnect: $e');
     }
   }
 

--- a/lib/core/database/mysql_connection.dart
+++ b/lib/core/database/mysql_connection.dart
@@ -254,7 +254,8 @@ class MysqlConnection {
         return true;
       }
       return false;
-    } catch (_) {
+    } catch (e) {
+      debugPrint('MysqlConnection.testConnection: $e');
       return false;
     } finally {
       await disconnect();

--- a/lib/core/database/postgres_connection.dart
+++ b/lib/core/database/postgres_connection.dart
@@ -265,7 +265,8 @@ class PostgresConnection {
       );
       if (r.isEmpty) return null;
       return r.first[0] as bool;
-    } catch (_) {
+    } catch (e) {
+      debugPrint('PostgresConnection.inOpenTransaction: $e');
       return null;
     }
   }

--- a/lib/core/database/redis_connection.dart
+++ b/lib/core/database/redis_connection.dart
@@ -112,8 +112,8 @@ class RedisConnection {
     _conn = null;
     try {
       await c?.close();
-    } catch (_) {
-      // Connection may already be closed — ignore.
+    } catch (e) {
+      debugPrint('RedisConnection.disconnect: $e');
     }
   }
 
@@ -129,7 +129,8 @@ class RedisConnection {
     try {
       await connect();
       return true;
-    } catch (_) {
+    } catch (e) {
+      debugPrint('RedisConnection.testConnection: $e');
       return false;
     } finally {
       await disconnect();
@@ -164,7 +165,8 @@ class RedisConnection {
       if (result is List && result.length >= 2) {
         return int.tryParse(result[1].toString()) ?? 16;
       }
-    } catch (_) {
+    } catch (e) {
+      debugPrint('RedisConnection.getMaxDatabases: $e');
       // Some Redis instances don't allow CONFIG; fall back.
     }
     return 16;

--- a/lib/core/database/sqlite_connection.dart
+++ b/lib/core/database/sqlite_connection.dart
@@ -79,7 +79,8 @@ class SqliteConnection {
         return true;
       }
       return false;
-    } catch (_) {
+    } catch (e) {
+      debugPrint('SqliteConnection.testConnection: $e');
       return false;
     } finally {
       await disconnect();


### PR DESCRIPTION
## Summary
- Completes #272 logging pass: no remaining `catch (_) {}` in `lib/core/database/`.
- Logs MongoDB/Redis disconnect failures, `testConnection` errors, Redis `CONFIG GET` fallback, and PostgreSQL `inOpenTransaction` probe failures via `debugPrint`.

Fixes #272

## Test plan
- [x] `flutter test test/core/database/`
- [ ] Trigger failed Redis/Mongo disconnect in dev — message appears in console