### PR TITLE
fix(theme): require SHA256 checksum for remote theme install

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -21,3 +21,7 @@ On upgrade from older databases, existing plaintext secrets in SQLite are **migr
 ## Tests
 
 Automated tests use an **in-memory** secrets backend (see `test/flutter_test_config.dart`) so CI does not require a desktop keyring.
+
+## Remote theme install integrity
+
+`ThemeRemoteInstallService` requires a **SHA256 checksum** for every remote theme URL install. Pass `sha256Checksum` to the API or append `?sha256=` to the theme URL. Installs without a checksum fail closed before download. This matches the marketplace extension install policy (#396).

--- a/lib/core/theme/theme_remote_install_service.dart
+++ b/lib/core/theme/theme_remote_install_service.dart
@@ -75,6 +75,12 @@ class ThemeRemoteInstallService {
     final expectedChecksum = _normalizeSha256(
       sha256Checksum ?? uri.queryParameters['sha256'],
     );
+    if (expectedChecksum == null) {
+      return const ThemeDefinitionImportFailure(
+        'SHA256 checksum is required for remote theme install. '
+        'Add ?sha256= to the URL or pass sha256Checksum.',
+      );
+    }
 
     File? tempFile;
     try {
@@ -92,7 +98,7 @@ class ThemeRemoteInstallService {
       }
 
       final actualChecksum = sha256.convert(utf8.encode(body)).toString();
-      if (expectedChecksum != null && expectedChecksum != actualChecksum) {
+      if (expectedChecksum != actualChecksum) {
         return const ThemeDefinitionImportFailure(
           'Checksum mismatch. Theme was not installed.',
         );

--- a/test/core/theme/theme_remote_install_service_test.dart
+++ b/test/core/theme/theme_remote_install_service_test.dart
@@ -1,5 +1,7 @@
+import 'dart:convert';
 import 'dart:io';
 
+import 'package:crypto/crypto.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
@@ -25,6 +27,8 @@ Future<String> _fixtureAssetLoader(String assetPath) async {
   final fileName = p.basename(assetPath);
   return File(p.join('test/fixtures/themes', fileName)).readAsString();
 }
+
+String _sha256Hex(String body) => sha256.convert(utf8.encode(body)).toString();
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -100,6 +104,7 @@ void main() {
 
       final result = await service.installFromUrl(
         'https://cdn.example.com/themes/querya_custom_dark.json',
+        sha256Checksum: _sha256Hex(raw),
       );
 
       expect(result, isA<ThemeDefinitionImportSuccess>());
@@ -136,18 +141,37 @@ void main() {
       expect(await ExtensionPaths.mockExtensionsDirectory!.list().length, 0);
     });
 
+    test('rejects install when SHA256 checksum is missing', () async {
+      final service = ThemeRemoteInstallService(
+        registry,
+        allowLocalhostInDebug: false,
+      );
+
+      final result = await service.installFromUrl(
+        'https://cdn.example.com/themes/querya_custom_dark.json',
+      );
+
+      expect(result, isA<ThemeDefinitionImportFailure>());
+      expect(
+        (result as ThemeDefinitionImportFailure).message,
+        contains('SHA256 checksum is required'),
+      );
+    });
+
     test('rejects invalid JSON without writing to themes folder', () async {
+      const brokenBody = '{ not valid json';
       final service = ThemeRemoteInstallService(
         registry,
         allowLocalhostInDebug: false,
         httpGet: (_) async => const RemoteThemeHttpResponse(
           statusCode: 200,
-          body: '{ not valid json',
+          body: brokenBody,
         ),
       );
 
       final result = await service.installFromUrl(
         'https://cdn.example.com/themes/broken.json',
+        sha256Checksum: _sha256Hex(brokenBody),
       );
 
       expect(result, isA<ThemeDefinitionImportFailure>());
@@ -219,6 +243,7 @@ void main() {
 
       final result = await service.installFromUrl(
         'https://cdn.example.com/themes/querya_custom_dark.json',
+        sha256Checksum: _sha256Hex(raw),
       );
 
       expect(result, isA<ThemeDefinitionImportSuccess>());
@@ -235,6 +260,7 @@ void main() {
 
       final result = await controller.importRegistryThemeFromUrl(
         'https://cdn.example.com/themes/querya_custom_dark.json',
+        sha256Checksum: _sha256Hex(raw),
         remoteInstallService: ThemeRemoteInstallService(
           registry,
           allowLocalhostInDebug: false,


### PR DESCRIPTION
## Summary
- Require SHA256 checksum before downloading remote theme URLs
- Accept checksum via `sha256Checksum` argument or `?sha256=` query param
- Document policy in `docs/security.md` (aligns with marketplace #396)

Closes #400

## Test plan
- [x] `flutter test test/core/theme/theme_remote_install_service_test.dart`
- [x] `flutter test test/core/theme/theme_remote_install_policy_test.dart`