### PR TITLE
ui(extensions): honest Updates tab (#495)

### DIFF
--- a/lib/features/extensions/presentation/pages/extension_manager_dialog.dart
+++ b/lib/features/extensions/presentation/pages/extension_manager_dialog.dart
@@ -403,10 +403,37 @@ class _ExtensionManagerContentState
   }
 
   material.Widget _buildUpdatesTab() {
-    return const material.Center(
+    if (_loading) {
+      return const material.Center(
+        child: material.CircularProgressIndicator(),
+      );
+    }
+    final theme = Theme.of(context).colorScheme;
+    return material.Center(
       child: material.Padding(
-        padding: material.EdgeInsets.all(32.0),
-        child: Text('All installed extensions are up to date!'),
+        padding: const material.EdgeInsets.all(32.0),
+        child: material.ConstrainedBox(
+          constraints: const material.BoxConstraints(maxWidth: 420),
+          child: material.Column(
+            mainAxisSize: material.MainAxisSize.min,
+            children: [
+              material.Icon(
+                material.Icons.system_update_alt_rounded,
+                size: 36,
+                color: theme.mutedForeground,
+              ),
+              const material.SizedBox(height: 16),
+              const Text('Extension update checks are not available yet')
+                  .semiBold(),
+              const material.SizedBox(height: 8),
+              const Text(
+                'Automatic update scanning ships with the Marketplace API. '
+                'Until then, reinstall from Marketplace or from a local file '
+                'to get a newer build.',
+              ).muted().small(),
+            ],
+          ),
+        ),
       ),
     );
   }

--- a/test/features/extensions/extension_manager_test.dart
+++ b/test/features/extensions/extension_manager_test.dart
@@ -125,6 +125,19 @@ void main() {
       expect(find.text('ClickHouse Driver'), findsOneWidget);
       expect(find.textContaining('preview listings only'), findsOneWidget);
       expect(find.text('Preview'), findsWidgets);
+
+      await tester.tap(find.text('Updates'));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text('All installed extensions are up to date!'),
+        findsNothing,
+      );
+      expect(
+        find.text('Extension update checks are not available yet'),
+        findsOneWidget,
+      );
+      expect(find.textContaining('Marketplace API'), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
## Summary
- Updates tab no longer shows false “All installed extensions are up to date!”
- While `_loading`: spinner (parity with Installed/Marketplace)
- After load: honest empty state — update checks land with Marketplace API; reinstall guidance meanwhile

Closes #495

## Test plan
- [ ] `flutter test test/features/extensions/extension_manager_test.dart`
- [ ] Open Extensions → Updates: no false success; spinner then “not available yet”