### PR TITLE
fix(macos): bitsdojo custom frame and traffic-light inset (#473)

### DIFF
--- a/lib/features/main_screen/querya_window_title_bar.dart
+++ b/lib/features/main_screen/querya_window_title_bar.dart
@@ -1,3 +1,5 @@
+import 'dart:io' show Platform;
+
 import 'package:bitsdojo_window/bitsdojo_window.dart';
 import 'package:flutter/material.dart' as material;
 import 'package:querya_desktop/core/layout/ui_scale.dart';
@@ -58,6 +60,15 @@ class QueryaWindowTitleBar extends StatelessWidget {
   }
 
   @visibleForTesting
+  static double titleBarLeadingInset({
+    required bool isMacOS,
+    required double Function(double designPx) scale,
+  }) {
+    // macOS traffic lights sit in the transparent titlebar (bitsdojo custom frame).
+    return scale(isMacOS ? 72 : 16);
+  }
+
+  @visibleForTesting
   static WindowButtonColors closeButtonColors(BuildContext context) {
     final wb = context.workbench;
     return WindowButtonColors(
@@ -85,7 +96,12 @@ class QueryaWindowTitleBar extends StatelessWidget {
               child: MoveWindow(
                 child: Row(
                   children: [
-                    const SizedBox(width: 16),
+                    SizedBox(
+                      width: QueryaWindowTitleBar.titleBarLeadingInset(
+                        isMacOS: Platform.isMacOS,
+                        scale: context.scaled,
+                      ),
+                    ),
                     material.Icon(
                       material.Icons.storage_rounded,
                       size: 18,

--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -1,7 +1,12 @@
 import Cocoa
 import FlutterMacOS
+import bitsdojo_window_macos
 
-class MainFlutterWindow: NSWindow {
+class MainFlutterWindow: BitsdojoWindow {
+  override func bitsdojo_window_configure() -> UInt {
+    return BDW_CUSTOM_FRAME | BDW_HIDE_ON_STARTUP
+  }
+
   override func awakeFromNib() {
     let flutterViewController = FlutterViewController()
     let windowFrame = self.frame

--- a/test/features/main_screen/querya_window_title_bar_test.dart
+++ b/test/features/main_screen/querya_window_title_bar_test.dart
@@ -97,6 +97,24 @@ void main() {
     expect(background, _customSurface);
   });
 
+  testWidgets('title bar leading inset reserves macOS traffic-light space',
+      (tester) async {
+    expect(
+      QueryaWindowTitleBar.titleBarLeadingInset(
+        isMacOS: true,
+        scale: (v) => v,
+      ),
+      72,
+    );
+    expect(
+      QueryaWindowTitleBar.titleBarLeadingInset(
+        isMacOS: false,
+        scale: (v) => v,
+      ),
+      16,
+    );
+  });
+
   testWidgets('read-only state is persistently visible in title bar',
       (tester) async {
     await tester.pumpWidget(


### PR DESCRIPTION
## Summary
- Enable bitsdojo custom window frame on macOS (`MainFlutterWindow` → `BitsdojoWindow`, `BDW_CUSTOM_FRAME | BDW_HIDE_ON_STARTUP`)
- Add macOS-specific leading inset (72px scaled) in `QueryaWindowTitleBar` so content clears traffic lights
- Regression test for inset helper

Closes #473

## Test plan
- [x] `flutter test test/features/main_screen/querya_window_title_bar_test.dart`
- [ ] Manual macOS: single titlebar row, traffic lights visible, drag works, no 800×600 startup flash