### PR TITLE
chore(release): prepare 0.4.11-a

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.11-a] - 2026-07-27
+
+Post-0.4.11 patch: security review hardening (#395–#402) and remaining Linux distro packages (#386).
+
 ### Added
 
 - **Linux distro packaging (#386)** — `.rpm`, Flatpak (`.flatpak` bundle + manifest), and AUR PKGBUILD; Release CI publishes rpm + Flatpak alongside existing `.deb` / AppImage — see [packaging.md](docs/packaging.md).
+
+### Security
+
+- **Theme remote install localhost (#399)** — `ThemeRemoteInstallService` defaults `allowLocalhostInDebug` to `kDebugMode`.
+- **Archive path guard (#401)** — zip extraction uses `p.isWithin()` bounds checks (`archive_path_guard.dart`).
+- **Marketplace SHA256 (#396)** — `HttpMarketplaceRepository` requires manifest checksum before install.
+- **Marketplace download URLs (#397)** — HTTPS allowlist / SSRF policy (`MarketplaceDownloadPolicy`).
+- **Safe zip extraction (#398)** — shared zip-bomb limits via `SafeZipExtractor` (extensions, updater, themes).
+- **Remote theme SHA256 (#400)** — remote theme install requires checksum when provided by metadata.
+- **Sandbox OS consent (#395)** — fail-closed unsandboxed driver launch without OS wrapper (bubblewrap / consent dialog).
+- **Sideload integrity UX (#402)** — local `.zip`/`.qext` install dialog with security notice and optional SHA256.
 
 ## [0.4.11] - 2026-07-27
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -3,6 +3,7 @@
 Living document for planned work. Not a commitment order; adjust as priorities change.
 
 **GitHub Latest Release:** [0.4.11](https://github.com/QueryaHub/Querya-Desktop/releases/tag/0.4.11) (2026-07-27).  
+**Next patch:** **0.4.11-a** — security review (#395–#402) + Linux rpm/Flatpak/AUR (#386); tag pending.  
 **Next product release:** **0.5.0** — live Marketplace download and install — see below.
 
 ## Theme system
@@ -24,7 +25,8 @@ Living document for planned work. Not a commitment order; adjust as priorities c
 - **Shipped in 0.4.8:** Extension Manager UI (+ mock Marketplace) — [planned-0.4.8.md](planned-0.4.8.md).
 - **Shipped in 0.4.9:** PostgreSQL SSL & connection reliability — see [CHANGELOG.md](../CHANGELOG.md).
 - **Shipped in 0.4.10:** Sandboxed extension runtime (Block E), Plugin RPC bridge (Block C), SDUI form/tree builders, local `.zip`/`.qext` install, Registration/Activation for external database drivers (e.g. ClickHouse), in-app updater — see [CHANGELOG.md](../CHANGELOG.md).
-- **Shipped in 0.4.11 (Latest):** Universal UI / SDUI RPC expand, ExtensionTableView, universal export, MySQL/SQLite parity, shell UX (#339), Fluid QueryaMotion (#342) + perf follow-ups (#356), grid/pool/timeout fixes, dual-channel packaging (portable zip + AppImage / `.deb` / Windows setup) — [CHANGELOG.md](../CHANGELOG.md) `[0.4.11]`, [packaging.md](packaging.md), epic [#379](https://github.com/QueryaHub/Querya-Desktop/issues/379).
+- **Shipped in 0.4.11:** Universal UI / SDUI RPC expand, ExtensionTableView, universal export, MySQL/SQLite parity, shell UX (#339), Fluid QueryaMotion (#342) + perf follow-ups (#356), grid/pool/timeout fixes, dual-channel packaging (portable zip + AppImage / `.deb` / Windows setup) — [CHANGELOG.md](../CHANGELOG.md) `[0.4.11]`, [packaging.md](packaging.md), epic [#379](https://github.com/QueryaHub/Querya-Desktop/issues/379).
+- **Pending 0.4.11-a:** security hardening (#395–#402), Linux `.rpm` / Flatpak / AUR (#386) — [CHANGELOG.md](../CHANGELOG.md) `[0.4.11-a]`.
 - **Planned 0.5.0:** Marketplace Launch — live download, `sha256` validation, install themes (and later DB drivers) from the network.
 
 ## Query history and favorites

--- a/packaging/linux/aur/PKGBUILD
+++ b/packaging/linux/aur/PKGBUILD
@@ -2,7 +2,7 @@
 # AUR package — installs the official Release portable Linux zip under /opt.
 # Bump pkgver/pkgrel when a new GitHub Release is published.
 pkgname=querya-desktop
-pkgver=0.4.11
+pkgver=0.4.11-a
 pkgrel=1
 pkgdesc="Multi-database desktop client (PostgreSQL, MySQL, Redis, MongoDB, SQLite)"
 arch=('x86_64')

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: querya_desktop
 description: Lightweight desktop SQL/NoSQL client. Flutter (Dart).
-version: 0.4.11+2
+version: 0.4.11-a
 
 
 


### PR DESCRIPTION
## Summary
- `pubspec.yaml` → `0.4.11-a`
- CHANGELOG section: security review (#395–#402) + Linux rpm/Flatpak/AUR (#386)
- Roadmap + AUR PKGBUILD version bump

Part of shipping **0.4.11-a** (patch after [0.4.11](https://github.com/QueryaHub/Querya-Desktop/releases/tag/0.4.11)).

## After merge
1. PR **`dev` → `main`** titled `Release 0.4.11-a`
2. Tag on `main`: `git tag -a 0.4.11-a -m "Querya Desktop 0.4.11-a"` && `git push origin 0.4.11-a`
3. Release workflow builds artifacts (incl. new `.rpm` / `.flatpak`)