### PR TITLE
ui(icons): drop unused sduiNode size token (#497)

### DIFF
--- a/lib/core/sdui/sdui_tree_builder.dart
+++ b/lib/core/sdui/sdui_tree_builder.dart
@@ -202,6 +202,7 @@ class SduiTreeBuilderState extends material.State<SduiTreeBuilder> {
     final isLoading = _loading.contains(node.id);
     final nodeKind = _resolveNodeKind(node);
     final isBrowsable = nodeKind == 'table' || nodeKind == 'view';
+    // Same hierarchy as native trees (#476 / #497) — no separate sduiNode size.
     final iconSize =
         canExpand ? QueryaIconSizes.treeGroup : QueryaIconSizes.treeLeaf;
     final iconColor = isBrowsable ? primary.withValues(alpha: 0.5) : muted;

--- a/lib/core/ui/querya_icon_sizes.dart
+++ b/lib/core/ui/querya_icon_sizes.dart
@@ -21,9 +21,6 @@ abstract final class QueryaIconSizes {
   /// Inline tree error indicator.
   static const double treeError = 14;
 
-  /// SDUI explorer tree nodes.
-  static const double sduiNode = 16;
-
   /// Menu / dialog leading icons.
   static const double menuLeading = 18;
 }

--- a/test/core/ui/querya_icons_test.dart
+++ b/test/core/ui/querya_icons_test.dart
@@ -91,4 +91,10 @@ void main() {
       QueryaIconSizes.sidebarConnectionIcon,
     );
   });
+
+  test('SDUI trees share native treeGroup/treeLeaf sizes (no sduiNode)', () {
+    // Guards against reintroducing a dead parallel size token (#497).
+    expect(QueryaIconSizes.treeGroup, 13);
+    expect(QueryaIconSizes.treeLeaf, 12);
+  });
 }


### PR DESCRIPTION
## Summary
- Remove dead `QueryaIconSizes.sduiNode` (16) — `SduiTreeBuilder` correctly uses `treeGroup` / `treeLeaf` to match native trees (#476).
- Comment + test guard against reintroducing a parallel SDUI size.

Closes #497

## Test plan
- [ ] `flutter test test/core/ui/querya_icons_test.dart test/core/sdui/sdui_builders_test.dart`
- [ ] Extension SDUI tree icons still align with native tree density