### PR TITLE
fix(ui): synchronize column width recalculation in VirtualResultGrid (#331)

### DIFF
--- a/lib/features/main_screen/result_grid_view.dart
+++ b/lib/features/main_screen/result_grid_view.dart
@@ -63,10 +63,7 @@ class _VirtualResultGridState extends material.State<VirtualResultGrid> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    if (_widthsNeedUpdate) {
-      _columnWidths = _computeColumnWidths();
-      _widthsNeedUpdate = false;
-    }
+    _widthsNeedUpdate = true;
   }
 
   @override
@@ -106,6 +103,10 @@ class _VirtualResultGridState extends material.State<VirtualResultGrid> {
 
   @override
   material.Widget build(material.BuildContext context) {
+    if (_widthsNeedUpdate) {
+      _columnWidths = _computeColumnWidths();
+      _widthsNeedUpdate = false;
+    }
     final cs = Theme.of(context).colorScheme;
     final colCount = widget.columns.length;
     final rowHeight = _scaledRowHeight(context);

--- a/test/features/main_screen/results_tab_test.dart
+++ b/test/features/main_screen/results_tab_test.dart
@@ -97,5 +97,46 @@ void main() {
           tester.widgetList(find.byType(material.Row)).length;
       expect(dataRowWidgets, lessThan(80));
     });
+
+    testWidgets(
+        'recalculates column widths when updated with different columns without throwing RangeError',
+        (tester) async {
+      await tester.pumpWidget(
+        queryaThemeTestShell(
+          child: const material.SizedBox(
+            height: 400,
+            width: 600,
+            child: VirtualResultGrid(
+              columns: ['id', 'name'],
+              rows: [
+                ['1', 'Alpha'],
+              ],
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Now update the grid with 5 columns instead of 2
+      await tester.pumpWidget(
+        queryaThemeTestShell(
+          child: const material.SizedBox(
+            height: 400,
+            width: 600,
+            child: VirtualResultGrid(
+              columns: ['id', 'name', 'email', 'status', 'created_at'],
+              rows: [
+                ['1', 'Alpha', 'alpha@example.com', 'active', '2026-07-13'],
+              ],
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('email'), findsOneWidget);
+      expect(find.text('created_at'), findsOneWidget);
+    });
   });
 }


### PR DESCRIPTION
### Что сделано
- Исправлена синхронизация перерасчета ширин колонок (`_columnWidths`) в `VirtualResultGrid` при изменении входных свойств `widget.columns` и `widget.rows`.
- Проверка флага `_widthsNeedUpdate` перенесена в начало метода `build(BuildContext context)`, гарантируя, что при любом обновлении таблицы или смене запроса вёрстка и ширины колонок всегда актуальны перед построением грида.
- Добавлен виджет-тест в `test/features/main_screen/results_tab_test.dart`, проверяющий динамическую смену колонок без выброса `RangeError`.

### Как проверялось
- Запуск `flutter analyze` — 0 проблем.
- Запуск `flutter test` — 814 из 814 тестов прошли успешно (включая новый тест на смену колонок).

Closes #331
