### PR TITLE
fix(macos): hide duplicate bitsdojo window buttons in title bar

### DIFF
--- a/lib/features/main_screen/querya_window_title_bar.dart
+++ b/lib/features/main_screen/querya_window_title_bar.dart
@@ -68,6 +68,10 @@ class QueryaWindowTitleBar extends StatelessWidget {
     return scale(isMacOS ? 72 : 16);
   }
 
+  /// Bitsdojo chrome buttons duplicate system traffic lights on macOS.
+  @visibleForTesting
+  static bool showBitsdojoWindowButtons({required bool isMacOS}) => !isMacOS;
+
   @visibleForTesting
   static WindowButtonColors closeButtonColors(BuildContext context) {
     final wb = context.workbench;
@@ -278,9 +282,13 @@ class QueryaWindowTitleBar extends StatelessWidget {
                 if (activeConnection != null && isReadOnly)
                   const QueryaReadOnlyBadge(),
                 UpdateAvailableBadge(controller: UpdateController.instance),
-                MinimizeWindowButton(colors: buttonColors),
-                MaximizeWindowButton(colors: buttonColors),
-                CloseWindowButton(colors: closeButtonColors),
+                if (QueryaWindowTitleBar.showBitsdojoWindowButtons(
+                  isMacOS: Platform.isMacOS,
+                )) ...[
+                  MinimizeWindowButton(colors: buttonColors),
+                  MaximizeWindowButton(colors: buttonColors),
+                  CloseWindowButton(colors: closeButtonColors),
+                ],
               ],
             )
           ],

--- a/test/features/main_screen/querya_window_title_bar_test.dart
+++ b/test/features/main_screen/querya_window_title_bar_test.dart
@@ -115,6 +115,17 @@ void main() {
     );
   });
 
+  test('bitsdojo window buttons hidden on macOS, shown elsewhere', () {
+    expect(
+      QueryaWindowTitleBar.showBitsdojoWindowButtons(isMacOS: true),
+      isFalse,
+    );
+    expect(
+      QueryaWindowTitleBar.showBitsdojoWindowButtons(isMacOS: false),
+      isTrue,
+    );
+  });
+
   testWidgets('read-only state is persistently visible in title bar',
       (tester) async {
     await tester.pumpWidget(


### PR DESCRIPTION
## Summary
- Skip bitsdojo Minimize/Maximize/Close on macOS so they do not duplicate system traffic lights
- Keep the existing leading inset for traffic-light clearance; Windows/Linux unchanged

Closes #500

## Test plan
- [ ] macOS: only system traffic lights in the title bar (no second button strip)
- [ ] Windows/Linux: Minimize / Maximize / Close still present
- [ ] Badges (read-only, updates) still appear on the right on all platforms
- [ ] `flutter test test/features/main_screen/querya_window_title_bar_test.dart`