### PR TITLE
fix(marketplace): require SHA256 checksum before HttpMarketplace install

### DIFF
--- a/lib/core/market/http_marketplace_repository.dart
+++ b/lib/core/market/http_marketplace_repository.dart
@@ -124,21 +124,26 @@ class HttpMarketplaceRepository implements MarketplaceRepository {
 
     try {
       // Step 2: SHA-256 Integrity Verification (Critical Security Check)
-      if (manifest.sha256Checksum != null && manifest.sha256Checksum!.trim().isNotEmpty) {
-        final bytes = await archiveFile.readAsBytes();
-        final actualSha256 = sha256.convert(bytes).toString().toLowerCase();
-        final expectedSha256 = manifest.sha256Checksum!.trim().toLowerCase();
-        if (actualSha256 != expectedSha256) {
-          throw MarketplaceException(
-            'SHA256 checksum mismatch for "${manifest.id}". Expected: $expectedSha256, Actual: $actualSha256. Installation aborted.',
-          );
-        }
+      final expectedSha256 = manifest.sha256Checksum?.trim().toLowerCase();
+      if (expectedSha256 == null || expectedSha256.isEmpty) {
+        throw MarketplaceException(
+          'Extension manifest is missing SHA256 checksum for "${manifest.id}". '
+          'Installation aborted.',
+        );
+      }
+
+      final bytes = await archiveFile.readAsBytes();
+      final actualSha256 = sha256.convert(bytes).toString().toLowerCase();
+      if (actualSha256 != expectedSha256) {
+        throw MarketplaceException(
+          'SHA256 checksum mismatch for "${manifest.id}". '
+          'Expected: $expectedSha256, Actual: $actualSha256. Installation aborted.',
+        );
       }
 
       onProgress?.call(0.85);
 
       // Step 3: Safe Archive Extraction (Preventing Path Traversal / Zip Bomb - Issue #242)
-      final bytes = await archiveFile.readAsBytes();
       final archive = ZipDecoder().decodeBytes(bytes);
 
       final dir = await ExtensionPaths.extensionsDirectory();

--- a/test/core/market/marketplace_repository_test.dart
+++ b/test/core/market/marketplace_repository_test.dart
@@ -231,6 +231,67 @@ void main() {
       );
     });
 
+    test('install aborts when SHA256 checksum is missing', () async {
+      final archive = Archive();
+      archive.addFile(ArchiveFile('test.txt', 4, utf8.encode('good')));
+      final zipBytes = ZipEncoder().encode(archive);
+
+      final mockClient = MockClient((request) async {
+        return http.Response.bytes(zipBytes, 200);
+      });
+
+      final repo = HttpMarketplaceRepository(client: mockClient);
+      const manifest = ExtensionManifest(
+        id: 'test.no-sha256',
+        name: 'No SHA256',
+        version: '1.0.0',
+        publisher: 'Test',
+        type: ExtensionType.theme,
+        engines: {'querya_desktop': '*'},
+        downloadUrl: 'http://localhost:8000/test.zip',
+      );
+
+      expect(
+        () => repo.install(manifest),
+        throwsA(isA<MarketplaceException>().having(
+          (e) => e.message,
+          'message',
+          contains('missing SHA256 checksum'),
+        )),
+      );
+    });
+
+    test('install aborts when SHA256 checksum is empty', () async {
+      final archive = Archive();
+      archive.addFile(ArchiveFile('test.txt', 4, utf8.encode('good')));
+      final zipBytes = ZipEncoder().encode(archive);
+
+      final mockClient = MockClient((request) async {
+        return http.Response.bytes(zipBytes, 200);
+      });
+
+      final repo = HttpMarketplaceRepository(client: mockClient);
+      const manifest = ExtensionManifest(
+        id: 'test.empty-sha256',
+        name: 'Empty SHA256',
+        version: '1.0.0',
+        publisher: 'Test',
+        type: ExtensionType.theme,
+        engines: {'querya_desktop': '*'},
+        downloadUrl: 'http://localhost:8000/test.zip',
+        sha256Checksum: '   ',
+      );
+
+      expect(
+        () => repo.install(manifest),
+        throwsA(isA<MarketplaceException>().having(
+          (e) => e.message,
+          'message',
+          contains('missing SHA256 checksum'),
+        )),
+      );
+    });
+
     test('install prevents Path Traversal during archive unpacking (Issue #242)', () async {
       final archive = Archive();
       archive.addFile(ArchiveFile('../evil.txt', 4, utf8.encode('evil')));


### PR DESCRIPTION
## Summary
- Marketplace install fails closed when manifest `sha256Checksum` is missing or empty
- Aligns HttpMarketplace with updater fail-closed checksum model
- Reuse archive bytes for SHA256 verify + zip decode (single read)

Closes #396

## Test plan
- [x] `flutter test test/core/market/marketplace_repository_test.dart`