### PR TITLE
fix(ui): clear loading on stats/table early exits (#448)

### DIFF
--- a/lib/features/mysql/mysql_stats_view.dart
+++ b/lib/features/mysql/mysql_stats_view.dart
@@ -94,11 +94,21 @@ class _MysqlStatsViewState extends material.State<MysqlStatsView> {
 
   Future<void> _fetch() async {
     final conn = _lease?.connection;
-    if (conn == null || !conn.isConnected) return;
+    if (conn == null || !conn.isConnected) {
+      if (!mounted) return;
+      setState(() {
+        _error = 'Not connected';
+        _loading = false;
+      });
+      return;
+    }
     try {
       final stats = await conn.serverStats();
       if (!mounted) return;
-      if (!replaceIfChanged(_stats, stats, (v) => _stats = v)) return;
+      if (!replaceIfChanged(_stats, stats, (v) => _stats = v)) {
+        if (_loading) setState(() => _loading = false);
+        return;
+      }
       setState(() => _loading = false);
     } catch (e) {
       if (!mounted) return;

--- a/lib/features/mysql/mysql_table_view.dart
+++ b/lib/features/mysql/mysql_table_view.dart
@@ -165,7 +165,15 @@ class _MysqlTableViewState extends material.State<MysqlTableView> {
 
   Future<void> _fetch({bool refreshCount = false}) async {
     final conn = _connection;
-    if (conn == null || !conn.isConnected) return;
+    if (conn == null || !conn.isConnected) {
+      if (mounted && _loading) {
+        setState(() {
+          _error = 'Not connected';
+          _loading = false;
+        });
+      }
+      return;
+    }
     if (_customSqlActive) {
       await _fetchCustom();
       return;
@@ -218,7 +226,15 @@ class _MysqlTableViewState extends material.State<MysqlTableView> {
 
   Future<void> _fetchCustom() async {
     final conn = _connection;
-    if (conn == null || !conn.isConnected) return;
+    if (conn == null || !conn.isConnected) {
+      if (mounted && _loading) {
+        setState(() {
+          _error = 'Not connected';
+          _loading = false;
+        });
+      }
+      return;
+    }
     final sql = _customSql;
     if (sql == null || sql.isEmpty) return;
     if (!mounted) return;

--- a/lib/features/postgresql/postgres_stats_view.dart
+++ b/lib/features/postgresql/postgres_stats_view.dart
@@ -104,11 +104,25 @@ class _PostgresStatsViewState extends material.State<PostgresStatsView> {
 
   Future<void> _fetch() async {
     final c = _connection;
-    if (c == null || !c.isConnected) return;
+    if (c == null || !c.isConnected) {
+      if (!mounted) return;
+      setState(() {
+        _error = 'Not connected';
+        _loading = false;
+      });
+      return;
+    }
     try {
       final stats = await c.serverStats();
       if (!mounted) return;
-      if (!replaceIfChanged(_stats, stats, (v) => _stats = v)) return;
+      if (!replaceIfChanged(_stats, stats, (v) => _stats = v)) {
+        if (_loading) {
+          setState(() {
+            _loading = false;
+          });
+        }
+        return;
+      }
       setState(() {
         _loading = false;
       });

--- a/lib/features/postgresql/postgres_table_view.dart
+++ b/lib/features/postgresql/postgres_table_view.dart
@@ -156,7 +156,15 @@ class _PostgresTableViewState extends material.State<PostgresTableView> {
   /// [refreshCount] runs `COUNT(*)` (e.g. first load or Refresh). Pagination only runs SELECT.
   Future<void> _fetch({bool refreshCount = false}) async {
     final conn = _connection;
-    if (conn == null || !conn.isConnected) return;
+    if (conn == null || !conn.isConnected) {
+      if (mounted && _loading) {
+        setState(() {
+          _error = 'Not connected';
+          _loading = false;
+        });
+      }
+      return;
+    }
     if (_customSqlActive) {
       await _fetchCustom();
       return;
@@ -219,7 +227,15 @@ class _PostgresTableViewState extends material.State<PostgresTableView> {
 
   Future<void> _fetchCustom() async {
     final conn = _connection;
-    if (conn == null || !conn.isConnected) return;
+    if (conn == null || !conn.isConnected) {
+      if (mounted && _loading) {
+        setState(() {
+          _error = 'Not connected';
+          _loading = false;
+        });
+      }
+      return;
+    }
     final sql = _customSql;
     if (sql == null || sql.isEmpty) return;
     if (!mounted) return;

--- a/lib/features/sqlite/sqlite_table_view.dart
+++ b/lib/features/sqlite/sqlite_table_view.dart
@@ -113,7 +113,15 @@ class _SqliteTableViewState extends material.State<SqliteTableView> {
 
   Future<void> _fetch({bool refreshCount = false}) async {
     final conn = _connection;
-    if (conn == null || !conn.isConnected) return;
+    if (conn == null || !conn.isConnected) {
+      if (mounted && _loading) {
+        setState(() {
+          _error = 'Not connected';
+          _loading = false;
+        });
+      }
+      return;
+    }
     setState(() {
       _loading = true;
       _error = null;


### PR DESCRIPTION
## Summary
- MySQL/Postgres stats: clear `_loading` when `replaceIfChanged` returns false; disconnect → error state.
- MySQL/Postgres/SQLite table (+ custom SQL): early exit while loading no longer leaves a stuck spinner.

Closes #448

## Test plan
- [ ] Open MySQL/Postgres stats; refresh with unchanged data — spinner clears
- [ ] Force disconnect mid-load — error UI, not infinite Connecting…