### PR TITLE
perf(ui): RepaintBoundary + TickerMode for workspace morph (#358)

### DIFF
--- a/lib/core/motion/querya_cross_fade_stack.dart
+++ b/lib/core/motion/querya_cross_fade_stack.dart
@@ -35,7 +35,10 @@ class QueryaCrossFadeStack extends StatelessWidget {
                     opacity: index == i ? 1 : 0,
                     duration: duration,
                     curve: curve,
-                    child: children[i],
+                    child: TickerMode(
+                      enabled: index == i,
+                      child: RepaintBoundary(child: children[i]),
+                    ),
                   ),
                 ),
               ),

--- a/lib/core/motion/querya_switching_body.dart
+++ b/lib/core/motion/querya_switching_body.dart
@@ -74,11 +74,16 @@ class _SwitchingLayer extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final curve = active ? inCurve : outCurve;
+    // Isolate paint; pause child tickers when inactive (opacity anim still runs).
+    final content = TickerMode(
+      enabled: active,
+      child: RepaintBoundary(child: child),
+    );
     Widget layer = AnimatedOpacity(
       opacity: active ? 1 : 0,
       duration: duration,
       curve: curve,
-      child: child,
+      child: content,
     );
 
     if (slide != Offset.zero) {

--- a/test/core/motion/querya_switching_body_test.dart
+++ b/test/core/motion/querya_switching_body_test.dart
@@ -251,6 +251,41 @@ void main() {
     );
   });
 
+  testWidgets('inactive layer disables TickerMode and uses RepaintBoundary',
+      (tester) async {
+    await tester.pumpWidget(
+      wrap(
+        const QueryaSwitchingBody(
+          index: 0,
+          children: [
+            Text('active'),
+            Text('inactive'),
+          ],
+        ),
+      ),
+    );
+
+    final tickers = tester
+        .widgetList<TickerMode>(
+          find.descendant(
+            of: find.byType(QueryaSwitchingBody),
+            matching: find.byType(TickerMode),
+          ),
+        )
+        .toList();
+    expect(tickers.length, 2);
+    expect(tickers.first.enabled, isTrue);
+    expect(tickers.last.enabled, isFalse);
+
+    expect(
+      find.descendant(
+        of: find.byType(QueryaSwitchingBody),
+        matching: find.byType(RepaintBoundary),
+      ),
+      findsNWidgets(2),
+    );
+  });
+
   testWidgets('ExcludeSemantics excludes inactive child', (tester) async {
     await tester.pumpWidget(
       wrap(


### PR DESCRIPTION
## Summary
- `QueryaSwitchingBody` / `QueryaCrossFadeStack`: `RepaintBoundary` + `TickerMode(enabled: active)` under opacity
- Opacity/slide animations still run; child tickers pause when inactive

Closes #358

## Test plan
- [x] `flutter test test/core/motion/querya_switching_body_test.dart test/core/motion/querya_cross_fade_stack_test.dart`
- [ ] Manual: empty ↔ connected workspace morph


Made with [Cursor](https://cursor.com)