### PR TITLE
fix(ui): Escape dismisses showAppDialog (#446)

### DIFF
--- a/lib/shared/widgets/app_dialog.dart
+++ b/lib/shared/widgets/app_dialog.dart
@@ -10,6 +10,10 @@ import 'package:querya_desktop/core/motion/querya_spring.dart';
 ///
 /// Use instead of [showDialog] so every overlay has consistent blur.
 /// Enter: fade + slight slide; exit uses [QueryaMotion.exit] via reverseCurve.
+///
+/// When [barrierDismissible] is true (default), Escape and backdrop tap dismiss.
+/// Escape is handled by the modal route; backdrop tap by [_BlurredDialogScaffold]
+/// (the route barrier stays transparent under the frosted layer).
 Future<T?> showAppDialog<T>({
   required BuildContext context,
   required WidgetBuilder builder,
@@ -17,7 +21,7 @@ Future<T?> showAppDialog<T>({
 }) {
   return showGeneralDialog<T>(
     context: context,
-    barrierDismissible: false,
+    barrierDismissible: barrierDismissible,
     barrierLabel: MaterialLocalizations.of(context).modalBarrierDismissLabel,
     barrierColor: Colors.transparent,
     transitionDuration: context.motionDuration(QueryaMotion.standard),

--- a/test/shared/app_dialog_test.dart
+++ b/test/shared/app_dialog_test.dart
@@ -1,6 +1,7 @@
 import 'dart:ui' show ImageFilter;
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:querya_desktop/core/motion/querya_motion.dart';
 import 'package:querya_desktop/core/motion/querya_motion_scope.dart';
@@ -64,6 +65,47 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Blocking dialog'), findsOneWidget);
+
+    Navigator.of(ctx, rootNavigator: true).pop();
+    await tester.pumpAndSettle();
+    await future;
+  });
+
+  testWidgets('barrierDismissible true closes dialog on Escape', (tester) async {
+    final ctx = await pumpHost(tester);
+    var completed = false;
+
+    final future = showAppDialog<void>(
+      context: ctx,
+      barrierDismissible: true,
+      builder: (c) => const AlertDialog(title: Text('Escapable')),
+    ).whenComplete(() => completed = true);
+
+    await tester.pumpAndSettle();
+    expect(find.text('Escapable'), findsOneWidget);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Escapable'), findsNothing);
+    expect(completed, isTrue);
+    await future;
+  });
+
+  testWidgets('barrierDismissible false ignores Escape', (tester) async {
+    final ctx = await pumpHost(tester);
+
+    final future = showAppDialog<void>(
+      context: ctx,
+      barrierDismissible: false,
+      builder: (c) => const AlertDialog(title: Text('No escape')),
+    );
+
+    await tester.pumpAndSettle();
+    await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+    await tester.pumpAndSettle();
+
+    expect(find.text('No escape'), findsOneWidget);
 
     Navigator.of(ctx, rootNavigator: true).pop();
     await tester.pumpAndSettle();


### PR DESCRIPTION
## Summary
- `showGeneralDialog(barrierDismissible:)` now matches the public flag so Escape works.
- Backdrop tap still handled by frosted scaffold.
- Tests for Escape dismiss / non-dismiss.

Closes #446

## Test plan
- [ ] `flutter test test/shared/app_dialog_test.dart`
- [ ] Open Preferences → Escape closes; DDL loading spinner Escape does not