### PR TITLE
ui(motion): Extension Manager TabStrip + CrossFadeStack (#488)

### DIFF
--- a/lib/features/extensions/presentation/pages/extension_manager_dialog.dart
+++ b/lib/features/extensions/presentation/pages/extension_manager_dialog.dart
@@ -6,6 +6,7 @@ import 'package:querya_desktop/core/extensions/local_extension_registry.dart';
 import 'package:querya_desktop/core/extensions/models/extension_manifest.dart';
 import 'package:querya_desktop/core/layout/window_layout.dart';
 import 'package:querya_desktop/core/market/marketplace_repository.dart';
+import 'package:querya_desktop/core/motion/querya_cross_fade_stack.dart';
 import 'package:querya_desktop/features/extensions/presentation/widgets/extension_card.dart';
 import 'package:querya_desktop/features/extensions/presentation/widgets/extension_sideload_dialog.dart';
 import 'package:querya_desktop/shared/widgets/widgets.dart';
@@ -214,19 +215,19 @@ class _ExtensionManagerContentState
                 material.Padding(
                   padding: const material.EdgeInsets.symmetric(
                       horizontal: 24.0, vertical: 8.0),
-                  child: material.Wrap(
-                    spacing: 8,
-                    runSpacing: 8,
-                    children: [
-                      _buildTabButton(0, 'Installed', count: _installed.length),
-                      _buildTabButton(1, 'Marketplace'),
-                      _buildTabButton(2, 'Updates'),
+                  child: QueryaTabStrip(
+                    labels: [
+                      'Installed (${_installed.length})',
+                      'Marketplace',
+                      'Updates',
                     ],
+                    selectedIndex: _tabIndex,
+                    onSelected: (index) => setState(() => _tabIndex = index),
                   ),
                 ),
                 material.Divider(height: 1, color: theme.border),
                 material.Expanded(
-                  child: material.IndexedStack(
+                  child: QueryaCrossFadeStack(
                     index: _tabIndex,
                     children: [
                       _buildInstalledTab(),
@@ -238,22 +239,6 @@ class _ExtensionManagerContentState
               ],
             ),
           ),
-        ),
-      ),
-    );
-  }
-
-  material.Widget _buildTabButton(int index, String label, {int? count}) {
-    final isSelected = _tabIndex == index;
-    final displayLabel = count != null ? '$label ($count)' : label;
-    return SecondaryButton(
-      onPressed: () => setState(() => _tabIndex = index),
-      child: material.Text(
-        displayLabel,
-        style: material.TextStyle(
-          color: isSelected ? Theme.of(context).colorScheme.primary : null,
-          fontWeight:
-              isSelected ? material.FontWeight.w600 : material.FontWeight.w400,
         ),
       ),
     );

--- a/test/features/extensions/extension_manager_test.dart
+++ b/test/features/extensions/extension_manager_test.dart
@@ -6,6 +6,7 @@ import 'package:querya_desktop/core/extensions/local_extension_registry.dart';
 import 'package:querya_desktop/core/extensions/models/extension_manifest.dart';
 import 'package:querya_desktop/core/extensions/models/extension_type.dart';
 import 'package:querya_desktop/core/market/marketplace_repository.dart';
+import 'package:querya_desktop/core/motion/querya_cross_fade_stack.dart';
 import 'package:querya_desktop/features/extensions/presentation/pages/extension_manager_dialog.dart';
 import 'package:querya_desktop/features/extensions/presentation/widgets/extension_card.dart';
 import 'package:querya_desktop/shared/widgets/widgets.dart';
@@ -114,6 +115,8 @@ void main() {
       expect(find.text('Installed (0)'), findsOneWidget);
       expect(find.text('Marketplace'), findsOneWidget);
       expect(find.text('Install from file…'), findsOneWidget);
+      expect(find.byType(QueryaTabStrip), findsOneWidget);
+      expect(find.byType(QueryaCrossFadeStack), findsOneWidget);
 
       // Switch to Marketplace tab
       await tester.tap(find.text('Marketplace'));


### PR DESCRIPTION
## Summary
- Leftover polish from #482 / epic #477: Extension Manager uses `QueryaTabStrip` + `QueryaCrossFadeStack` like workspace homes.
- Keeps Installed count in the tab label; removes hard-cut `IndexedStack` / ad-hoc SecondaryButton tabs.

Closes #488

## Test plan
- [ ] `flutter test test/features/extensions/extension_manager_test.dart`
- [ ] Open Extensions → switch Installed / Marketplace / Updates (cross-fade + pill)
- [ ] Reduced / Off motion still usable; sideload / install still work