### PR TITLE
perf(ui): ResultsTab mode morph RepaintBoundary (#364)

### DIFF
--- a/lib/features/main_screen/results_tab.dart
+++ b/lib/features/main_screen/results_tab.dart
@@ -37,7 +37,7 @@ class ResultsTab extends StatelessWidget {
     return QueryaFadeSlide(
       alignment: material.Alignment.center,
       offset: const material.Offset(0, 0.015),
-      child: _buildBody(context),
+      child: material.RepaintBoundary(child: _buildBody(context)),
     );
   }
 


### PR DESCRIPTION
## Summary
- Wrap ResultsTab morph child in `RepaintBoundary`
- Mode keys unchanged; no per-row scroll animation

Closes #364

## Test plan
- [x] `flutter test test/features/main_screen/results_tab_test.dart`


Made with [Cursor](https://cursor.com)