### PR TITLE
fix(ui): tree errors, empty table state, scrollable toolbars

### DIFF
--- a/lib/features/connections/connections_panel_mysql.dart
+++ b/lib/features/connections/connections_panel_mysql.dart
@@ -369,6 +369,7 @@ class _MysqlDatabaseNode extends StatefulWidget {
 class _MysqlDatabaseNodeState extends State<_MysqlDatabaseNode> {
   bool _expanded = false;
   bool _loading = false;
+  String? _error;
   List<String> _tables = [];
   List<String> _views = [];
   List<String> _procedures = [];
@@ -388,7 +389,10 @@ class _MysqlDatabaseNodeState extends State<_MysqlDatabaseNode> {
 
   Future<void> _loadTables() async {
     if (!mounted) return;
-    setState(() => _loading = true);
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
     MysqlLease? lease;
     try {
       final c = widget.connection;
@@ -412,10 +416,14 @@ class _MysqlDatabaseNodeState extends State<_MysqlDatabaseNode> {
         _procedures = procs;
         _functions = funcs;
         _loading = false;
+        _error = null;
       });
     } catch (e) {
       if (!mounted) return;
-      setState(() => _loading = false);
+      setState(() {
+        _error = e.toString();
+        _loading = false;
+      });
     } finally {
       lease?.release();
     }
@@ -478,6 +486,31 @@ class _MysqlDatabaseNodeState extends State<_MysqlDatabaseNode> {
                         ),
                         const Gap(6),
                         const Text('Loading...').muted().xSmall(),
+                      ],
+                    ),
+                  )
+                else if (_error != null)
+                  material.Padding(
+                    padding: const material.EdgeInsets.only(
+                      left: 24,
+                      top: 4,
+                      bottom: 8,
+                    ),
+                    child: material.Column(
+                      crossAxisAlignment: material.CrossAxisAlignment.start,
+                      children: [
+                        material.SelectableText(
+                          _error!,
+                          style: material.TextStyle(
+                            fontSize: 11,
+                            color: theme.colorScheme.destructive,
+                          ),
+                        ),
+                        const material.SizedBox(height: 6),
+                        GhostButton(
+                          onPressed: _loadTables,
+                          child: const Text('Retry'),
+                        ),
                       ],
                     ),
                   ),

--- a/lib/features/connections/connections_panel_pg_tree.dart
+++ b/lib/features/connections/connections_panel_pg_tree.dart
@@ -285,6 +285,7 @@ class _PgDatabaseNode extends StatefulWidget {
 class _PgDatabaseNodeState extends State<_PgDatabaseNode> {
   bool _expanded = false;
   bool _loading = false;
+  String? _error;
   List<String> _schemas = [];
 
   void _toggle() {
@@ -296,7 +297,10 @@ class _PgDatabaseNodeState extends State<_PgDatabaseNode> {
 
   Future<void> _loadSchemas() async {
     if (!mounted) return;
-    setState(() => _loading = true);
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
     PgLease? lease;
     try {
       final c = widget.connection;
@@ -310,10 +314,14 @@ class _PgDatabaseNodeState extends State<_PgDatabaseNode> {
       setState(() {
         _schemas = schemas;
         _loading = false;
+        _error = null;
       });
     } catch (e) {
       if (!mounted) return;
-      setState(() => _loading = false);
+      setState(() {
+        _error = e.toString();
+        _loading = false;
+      });
     } finally {
       lease?.release();
     }
@@ -393,6 +401,31 @@ class _PgDatabaseNodeState extends State<_PgDatabaseNode> {
                         ),
                         const Gap(6),
                         const Text('Loading...').muted().xSmall(),
+                      ],
+                    ),
+                  )
+                else if (_error != null)
+                  material.Padding(
+                    padding: const material.EdgeInsets.only(
+                      left: 24,
+                      top: 4,
+                      bottom: 8,
+                    ),
+                    child: material.Column(
+                      crossAxisAlignment: material.CrossAxisAlignment.start,
+                      children: [
+                        material.SelectableText(
+                          _error!,
+                          style: material.TextStyle(
+                            fontSize: 11,
+                            color: theme.colorScheme.destructive,
+                          ),
+                        ),
+                        const material.SizedBox(height: 6),
+                        GhostButton(
+                          onPressed: _loadSchemas,
+                          child: const Text('Retry'),
+                        ),
                       ],
                     ),
                   ),
@@ -597,6 +630,7 @@ class _PgSchemaNode extends StatefulWidget {
 class _PgSchemaNodeState extends State<_PgSchemaNode> {
   bool _expanded = false;
   bool _loading = false;
+  String? _error;
   List<String> _tables = [];
   List<String> _views = [];
   List<String> _matviews = [];
@@ -613,7 +647,10 @@ class _PgSchemaNodeState extends State<_PgSchemaNode> {
 
   Future<void> _loadObjects() async {
     if (!mounted) return;
-    setState(() => _loading = true);
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
     PgLease? lease;
     try {
       final c = widget.connection;
@@ -642,10 +679,14 @@ class _PgSchemaNodeState extends State<_PgSchemaNode> {
         _sequences = sequences;
         _loading = false;
         _loaded = true;
+        _error = null;
       });
     } catch (e) {
       if (!mounted) return;
-      setState(() => _loading = false);
+      setState(() {
+        _error = e.toString();
+        _loading = false;
+      });
     } finally {
       lease?.release();
     }
@@ -704,6 +745,31 @@ class _PgSchemaNodeState extends State<_PgSchemaNode> {
                         ),
                         const Gap(6),
                         const Text('Loading...').muted().xSmall(),
+                      ],
+                    ),
+                  )
+                else if (_error != null)
+                  material.Padding(
+                    padding: const material.EdgeInsets.only(
+                      left: 24,
+                      top: 4,
+                      bottom: 8,
+                    ),
+                    child: material.Column(
+                      crossAxisAlignment: material.CrossAxisAlignment.start,
+                      children: [
+                        material.SelectableText(
+                          _error!,
+                          style: material.TextStyle(
+                            fontSize: 11,
+                            color: theme.colorScheme.destructive,
+                          ),
+                        ),
+                        const material.SizedBox(height: 6),
+                        GhostButton(
+                          onPressed: _loadObjects,
+                          child: const Text('Retry'),
+                        ),
                       ],
                     ),
                   ),

--- a/lib/features/mysql/mysql_table_view.dart
+++ b/lib/features/mysql/mysql_table_view.dart
@@ -405,7 +405,33 @@ class _MysqlTableViewState extends material.State<MysqlTableView> {
     }
 
     if (_columnNames.isEmpty) {
-      return material.Container(color: cs.background);
+      return material.Container(
+        color: cs.background,
+        child: material.Center(
+          child: material.Padding(
+            padding: const material.EdgeInsets.all(32),
+            child: material.Column(
+              mainAxisSize: material.MainAxisSize.min,
+              children: [
+                const Text('No columns returned').muted().small(),
+                const Gap(24),
+                OutlineButton(
+                  onPressed: () {
+                    if (_customSqlActive) {
+                      unawaited(_fetchCustom());
+                    } else {
+                      unawaited(_fetch(refreshCount: true));
+                    }
+                  },
+                  leading: const material.Icon(material.Icons.refresh_rounded,
+                      size: 18),
+                  child: const Text('Retry'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
     }
 
     const double rowHeight = 36;
@@ -444,6 +470,7 @@ class _MysqlTableViewState extends material.State<MysqlTableView> {
                   child: material.Text(
                     title,
                     overflow: material.TextOverflow.ellipsis,
+                    maxLines: 1,
                     style: material.TextStyle(
                       fontSize: 13,
                       fontWeight: material.FontWeight.w600,
@@ -451,49 +478,75 @@ class _MysqlTableViewState extends material.State<MysqlTableView> {
                     ),
                   ),
                 ),
-                material.Text(
-                  _paginationLabel(),
-                  style: material.TextStyle(
-                    fontSize: 11,
-                    color: cs.mutedForeground,
+                material.Expanded(
+                  flex: 2,
+                  child: material.LayoutBuilder(
+                    builder: (context, constraints) {
+                      return material.SingleChildScrollView(
+                        scrollDirection: material.Axis.horizontal,
+                        child: material.ConstrainedBox(
+                          constraints: material.BoxConstraints(
+                            minWidth: constraints.maxWidth,
+                          ),
+                          child: material.Row(
+                            mainAxisAlignment: material.MainAxisAlignment.end,
+                            mainAxisSize: material.MainAxisSize.min,
+                            children: [
+                              material.Text(
+                                _paginationLabel(),
+                                style: material.TextStyle(
+                                  fontSize: 11,
+                                  color: cs.mutedForeground,
+                                ),
+                              ),
+                              const Gap(8),
+                              OutlineButton(
+                                onPressed: _loading
+                                    ? null
+                                    : () {
+                                        if (_customSqlActive) {
+                                          unawaited(_fetchCustom());
+                                        } else {
+                                          unawaited(_fetch(refreshCount: true));
+                                        }
+                                      },
+                                child: const Text('Refresh'),
+                              ),
+                              const Gap(6),
+                              OutlineButton(
+                                onPressed: _openSqlEditor,
+                                child: const Text('SQL'),
+                              ),
+                              if (_customSqlActive) ...[
+                                const Gap(6),
+                                OutlineButton(
+                                  onPressed: _exitCustomMode,
+                                  child: const Text('Browse'),
+                                ),
+                              ],
+                              const Gap(6),
+                              GhostButton(
+                                onPressed: (!_canGoPrevious || _loading)
+                                    ? null
+                                    : _goToPreviousPage,
+                                child: const Icon(
+                                    material.Icons.chevron_left_rounded,
+                                    size: 20),
+                              ),
+                              GhostButton(
+                                onPressed: (!_canGoNext || _loading)
+                                    ? null
+                                    : _goToNextPage,
+                                child: const Icon(
+                                    material.Icons.chevron_right_rounded,
+                                    size: 20),
+                              ),
+                            ],
+                          ),
+                        ),
+                      );
+                    },
                   ),
-                ),
-                const Gap(8),
-                OutlineButton(
-                  onPressed: _loading
-                      ? null
-                      : () {
-                          if (_customSqlActive) {
-                            unawaited(_fetchCustom());
-                          } else {
-                            unawaited(_fetch(refreshCount: true));
-                          }
-                        },
-                  child: const Text('Refresh'),
-                ),
-                const Gap(6),
-                OutlineButton(
-                  onPressed: _openSqlEditor,
-                  child: const Text('SQL'),
-                ),
-                if (_customSqlActive) ...[
-                  const Gap(6),
-                  OutlineButton(
-                    onPressed: _exitCustomMode,
-                    child: const Text('Browse'),
-                  ),
-                ],
-                const Gap(6),
-                GhostButton(
-                  onPressed:
-                      (!_canGoPrevious || _loading) ? null : _goToPreviousPage,
-                  child:
-                      const Icon(material.Icons.chevron_left_rounded, size: 20),
-                ),
-                GhostButton(
-                  onPressed: (!_canGoNext || _loading) ? null : _goToNextPage,
-                  child: const Icon(material.Icons.chevron_right_rounded,
-                      size: 20),
                 ),
               ],
             ),

--- a/lib/features/postgresql/postgres_table_view.dart
+++ b/lib/features/postgresql/postgres_table_view.dart
@@ -447,7 +447,33 @@ class _PostgresTableViewState extends material.State<PostgresTableView> {
     }
 
     if (_columnNames.isEmpty) {
-      return material.Container(color: cs.background);
+      return material.Container(
+        color: cs.background,
+        child: material.Center(
+          child: material.Padding(
+            padding: const material.EdgeInsets.all(32),
+            child: material.Column(
+              mainAxisSize: material.MainAxisSize.min,
+              children: [
+                const Text('No columns returned').muted().small(),
+                const Gap(24),
+                OutlineButton(
+                  onPressed: () {
+                    if (_customSqlActive) {
+                      _fetchCustom();
+                    } else {
+                      _fetch(refreshCount: true);
+                    }
+                  },
+                  leading: const material.Icon(material.Icons.refresh_rounded,
+                      size: 18),
+                  child: const Text('Retry'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
     }
 
     const double rowHeight = 36;

--- a/lib/features/sqlite/sqlite_table_view.dart
+++ b/lib/features/sqlite/sqlite_table_view.dart
@@ -392,7 +392,27 @@ class _SqliteTableViewState extends material.State<SqliteTableView> {
     }
 
     if (_columnNames.isEmpty) {
-      return material.Container(color: cs.background);
+      return material.Container(
+        color: cs.background,
+        child: material.Center(
+          child: material.Padding(
+            padding: const material.EdgeInsets.all(32),
+            child: material.Column(
+              mainAxisSize: material.MainAxisSize.min,
+              children: [
+                const Text('No columns returned').muted().small(),
+                const Gap(24),
+                OutlineButton(
+                  onPressed: _connectAndLoad,
+                  leading: const material.Icon(material.Icons.refresh_rounded,
+                      size: 18),
+                  child: const Text('Retry'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
     }
 
     const double rowHeight = 36;
@@ -430,6 +450,7 @@ class _SqliteTableViewState extends material.State<SqliteTableView> {
                   child: material.Text(
                     title,
                     overflow: material.TextOverflow.ellipsis,
+                    maxLines: 1,
                     style: material.TextStyle(
                       fontSize: 13,
                       fontWeight: material.FontWeight.w600,
@@ -437,36 +458,65 @@ class _SqliteTableViewState extends material.State<SqliteTableView> {
                     ),
                   ),
                 ),
-                material.Text(
-                  _paginationLabel(),
-                  style: material.TextStyle(
-                    fontSize: 11,
-                    color: cs.mutedForeground,
+                material.Expanded(
+                  flex: 2,
+                  child: material.LayoutBuilder(
+                    builder: (context, constraints) {
+                      return material.SingleChildScrollView(
+                        scrollDirection: material.Axis.horizontal,
+                        child: material.ConstrainedBox(
+                          constraints: material.BoxConstraints(
+                            minWidth: constraints.maxWidth,
+                          ),
+                          child: material.Row(
+                            mainAxisAlignment: material.MainAxisAlignment.end,
+                            mainAxisSize: material.MainAxisSize.min,
+                            children: [
+                              material.Text(
+                                _paginationLabel(),
+                                style: material.TextStyle(
+                                  fontSize: 11,
+                                  color: cs.mutedForeground,
+                                ),
+                              ),
+                              const Gap(8),
+                              OutlineButton(
+                                size: ButtonSize.small,
+                                onPressed: _loading
+                                    ? null
+                                    : () => unawaited(_showDdlDialog()),
+                                child: const Text('DDL'),
+                              ),
+                              const Gap(6),
+                              OutlineButton(
+                                onPressed: _loading
+                                    ? null
+                                    : () => unawaited(_fetch()),
+                                child: const Text('Refresh'),
+                              ),
+                              const Gap(6),
+                              GhostButton(
+                                onPressed: (!_canGoPrevious || _loading)
+                                    ? null
+                                    : _goToPreviousPage,
+                                child: const Icon(
+                                    material.Icons.chevron_left_rounded,
+                                    size: 20),
+                              ),
+                              GhostButton(
+                                onPressed: (!_canGoNext || _loading)
+                                    ? null
+                                    : _goToNextPage,
+                                child: const Icon(
+                                    material.Icons.chevron_right_rounded,
+                                    size: 20),
+                              ),
+                            ],
+                          ),
+                        ),
+                      );
+                    },
                   ),
-                ),
-                const Gap(8),
-                OutlineButton(
-                  size: ButtonSize.small,
-                  onPressed:
-                      _loading ? null : () => unawaited(_showDdlDialog()),
-                  child: const Text('DDL'),
-                ),
-                const Gap(6),
-                OutlineButton(
-                  onPressed: _loading ? null : () => unawaited(_fetch()),
-                  child: const Text('Refresh'),
-                ),
-                const Gap(6),
-                GhostButton(
-                  onPressed:
-                      (!_canGoPrevious || _loading) ? null : _goToPreviousPage,
-                  child:
-                      const Icon(material.Icons.chevron_left_rounded, size: 20),
-                ),
-                GhostButton(
-                  onPressed: (!_canGoNext || _loading) ? null : _goToNextPage,
-                  child: const Icon(material.Icons.chevron_right_rounded,
-                      size: 20),
                 ),
               ],
             ),


### PR DESCRIPTION
## Summary
- **#449** PG/MySQL connection tree: inline error + Retry on failed expand/load
- **#450** MySQL/Postgres/SQLite table browse: empty-state when no columns
- **#451** MySQL (+ SQLite) table toolbar: horizontal scroll under narrow width

Closes #449
Closes #450
Closes #451

## Test plan
- [ ] Fail PG/MySQL tree load — error + Retry, not empty list
- [ ] Browse empty/broken table — “No columns returned” + Retry
- [ ] Narrow MySQL table pane — no RenderFlex overflow on toolbar