### PR TITLE
fix(ui): always pop DDL loading overlay (#447)

### DIFF
--- a/lib/features/extensions/extension_table_view.dart
+++ b/lib/features/extensions/extension_table_view.dart
@@ -177,6 +177,7 @@ class _ExtensionTableViewState extends material.State<ExtensionTableView> {
   }
 
   Future<void> _openDdlDialog() async {
+    final navigator = material.Navigator.of(context, rootNavigator: true);
     unawaited(showAppDialog<void>(
       context: context,
       barrierDismissible: false,
@@ -191,8 +192,8 @@ class _ExtensionTableViewState extends material.State<ExtensionTableView> {
         nodeId: widget.tableName,
         nodeType: widget.isView ? 'view' : 'table',
       );
+      if (navigator.canPop()) navigator.pop();
       if (!mounted) return;
-      material.Navigator.of(context).pop();
 
       final ddlText = meta.ddl?.trim().isNotEmpty == true
           ? meta.ddl!
@@ -223,8 +224,8 @@ class _ExtensionTableViewState extends material.State<ExtensionTableView> {
         ),
       );
     } catch (e) {
+      if (navigator.canPop()) navigator.pop();
       if (!mounted) return;
-      material.Navigator.of(context).pop();
       showAppToast(
         context: context,
         message: 'Failed to fetch DDL: $e',

--- a/lib/features/sqlite/sqlite_table_view.dart
+++ b/lib/features/sqlite/sqlite_table_view.dart
@@ -194,6 +194,7 @@ class _SqliteTableViewState extends material.State<SqliteTableView> {
   Future<void> _showDdlDialog() async {
     final conn = _connection;
     if (conn == null || !conn.isConnected) return;
+    final navigator = material.Navigator.of(context, rootNavigator: true);
     unawaited(showAppDialog<void>(
       context: context,
       barrierDismissible: false,
@@ -203,8 +204,8 @@ class _SqliteTableViewState extends material.State<SqliteTableView> {
     ));
     try {
       final ddl = await conn.getObjectDdl(widget.tableName);
+      if (navigator.canPop()) navigator.pop();
       if (!mounted) return;
-      material.Navigator.of(context).pop();
       await showAppDialog<void>(
         context: context,
         builder: (ctx) => material.AlertDialog(
@@ -230,8 +231,8 @@ class _SqliteTableViewState extends material.State<SqliteTableView> {
         ),
       );
     } catch (e) {
+      if (navigator.canPop()) navigator.pop();
       if (!mounted) return;
-      material.Navigator.of(context).pop();
       showAppToast(
         context: context,
         message: 'Failed to fetch DDL: $e',


### PR DESCRIPTION
## Summary
- Capture root navigator before DDL fetch; pop loading on success, error, and unmount.
- Extension + SQLite table views.

Closes #447

## Test plan
- [ ] Open DDL, navigate away mid-load — no stuck spinner
- [ ] DDL success and failure still work