### PR TITLE
fix(linux)+ui: secure_storage clang warning and larger dialogs

### DIFF
--- a/lib/core/layout/window_layout.dart
+++ b/lib/core/layout/window_layout.dart
@@ -10,6 +10,16 @@ abstract class WindowLayout {
   static const double narrowWindowWidth = 720;
   static const double compactWindowWidth = 520;
 
+  /// Logical sizes for connection credential forms (Postgres/MySQL/Redis/…).
+  static const double connectionFormMaxWidth = 700;
+  static const double connectionFormMaxHeight = 760;
+  static const double connectionFormMongoMaxHeight = 820;
+
+  /// Preferences / settings dialog.
+  static const double preferencesDialogMaxWidth = 600;
+  static const double preferencesDialogMinWidth = 420;
+  static const double preferencesDialogMaxHeight = 760;
+
   /// Horizontal inset for modal dialogs (clamped by screen).
   static double dialogHorizontalInset(double screenWidth) {
     return (screenWidth * 0.05).clamp(12.0, 48.0);
@@ -68,7 +78,7 @@ abstract class WindowLayout {
       context,
       screenExtent: mq.width,
       insetTotal: inset,
-      baseMax: 740,
+      baseMax: 860,
       baseMin: 280,
       viewportFactor: 1.0,
     );
@@ -81,9 +91,9 @@ abstract class WindowLayout {
       context,
       screenExtent: mq.height,
       insetTotal: inset,
-      baseMax: 580,
+      baseMax: 680,
       baseMin: 320,
-      viewportFactor: 0.78,
+      viewportFactor: 0.85,
     );
   }
 

--- a/lib/features/connections/extension_connection_form.dart
+++ b/lib/features/connections/extension_connection_form.dart
@@ -174,8 +174,8 @@ class _ExtensionConnectionFormContentState
     return material.Container(
       constraints: WindowLayout.dialogConstraints(
         context,
-        maxWidth: 520,
-        minWidth: 400,
+        maxWidth: WindowLayout.connectionFormMaxWidth,
+        minWidth: 440,
       ),
       decoration: material.BoxDecoration(
         color: theme.popover,

--- a/lib/features/connections/new_connection_url_dialog.dart
+++ b/lib/features/connections/new_connection_url_dialog.dart
@@ -52,8 +52,8 @@ class _NewConnectionUrlDialogContentState
     return material.Container(
       constraints: WindowLayout.dialogConstraints(
         context,
-        maxWidth: 500,
-        minWidth: 380,
+        maxWidth: 580,
+        minWidth: 420,
       ),
       decoration: material.BoxDecoration(
         color: theme.popover,

--- a/lib/features/mongodb/mongodb_connection_form.dart
+++ b/lib/features/mongodb/mongodb_connection_form.dart
@@ -305,8 +305,8 @@ class _MongoConnectionFormContentState
     return material.Container(
       constraints: WindowLayout.dialogConstraints(
         context,
-        maxWidth: 600,
-        maxHeight: 700,
+        maxWidth: WindowLayout.connectionFormMaxWidth,
+        maxHeight: WindowLayout.connectionFormMongoMaxHeight,
       ),
       decoration: material.BoxDecoration(
         color: theme.popover,

--- a/lib/features/mysql/mysql_connection_form.dart
+++ b/lib/features/mysql/mysql_connection_form.dart
@@ -274,8 +274,8 @@ class _MysqlConnectionFormContentState
     return material.Container(
       constraints: WindowLayout.dialogConstraints(
         context,
-        maxWidth: 600,
-        maxHeight: 640,
+        maxWidth: WindowLayout.connectionFormMaxWidth,
+        maxHeight: WindowLayout.connectionFormMaxHeight,
       ),
       decoration: material.BoxDecoration(
         color: theme.popover,

--- a/lib/features/postgresql/postgresql_connection_form.dart
+++ b/lib/features/postgresql/postgresql_connection_form.dart
@@ -388,8 +388,8 @@ class _PostgresConnectionFormContentState
     return material.Container(
       constraints: WindowLayout.dialogConstraints(
         context,
-        maxWidth: 600,
-        maxHeight: 640,
+        maxWidth: WindowLayout.connectionFormMaxWidth,
+        maxHeight: WindowLayout.connectionFormMaxHeight,
       ),
       decoration: material.BoxDecoration(
         color: theme.popover,

--- a/lib/features/redis/redis_connection_form.dart
+++ b/lib/features/redis/redis_connection_form.dart
@@ -249,8 +249,8 @@ class _RedisConnectionFormContentState
     return material.Container(
       constraints: WindowLayout.dialogConstraints(
         context,
-        maxWidth: 600,
-        maxHeight: 640,
+        maxWidth: WindowLayout.connectionFormMaxWidth,
+        maxHeight: WindowLayout.connectionFormMaxHeight,
       ),
       decoration: material.BoxDecoration(
         color: theme.popover,

--- a/lib/features/settings/preferences_dialog.dart
+++ b/lib/features/settings/preferences_dialog.dart
@@ -105,9 +105,9 @@ class _PreferencesDialogContentState
         child: material.Container(
           constraints: WindowLayout.dialogConstraints(
             context,
-            maxWidth: 480,
-            minWidth: 360,
-            maxHeight: 640,
+            maxWidth: WindowLayout.preferencesDialogMaxWidth,
+            minWidth: WindowLayout.preferencesDialogMinWidth,
+            maxHeight: WindowLayout.preferencesDialogMaxHeight,
           ),
           decoration: material.BoxDecoration(
             color: theme.popover,

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -41,7 +41,11 @@ endif()
 # of modifying this function.
 function(APPLY_STANDARD_SETTINGS TARGET)
   target_compile_features(${TARGET} PUBLIC cxx_std_14)
-  target_compile_options(${TARGET} PRIVATE -Wall -Werror)
+  # flutter_secure_storage_linux 9.x ships an old nlohmann/json.hpp that
+  # trips -Wdeprecated-literal-operator under newer Clang.
+  # Upstream fix is in flutter_secure_storage 10+; silence until then.
+  target_compile_options(${TARGET} PRIVATE
+    -Wall -Werror -Wno-deprecated-literal-operator)
   target_compile_options(${TARGET} PRIVATE "$<$<NOT:$<CONFIG:Debug>>:-O3>")
   target_compile_definitions(${TARGET} PRIVATE "$<$<NOT:$<CONFIG:Debug>>:NDEBUG>")
 endfunction()


### PR DESCRIPTION
## Summary
- Silence `-Wdeprecated-literal-operator` from flutter_secure_storage 9.x `json.hpp` on Linux
- Enlarge DB picker, connection forms, and Preferences dialogs

## Test plan
- [x] `flutter build linux` completes without json.hpp errors
- [ ] Spot-check New Connection / Preferences sizing


Made with [Cursor](https://cursor.com)