### PR TITLE
perf(ui): vertical split pane RepaintBoundary (#360)

### DIFF
--- a/docs/perf-baseline.md
+++ b/docs/perf-baseline.md
@@ -36,4 +36,4 @@ Repeat on a **120 Hz** display (budget **≤ 8.3 ms** build+raster). Prefer prof
 12. **Results modes**: idle → run (spinner) → grid; force an error — mode keys morph; scrolling the grid must not fade rows.
 13. **Dialog / dropdown**: open/close `showAppDialog` and a `QueryaDropdown` — enter fade-slide, exit uses exit curve; Motion Off snaps.
 14. **Theme cross-fade**: Preferences → enable Animate theme + Motion Full; switch dark/light — shadcn + `AnimatedQueryaTheme` lerp. Repeat with Motion Off (snap).
-15. **Split settle**: drag the connections sidebar handle and the SQL/results vertical split with a fling — mid-drag stays 1:1; release may soft-settle. Focus the handle — ring uses motion tokens (not mid-drag animation).
+15. **Split settle**: drag the connections sidebar handle and the SQL/results vertical split with a fling — mid-drag stays 1:1; release may soft-settle. Focus the handle — ring uses motion tokens (not mid-drag animation). Expect **layout** of editor/results each tick (constraint/flex); paint is isolated via `RepaintBoundary` on panes — do not add mid-drag springs to “fix” that cost.

--- a/lib/core/layout/vertical_split_pane.dart
+++ b/lib/core/layout/vertical_split_pane.dart
@@ -113,7 +113,10 @@ class _VerticalSplitPaneState extends State<VerticalSplitPane>
             return Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
-                Expanded(flex: topFlex, child: pair.top),
+                Expanded(
+                  flex: topFlex,
+                  child: material.RepaintBoundary(child: pair.top),
+                ),
                 QueryaSplitHandle(
                   key: widget.handleKey,
                   axis: material.Axis.vertical,
@@ -136,7 +139,10 @@ class _VerticalSplitPaneState extends State<VerticalSplitPane>
                     );
                   },
                 ),
-                Expanded(flex: bottomFlex, child: pair.bottom),
+                Expanded(
+                  flex: bottomFlex,
+                  child: material.RepaintBoundary(child: pair.bottom),
+                ),
               ],
             );
           },


### PR DESCRIPTION
## Summary
- Wrap vertical split top/bottom in `RepaintBoundary`
- Document accepted layout cost during settle in `docs/perf-baseline.md` §15

Closes #360

## Test plan
- [x] `flutter test test/core/layout/querya_split_handle_test.dart`
- [ ] Manual: fling SQL/results split — still 1:1 mid-drag


Made with [Cursor](https://cursor.com)