### PR TITLE
ci(packaging): automate AUR publish on Release (#507)

### DIFF
--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -1,0 +1,47 @@
+# Manual AUR publish (hotfix / re-publish). Normal path: Release workflow → publish-aur job.
+#
+# First push creates the AUR repo automatically. Requires secret AUR_SSH_PRIVATE_KEY.
+
+name: Publish AUR (querya-desktop)
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'pkgver (e.g. 0.4.12) — Querya-Desktop-{version}-linux.zip must exist on GitHub Releases'
+        required: true
+        type: string
+      release_tag:
+        description: 'GitHub Release tag if different from version (e.g. v0.4.12); leave empty to auto-try'
+        required: false
+        type: string
+
+jobs:
+  aur:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Require AUR SSH secret
+        env:
+          KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+        run: |
+          if [ -z "${KEY:-}" ]; then
+            echo "Missing repository secret AUR_SSH_PRIVATE_KEY" >&2
+            exit 1
+          fi
+
+      - name: SSH agent
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+
+      - name: Publish to AUR
+        env:
+          RELEASE_TAG: ${{ github.event.inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          VER="${{ github.event.inputs.version }}"
+          TAG="${RELEASE_TAG:-$VER}"
+          chmod +x ./scripts/linux/aur_publish.sh
+          ./scripts/linux/aur_publish.sh "$VER" "$TAG"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -269,6 +269,9 @@ jobs:
     name: Publish GitHub Release
     needs: [build-windows, build-linux, build-macos]
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ needs.build-windows.outputs.version }}
+      release_tag: ${{ steps.rel.outputs.tag }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -320,7 +323,7 @@ jobs:
             echo "- **Linux Flatpak**: \`Querya-Desktop-${VERSION}-linux.flatpak\` — \`flatpak install --user ./Querya-Desktop-${VERSION}-linux.flatpak\`"
             echo "- **Windows setup**: \`Querya-Desktop-${VERSION}-windows-setup.exe\` (Inno Setup)"
             echo ""
-            echo "**Arch (AUR):** PKGBUILD in \`packaging/linux/aur/\` (community-maintained)."
+            echo "**Arch (AUR):** \`querya-desktop\` — \`yay -S querya-desktop\` (auto-published when \`AUR_SSH_PRIVATE_KEY\` is configured)."
             echo ""
             echo "Verify checksums: \`SHA256SUMS.txt\`"
             echo ""
@@ -355,3 +358,41 @@ jobs:
             dist/SHA256SUMS.txt
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-aur:
+    name: Publish AUR (querya-desktop)
+    needs: [publish]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check AUR secret
+        id: aur
+        env:
+          AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+        run: |
+          if [ -n "${AUR_SSH_PRIVATE_KEY}" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Wait for release assets
+        if: steps.aur.outputs.enabled == 'true'
+        run: sleep 15
+
+      - uses: actions/checkout@v4
+        if: steps.aur.outputs.enabled == 'true'
+
+      - name: SSH agent
+        if: steps.aur.outputs.enabled == 'true'
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+
+      - name: Publish to AUR
+        if: steps.aur.outputs.enabled == 'true'
+        run: |
+          set -euo pipefail
+          VER="${{ needs.publish.outputs.version }}"
+          TAG="${{ needs.publish.outputs.release_tag }}"
+          chmod +x ./scripts/linux/aur_publish.sh
+          ./scripts/linux/aur_publish.sh "$VER" "$TAG"

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -80,11 +80,20 @@ jobs:
           sed -i "s/^version: .*/version: ${NEW_VERSION}+${NEW_BUILD}/" pubspec.yaml
           grep "^version:" pubspec.yaml
 
+      - name: Sync AUR PKGBUILD pkgver with pubspec
+        if: steps.check.outputs.merged == 'true'
+        run: |
+          NEW_VERSION="${{ steps.bump.outputs.new_version }}"
+          sed -i "s/^pkgver=.*/pkgver=${NEW_VERSION}/" packaging/linux/aur/PKGBUILD
+          sed -i "s/^pkgrel=.*/pkgrel=1/" packaging/linux/aur/PKGBUILD
+          sed -i "s/^sha256sums=.*/sha256sums=('SKIP' 'SKIP' 'SKIP')/" packaging/linux/aur/PKGBUILD
+          grep ^pkgver packaging/linux/aur/PKGBUILD
+
       - name: Commit version bump
         if: steps.check.outputs.merged == 'true'
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git add pubspec.yaml
+          git add pubspec.yaml packaging/linux/aur/PKGBUILD
           git commit -m "Bump version to ${{ steps.bump.outputs.new_version }}+${{ steps.bump.outputs.new_build }}"
           git push origin main

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -65,7 +65,7 @@ payload as the portable zip and AppImage.
 | `.deb` | [`scripts/linux/build_deb.sh`](../scripts/linux/build_deb.sh) | `sudo apt install ./Querya-Desktop-{ver}-linux.deb` |
 | `.rpm` | [`scripts/linux/build_rpm.sh`](../scripts/linux/build_rpm.sh) | `sudo dnf install ./Querya-Desktop-{ver}-linux.rpm` |
 | Flatpak | [`scripts/linux/build_flatpak.sh`](../scripts/linux/build_flatpak.sh) | `flatpak install --user ./Querya-Desktop-{ver}-linux.flatpak` |
-| AUR | [`packaging/linux/aur/`](../packaging/linux/aur/) | Community PKGBUILD (Release zip under `/opt`) |
+| AUR | [`packaging/linux/aur/`](../packaging/linux/aur/) | `yay -S querya-desktop` (CI publishes on Release when `AUR_SSH_PRIVATE_KEY` is set) |
 
 **Runtime dependencies (deb/rpm):** GTK 3, libsecret, GLib; app indicator recommended for tray.
 

--- a/docs/tags-and-releases.md
+++ b/docs/tags-and-releases.md
@@ -53,7 +53,7 @@ sudo dnf install ./Querya-Desktop-X.Y.Z-linux.rpm
 flatpak install --user ./Querya-Desktop-X.Y.Z-linux.flatpak
 ```
 
-**Arch (AUR):** community PKGBUILD — [`packaging/linux/aur/`](../packaging/linux/aur/) (installs the Release portable zip under `/opt`).
+**Arch (AUR):** `yay -S querya-desktop` — auto-published by Release CI when `AUR_SSH_PRIVATE_KEY` is configured ([`packaging/linux/aur/`](../packaging/linux/aur/)).
 
 ## Changelog в GitHub Release
 

--- a/packaging/linux/aur/PKGBUILD
+++ b/packaging/linux/aur/PKGBUILD
@@ -1,8 +1,8 @@
 # Maintainer: QueryaHub <https://github.com/QueryaHub/Querya-Desktop>
 # AUR package — installs the official Release portable Linux zip under /opt.
-# Bump pkgver/pkgrel when a new GitHub Release is published.
+# pkgver is synced by version-bump.yml; CI publishes real sha256sums on Release.
 pkgname=querya-desktop
-pkgver=0.4.11-b
+pkgver=0.4.12
 pkgrel=1
 pkgdesc="Multi-database desktop client (PostgreSQL, MySQL, Redis, MongoDB, SQLite)"
 arch=('x86_64')
@@ -15,8 +15,9 @@ optdepends=(
 source=(
   "Querya-Desktop-${pkgver}-linux.zip::https://github.com/QueryaHub/Querya-Desktop/releases/download/${pkgver}/Querya-Desktop-${pkgver}-linux.zip"
   "querya_desktop.desktop"
+  "querya_desktop.png"
 )
-sha256sums=('SKIP' 'SKIP')
+sha256sums=('SKIP' 'SKIP' 'SKIP')
 
 prepare() {
   bsdtar -xf "$srcdir/Querya-Desktop-${pkgver}-linux.zip" -C "$srcdir"

--- a/packaging/linux/aur/README.md
+++ b/packaging/linux/aur/README.md
@@ -1,19 +1,38 @@
 # Arch Linux (AUR)
 
-Community packaging for Arch-based distros. The PKGBUILD installs the official
-**portable Linux zip** from GitHub Releases under `/opt/querya-desktop`.
+Official **`querya-desktop`** package on AUR. Installs the Release portable Linux zip
+under `/opt/querya-desktop`.
 
-## Before publishing to AUR
+## Install
 
-1. Copy `PKGBUILD`, `querya_desktop.desktop`, and `querya_desktop.png` into a clean build directory.
-2. Bump `pkgver` / `pkgrel` to match the GitHub Release tag and AUR revision.
-3. Run `makepkg -si` locally and smoke-launch `querya_desktop`.
-4. Generate `.SRCINFO`: `makepkg --printsrcinfo > .SRCINFO`
-5. Push to your AUR repo (e.g. `querya-desktop`).
+```bash
+yay -S querya-desktop
+# or: paru -S querya-desktop
+```
 
-`querya_desktop.desktop` and the 512×512 icon are the same assets used by
-`.deb` / `.rpm` packaging (`packaging/linux/querya_desktop.desktop` and
-`macos/Runner/Assets.xcassets/.../app_icon_512.png`).
+## CI publish
+
+| Trigger | Workflow |
+|---------|----------|
+| After GitHub Release | [Release](../../.github/workflows/release.yml) → job `publish-aur` |
+| Manual hotfix | [Publish AUR](../../.github/workflows/aur-publish.yml) |
+
+Requires repository secret **`AUR_SSH_PRIVATE_KEY`**. Without it, Release skips AUR
+(no failed job). First `git push` creates the AUR repo automatically.
+
+`pkgver` in the template PKGBUILD is synced on merge to `main` by
+[version-bump.yml](../../.github/workflows/version-bump.yml); CI fills real
+`sha256sums` and `.SRCINFO` at publish time via
+[scripts/linux/aur_publish.sh](../../scripts/linux/aur_publish.sh).
+
+## Local smoke test
+
+```bash
+cp packaging/linux/aur/{PKGBUILD,querya_desktop.desktop,querya_desktop.png} /tmp/querya-aur/
+cd /tmp/querya-aur
+makepkg -si
+querya_desktop
+```
 
 ## Updates
 

--- a/scripts/linux/aur_publish.sh
+++ b/scripts/linux/aur_publish.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Push querya-desktop PKGBUILD to AUR (used by Release CI and aur-publish workflow).
+#
+# Prerequisites: ssh-agent loaded with AUR key; docker available for makepkg --printsrcinfo.
+#
+# Usage:
+#   aur_publish.sh <version> [release_tag]
+#
+# release_tag — GitHub Release tag (tries release_tag, version, vversion for asset URL).
+set -euo pipefail
+
+VERSION="${1:?version required}"
+RELEASE_TAG="${2:-$VERSION}"
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEMPLATE="$ROOT/packaging/linux/aur"
+AUR_REPO="${AUR_REPO:-querya-desktop}"
+WORK="$ROOT/aur-repo"
+ZIP="Querya-Desktop-${VERSION}-linux.zip"
+REPO="${GITHUB_REPOSITORY:-QueryaHub/Querya-Desktop}"
+
+download_release_zip() {
+  local tag url
+  for tag in "$RELEASE_TAG" "$VERSION" "v${VERSION}"; do
+    url="https://github.com/${REPO}/releases/download/${tag}/${ZIP}"
+    echo "Fetching ${url}"
+    if curl -fsSL -o "$ZIP" "$url"; then
+      echo "Downloaded from tag ${tag}"
+      return 0
+    fi
+    echo "retry with next tag candidate..."
+    sleep 5
+  done
+  return 1
+}
+
+echo "AUR publish: pkgver=${VERSION} release_tag=${RELEASE_TAG}"
+
+cd "$ROOT"
+for attempt in 1 2 3 4 5 6; do
+  if download_release_zip; then
+    break
+  fi
+  if [ "$attempt" -eq 6 ]; then
+    echo "error: could not download ${ZIP}" >&2
+    exit 1
+  fi
+  echo "retry ${attempt}..."
+  sleep 10
+done
+
+ZIP_SHA="$(sha256sum "$ZIP" | awk '{print $1}')"
+DESKTOP_SHA="$(sha256sum "$TEMPLATE/querya_desktop.desktop" | awk '{print $1}')"
+PNG_SHA="$(sha256sum "$TEMPLATE/querya_desktop.png" | awk '{print $1}')"
+
+mkdir -p ~/.ssh
+ssh-keyscan -t rsa,ecdsa,ed25519 aur.archlinux.org >> ~/.ssh/known_hosts 2>/dev/null
+
+rm -rf "$WORK"
+if ! git clone "ssh://aur@aur.archlinux.org/${AUR_REPO}.git" "$WORK" 2>/dev/null; then
+  mkdir -p "$WORK"
+  git -C "$WORK" init
+  git -C "$WORK" remote add origin "ssh://aur@aur.archlinux.org/${AUR_REPO}.git"
+fi
+
+cp "$TEMPLATE/PKGBUILD" "$WORK/PKGBUILD"
+cp "$TEMPLATE/querya_desktop.desktop" "$WORK/querya_desktop.desktop"
+cp "$TEMPLATE/querya_desktop.png" "$WORK/querya_desktop.png"
+
+cd "$WORK"
+sed -i "s/^pkgver=.*/pkgver=${VERSION}/" PKGBUILD
+sed -i "s/^pkgrel=.*/pkgrel=1/" PKGBUILD
+sed -i "s/^sha256sums=.*/sha256sums=('${ZIP_SHA}' '${DESKTOP_SHA}' '${PNG_SHA}')/" PKGBUILD
+
+out="$WORK/.SRCINFO"
+docker run --rm \
+  -v "$WORK:/pkg" \
+  archlinux:latest \
+  bash -lc '
+    set -euo pipefail
+    pacman -Syu --noconfirm --needed archlinux-keyring pacman base-devel >/dev/null 2>&1
+    useradd -m -s /bin/bash builduser
+    chown -R builduser:builduser /pkg
+    runuser -u builduser -- env HOME=/home/builduser bash -lc "cd /pkg && makepkg --printsrcinfo"
+  ' > "$out"
+sudo chown -R "$(id -u):$(id -g)" "$WORK" 2>/dev/null || true
+test -s "$out"
+grep -qE "^pkgbase[[:space:]]*=" "$out" || { echo "::error::Invalid .SRCINFO"; head -50 "$out"; exit 1; }
+
+git config user.email "github-actions[bot]@users.noreply.github.com"
+git config user.name "github-actions[bot]"
+git add PKGBUILD .SRCINFO querya_desktop.desktop querya_desktop.png
+if git diff --cached --quiet; then
+  echo "No changes to commit"
+  exit 0
+fi
+git commit -m "chore: ${VERSION}"
+git push origin HEAD:master
+
+echo "AUR ${AUR_REPO} updated to ${VERSION}"


### PR DESCRIPTION
Add aur-publish workflow, publish-aur job in Release, PKGBUILD sync in version-bump, and scripts/linux/aur_publish.sh for push + .SRCINFO generation.

## Summary

<!-- What changed and why (1–3 sentences). -->

## Linked issue

<!-- Use branch `issue/<number>-<slug>` and/or: -->

Closes #

## Checklist

- [x] `flutter analyze` and `flutter test` pass locally
- [x] Scope matches the linked issue only (no drive-by refactors)
- [x] PR targets **`dev`** (not `main`, unless hotfix)

## Metadata (automation)

If the branch is `issue/<n>-…` or the body contains `Closes #n`, workflow **[PR linked issue metadata](.github/workflows/pr-linked-issue-metadata.yml)** copies **labels** and **milestone** from the linked issue onto this PR.

For **Theme system** work, ensure the issue has milestone **Theme system** and labels such as `theme`, `editor`, `enhancement`.

Manual override when creating the PR:

```bash
gh pr create --base dev \
  --milestone "Theme system" \
  --label "theme,enhancement" \
  --title "feat(theme): short description (#NN)" \
  --body "$(cat <<'EOF'
## Summary
...

Closes #NN
EOF
)"
```
