### PR TITLE
ui(motion): morph connection A→B switches (#494)

### DIFF
--- a/lib/features/main_screen/workspace_panel.dart
+++ b/lib/features/main_screen/workspace_panel.dart
@@ -133,6 +133,9 @@ class _WorkspacePanelState extends State<WorkspacePanel> {
   /// Keeps the last connected workspace mounted so empty↔active can cross-fade.
   material.Widget? _cachedActiveBody;
 
+  /// Connection id for the cached active body (stable FadeSlide key on empty).
+  int? _lastConnectedId;
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -152,9 +155,14 @@ class _WorkspacePanelState extends State<WorkspacePanel> {
     if (activeConn == null) {
       activeBody = _cachedActiveBody ?? const material.SizedBox.expand();
     } else {
+      _lastConnectedId = activeConn.id;
       activeBody = _buildActiveConnectionBody(theme, activeConn);
       _cachedActiveBody = activeBody;
     }
+
+    // Connection A→B: keyed FadeSlide inside the connected slot (#494).
+    // Keep last id when deselected so empty↔connected SwitchingBody is undisturbed.
+    final connKey = activeConn?.id ?? _lastConnectedId ?? 0;
 
     return material.Container(
       color: theme.colorScheme.background,
@@ -162,7 +170,12 @@ class _WorkspacePanelState extends State<WorkspacePanel> {
         index: activeConn == null ? 0 : 1,
         children: [
           empty,
-          material.SizedBox.expand(child: activeBody),
+          QueryaFadeSlide(
+            child: material.SizedBox.expand(
+              key: ValueKey('ws_conn_$connKey'),
+              child: activeBody,
+            ),
+          ),
         ],
       ),
     );

--- a/test/features/main_screen/workspace_panel_layout_test.dart
+++ b/test/features/main_screen/workspace_panel_layout_test.dart
@@ -211,5 +211,49 @@ void main() {
       expect(find.byType(RedisView), findsOneWidget);
       expect(find.byType(QueryaSwitchingBody), findsNWidgets(2));
     });
+
+    testWidgets('connection A→B morph uses outer QueryaFadeSlide',
+        (tester) async {
+      const redisB = ConnectionRow(
+        id: 43,
+        type: 'redis',
+        name: 'redis-b',
+        host: '127.0.0.1',
+        port: 6380,
+        createdAt: '0',
+      );
+
+      await pumpWidgetWithSurfaceSize(
+        tester,
+        const material.Size(800, 600),
+        queryaThemeTestShell(
+          child: const material.SizedBox.expand(
+            child: WorkspacePanel(activeConnection: redisConnection),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byKey(const material.ValueKey('ws_conn_42')), findsOneWidget);
+      expect(find.byType(RedisView), findsOneWidget);
+
+      await pumpWidgetWithSurfaceSize(
+        tester,
+        const material.Size(800, 600),
+        queryaThemeTestShell(
+          child: const material.SizedBox.expand(
+            child: WorkspacePanel(activeConnection: redisB),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      expect(find.byKey(const material.ValueKey('ws_conn_43')), findsOneWidget);
+      // Outer empty↔connected FadeSlide + home↔object FadeSlide.
+      expect(find.byType(QueryaFadeSlide), findsWidgets);
+      expect(find.byType(RedisView), findsOneWidget);
+      expect(find.byType(QueryaSwitchingBody), findsNWidgets(2));
+    });
   });
 }


### PR DESCRIPTION
## Summary
- Connected workspace slot uses `QueryaFadeSlide` keyed by `ws_conn_<id>`.
- Keeps `_lastConnectedId` when deselected so empty↔connected `QueryaSwitchingBody` is undisturbed.
- Home↔object morphs unchanged; inactive-connection SQL state was already not keep-alive across A→B (same as before).

Closes #494

## Test plan
- [ ] `flutter test test/features/main_screen/workspace_panel_layout_test.dart`
- [ ] Switch between two connections — cross-fade (Full/Reduced); Off snaps
- [ ] Empty↔connected and home↔object morphs still work