### PR TITLE
fix(theme): default remote install localhost policy to kDebugMode

### DIFF
--- a/lib/core/theme/theme_remote_install_service.dart
+++ b/lib/core/theme/theme_remote_install_service.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:crypto/crypto.dart';
+import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as p;
 
@@ -27,7 +28,7 @@ class ThemeRemoteInstallService {
     this._registry, {
     Future<RemoteThemeHttpResponse> Function(Uri uri)? httpGet,
     Duration timeout = const Duration(seconds: 30),
-    bool allowLocalhostInDebug = true,
+    bool allowLocalhostInDebug = kDebugMode,
   })  : _httpGet = httpGet ?? _defaultHttpGet,
         _timeout = timeout,
         _allowLocalhostInDebug = allowLocalhostInDebug;

--- a/test/core/theme/theme_remote_install_service_test.dart
+++ b/test/core/theme/theme_remote_install_service_test.dart
@@ -164,6 +164,32 @@ void main() {
       expect(result, isA<ThemeDefinitionImportFailure>());
     });
 
+    test('rejects localhost URLs when release policy is enforced', () async {
+      final service = ThemeRemoteInstallService(
+        registry,
+        allowLocalhostInDebug: false,
+      );
+      final result = await service.installFromUrl(
+        'https://127.0.0.1/theme.json',
+      );
+      expect(result, isA<ThemeDefinitionImportFailure>());
+      expect(
+        (result as ThemeDefinitionImportFailure).message,
+        contains('Only public HTTPS theme URLs are allowed'),
+      );
+    });
+
+    test('rejects private IPv4 URLs when release policy is enforced', () async {
+      final service = ThemeRemoteInstallService(
+        registry,
+        allowLocalhostInDebug: false,
+      );
+      final result = await service.installFromUrl(
+        'https://192.168.1.10/theme.json',
+      );
+      expect(result, isA<ThemeDefinitionImportFailure>());
+    });
+
     test('reuses existing file when remote content hash matches', () async {
       final raw = await File('test/fixtures/themes/querya_custom_dark.json')
           .readAsString();


### PR DESCRIPTION
## Summary
- Fix `ThemeRemoteInstallService` constructor default: `allowLocalhostInDebug: kDebugMode` instead of `true`
- Release builds no longer silently allow localhost/private HTTPS theme URLs
- Add regression tests for release-policy enforcement

Closes #399

## Test plan
- [x] `flutter test test/core/theme/theme_remote_install_service_test.dart`
- [x] `flutter test test/core/theme/theme_remote_install_policy_test.dart`