### PR TITLE
perf(editor): honor syntax highlight isolate threshold (#424)

### DIFF
--- a/lib/core/editor/syntax_highlight_isolate.dart
+++ b/lib/core/editor/syntax_highlight_isolate.dart
@@ -118,9 +118,14 @@ TextStyle? _styleFromSegment(HighlightSegment s, TextStyle? base) {
   );
 }
 
-/// Runs [syntaxHighlightInIsolate] off the UI thread.
+/// Runs highlighting on a worker isolate when [job.code] is large enough;
+/// otherwise highlights synchronously on the calling isolate (avoids
+/// `compute` overhead for small editors).
 Future<List<HighlightSegment>> highlightOffMainThread(
   SyntaxHighlightJob job,
 ) {
+  if (job.code.length < kSyntaxHighlightIsolateThreshold) {
+    return Future<List<HighlightSegment>>.value(syntaxHighlightInIsolate(job));
+  }
   return compute(syntaxHighlightInIsolate, job);
 }

--- a/test/core/editor/syntax_highlight_isolate_test.dart
+++ b/test/core/editor/syntax_highlight_isolate_test.dart
@@ -33,4 +33,27 @@ void main() {
     expect(segments, isNotEmpty);
     expect(segments.map((s) => s.text).join(), code);
   });
+
+  test('small SQL buffer highlights inline below isolate threshold', () async {
+    const code = 'SELECT 1;';
+    expect(code.length, lessThan(kSyntaxHighlightIsolateThreshold));
+
+    final config = buildDefaultEditorHighlighterConfig(
+      QueryaTheme.darkDefault.editor,
+    );
+    final segments = await highlightOffMainThread(
+      SyntaxHighlightJob(
+        code: code,
+        language: 'sql',
+        themeConfigJson: config,
+        grammarJson: SyntaxHighlightService.grammarJsonFor(
+          QueryaCodeLanguage.sql,
+        ),
+        wrapperArgb: QueryaTheme.darkDefault.editor.foreground.toARGB32(),
+      ),
+    );
+
+    expect(segments, isNotEmpty);
+    expect(segments.map((s) => s.text).join(), code);
+  });
 }


### PR DESCRIPTION
## Summary
- `highlightOffMainThread` uses inline path when `code.length < 8192`
- Above threshold still uses `compute`
- Regression test for small buffer

Closes #424  
Parent: #414

## Test plan
- [x] `flutter test test/core/editor/syntax_highlight_isolate_test.dart`