### PR TITLE
chore(release): prepare 0.4.11-b

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.4.11-a] - 2026-07-27
+## [0.4.11-b] - 2026-07-27
 
-Post-0.4.11 patch: security review hardening (#395–#402) and remaining Linux distro packages (#386).
+Post-0.4.11 patch that **ships** security + Linux distro packaging (intended for 0.4.11-a), plus performance bounds (#414), UI reliability (#445), and code-review correctness (#463).
+
+> Note: GitHub tag `0.4.11-a` was mistakenly placed on the same commit as `0.4.11`, so those binaries did not include the 0.4.11-a changelog. Treat **0.4.11-b** as the first patch after **0.4.11**.
 
 ### Added
 
@@ -25,6 +27,24 @@ Post-0.4.11 patch: security review hardening (#395–#402) and remaining Linux d
 - **Remote theme SHA256 (#400)** — remote theme install requires checksum when provided by metadata.
 - **Sandbox OS consent (#395)** — fail-closed unsandboxed driver launch without OS wrapper (bubblewrap / consent dialog).
 - **Sideload integrity UX (#402)** — local `.zip`/`.qext` install dialog with security notice and optional SHA256.
+
+### Performance
+
+- **SQL result caps (#415 / #416)** — SQLite injects `LIMIT` before materializing rows; Postgres clamps oversized `LIMIT` / `FETCH`.
+- **Streaming I/O (#417 / #418)** — export writes stream to disk; marketplace SHA256 + zip extract avoid dual full-buffer copies.
+- **RPC / SDUI bounds (#419 / #420)** — NDJSON line size caps; virtualized `SduiTreeBuilder`.
+- **Hot-path yielding (#421 / #422)** — result cell string conversion and MySQL table browse yield to the UI isolate.
+- **Editor / Redis / sandbox / storage (#424–#428)** — syntax-highlight threshold, Redis TYPE/TTL pipeline, bounded stderr, SQL history index/prune, incremental theme mtime scan.
+- **VirtualResultGrid (#423)** — 2D column virtualization for wide result sets.
+
+### Fixed
+
+- **UI reliability (#445 / #446–#457)** — Escape on `showAppDialog`; DDL overlay always pops; stats/table loading clears on early exit; tree error + Retry; empty table state; scrollable toolbars; SQL open/save toasts; title-bar scale; Redis/Mongo empty banners; mounted guards; ResultsTab invariants.
+- **Correctness follow-ups (#463 / #464–#468)** — `injectSqlLimit` skips string/dollar quotes; delete partial export files on failure; PG tree clears stale children on error; theme watcher queues in-flight refresh; Redis keys error banner clears on success.
+
+## [0.4.11-a] - 2026-07-27
+
+Prepared changelog for security (#395–#402) + Linux rpm/Flatpak/AUR (#386). **Tag/binaries were mistargeted** (same commit as `0.4.11`); content ships in **0.4.11-b**.
 
 ## [0.4.11] - 2026-07-27
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -3,7 +3,7 @@
 Living document for planned work. Not a commitment order; adjust as priorities change.
 
 **GitHub Latest Release:** [0.4.11](https://github.com/QueryaHub/Querya-Desktop/releases/tag/0.4.11) (2026-07-27).  
-**Next patch:** **0.4.11-a** — security review (#395–#402) + Linux rpm/Flatpak/AUR (#386); tag pending.  
+**Next patch:** **0.4.11-b** — security + packaging (from mistagged 0.4.11-a) + perf (#414) + UI (#445) + code-review (#463); tag after merge to `main`.  
 **Next product release:** **0.5.0** — live Marketplace download and install — see below.
 
 ## Theme system
@@ -26,7 +26,8 @@ Living document for planned work. Not a commitment order; adjust as priorities c
 - **Shipped in 0.4.9:** PostgreSQL SSL & connection reliability — see [CHANGELOG.md](../CHANGELOG.md).
 - **Shipped in 0.4.10:** Sandboxed extension runtime (Block E), Plugin RPC bridge (Block C), SDUI form/tree builders, local `.zip`/`.qext` install, Registration/Activation for external database drivers (e.g. ClickHouse), in-app updater — see [CHANGELOG.md](../CHANGELOG.md).
 - **Shipped in 0.4.11:** Universal UI / SDUI RPC expand, ExtensionTableView, universal export, MySQL/SQLite parity, shell UX (#339), Fluid QueryaMotion (#342) + perf follow-ups (#356), grid/pool/timeout fixes, dual-channel packaging (portable zip + AppImage / `.deb` / Windows setup) — [CHANGELOG.md](../CHANGELOG.md) `[0.4.11]`, [packaging.md](packaging.md), epic [#379](https://github.com/QueryaHub/Querya-Desktop/issues/379).
-- **Pending 0.4.11-a:** security hardening (#395–#402), Linux `.rpm` / Flatpak / AUR (#386) — [CHANGELOG.md](../CHANGELOG.md) `[0.4.11-a]`.
+- **0.4.11-a:** changelog prepared; GitHub tag mistargeted onto `0.4.11` — do not treat as a shipped patch.
+- **Pending 0.4.11-b:** ships security (#395–#402), Linux `.rpm` / Flatpak / AUR (#386), perf (#414), UI reliability (#445), code-review fixes (#463) — [CHANGELOG.md](../CHANGELOG.md) `[0.4.11-b]`.
 - **Planned 0.5.0:** Marketplace Launch — live download, `sha256` validation, install themes (and later DB drivers) from the network.
 
 ## Query history and favorites

--- a/packaging/linux/aur/PKGBUILD
+++ b/packaging/linux/aur/PKGBUILD
@@ -2,7 +2,7 @@
 # AUR package — installs the official Release portable Linux zip under /opt.
 # Bump pkgver/pkgrel when a new GitHub Release is published.
 pkgname=querya-desktop
-pkgver=0.4.11-a
+pkgver=0.4.11-b
 pkgrel=1
 pkgdesc="Multi-database desktop client (PostgreSQL, MySQL, Redis, MongoDB, SQLite)"
 arch=('x86_64')

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: querya_desktop
 description: Lightweight desktop SQL/NoSQL client. Flutter (Dart).
-version: 0.4.11-a
+version: 0.4.11-b
 
 
 


### PR DESCRIPTION
## Summary
- `pubspec.yaml` → **0.4.11-b**
- CHANGELOG `[0.4.11-b]`: security + packaging (from mistagged 0.4.11-a) + perf (#414) + UI (#445) + code-review (#463)
- Documents that tag `0.4.11-a` pointed at the same commit as `0.4.11`
- Roadmap + AUR `pkgver=0.4.11-b`

## After merge to dev
Open **`dev` → `main`** release PR, then tag **on the merge commit**:

```bash
git checkout main && git pull
# confirm pubspec is 0.4.11-b on the tip you tag
git tag -a 0.4.11-b -m "Querya Desktop 0.4.11-b"
git push origin 0.4.11-b
```

Verify `git rev-parse 0.4.11-b^{}` ≠ `0.4.11^{}` and artifacts are named `Querya-Desktop-0.4.11-b-*` (incl. `.rpm` / `.flatpak`).