### PR TITLE
ui(connections): migrate connection forms to QueryaDialogCard (#520)

### DIFF
--- a/lib/features/connections/extension_connection_form.dart
+++ b/lib/features/connections/extension_connection_form.dart
@@ -190,27 +190,20 @@ class _ExtensionConnectionFormContentState
   @override
   material.Widget build(material.BuildContext context) {
     final theme = Theme.of(context).colorScheme;
-    final radius = Theme.of(context).radiusXxl;
     final title = _isEditing
         ? 'Edit ${widget.driver.displayName}'
         : widget.driver.displayName;
-    return material.Container(
+    return QueryaDialogCard(
       constraints: WindowLayout.dialogConstraints(
         context,
         maxWidth: WindowLayout.connectionFormMaxWidth,
         minWidth: 440,
       ),
-      decoration: material.BoxDecoration(
-        color: theme.popover,
-        borderRadius: material.BorderRadius.circular(radius),
-        border: material.Border.all(color: theme.muted),
-      ),
-      child: material.ClipRRect(
-        borderRadius: material.BorderRadius.circular(radius),
-        child: material.Column(
-          mainAxisSize: material.MainAxisSize.min,
-          crossAxisAlignment: material.CrossAxisAlignment.stretch,
-          children: [
+      borderColor: theme.muted,
+      child: material.Column(
+        mainAxisSize: material.MainAxisSize.min,
+        crossAxisAlignment: material.CrossAxisAlignment.stretch,
+        children: [
             material.Padding(
               padding: const material.EdgeInsets.fromLTRB(24, 24, 24, 8),
               child: material.Column(
@@ -315,7 +308,6 @@ class _ExtensionConnectionFormContentState
             ),
           ],
         ),
-      ),
     );
   }
 }

--- a/lib/features/connections/sqlite_connection_form.dart
+++ b/lib/features/connections/sqlite_connection_form.dart
@@ -174,21 +174,14 @@ class _SqliteConnectionFormContentState
     final dialogH = WindowLayout.newConnectionDialogHeight(context);
     final scrollH = dialogH - 120.0; // Subtract header and footer heights
 
-    return material.Container(
+    return material.SizedBox(
       width: dialogMaxW,
-      constraints: material.BoxConstraints(
-        maxWidth: dialogMaxW,
-        maxHeight: dialogH,
-      ),
-      decoration: material.BoxDecoration(
-        color: theme.popover,
-        borderRadius:
-            material.BorderRadius.circular(Theme.of(context).radiusXxl),
-        border: material.Border.all(color: theme.muted),
-      ),
-      child: material.ClipRRect(
-        borderRadius:
-            material.BorderRadius.circular(Theme.of(context).radiusXxl),
+      child: QueryaDialogCard(
+        constraints: material.BoxConstraints(
+          maxWidth: dialogMaxW,
+          maxHeight: dialogH,
+        ),
+        borderColor: theme.muted,
         child: material.Column(
           mainAxisSize: material.MainAxisSize.min,
           crossAxisAlignment: material.CrossAxisAlignment.stretch,

--- a/lib/features/mongodb/mongodb_connection_form.dart
+++ b/lib/features/mongodb/mongodb_connection_form.dart
@@ -330,24 +330,17 @@ class _MongoConnectionFormContentState
   @override
   material.Widget build(material.BuildContext context) {
     final theme = Theme.of(context).colorScheme;
-    final radius = Theme.of(context).radiusXxl;
 
-    return material.Container(
+    return QueryaDialogCard(
       constraints: WindowLayout.dialogConstraints(
         context,
         maxWidth: WindowLayout.connectionFormMaxWidth,
         maxHeight: WindowLayout.connectionFormMongoMaxHeight,
       ),
-      decoration: material.BoxDecoration(
-        color: theme.popover,
-        borderRadius: material.BorderRadius.circular(radius),
-        border: material.Border.all(color: theme.muted),
-      ),
-      child: material.ClipRRect(
-        borderRadius: material.BorderRadius.circular(radius),
-        child: material.Column(
-          crossAxisAlignment: material.CrossAxisAlignment.stretch,
-          children: [
+      borderColor: theme.muted,
+      child: material.Column(
+        crossAxisAlignment: material.CrossAxisAlignment.stretch,
+        children: [
             material.Padding(
               padding: const material.EdgeInsets.fromLTRB(24, 24, 24, 16),
               child: Column(
@@ -706,7 +699,6 @@ class _MongoConnectionFormContentState
             ),
           ],
         ),
-      ),
     );
   }
 }

--- a/lib/features/mysql/mysql_connection_form.dart
+++ b/lib/features/mysql/mysql_connection_form.dart
@@ -295,24 +295,17 @@ class _MysqlConnectionFormContentState
   @override
   material.Widget build(material.BuildContext context) {
     final theme = Theme.of(context).colorScheme;
-    final radius = Theme.of(context).radiusXxl;
 
-    return material.Container(
+    return QueryaDialogCard(
       constraints: WindowLayout.dialogConstraints(
         context,
         maxWidth: WindowLayout.connectionFormMaxWidth,
         maxHeight: WindowLayout.connectionFormMaxHeight,
       ),
-      decoration: material.BoxDecoration(
-        color: theme.popover,
-        borderRadius: material.BorderRadius.circular(radius),
-        border: material.Border.all(color: theme.muted),
-      ),
-      child: material.ClipRRect(
-        borderRadius: material.BorderRadius.circular(radius),
-        child: material.Column(
-          crossAxisAlignment: material.CrossAxisAlignment.stretch,
-          children: [
+      borderColor: theme.muted,
+      child: material.Column(
+        crossAxisAlignment: material.CrossAxisAlignment.stretch,
+        children: [
             material.Padding(
               padding: const material.EdgeInsets.fromLTRB(24, 24, 24, 16),
               child: material.Column(
@@ -619,7 +612,6 @@ class _MysqlConnectionFormContentState
             ),
           ],
         ),
-      ),
     );
   }
 }

--- a/lib/features/postgresql/postgresql_connection_form.dart
+++ b/lib/features/postgresql/postgresql_connection_form.dart
@@ -412,24 +412,17 @@ class _PostgresConnectionFormContentState
   @override
   material.Widget build(material.BuildContext context) {
     final theme = Theme.of(context).colorScheme;
-    final radius = Theme.of(context).radiusXxl;
 
-    return material.Container(
+    return QueryaDialogCard(
       constraints: WindowLayout.dialogConstraints(
         context,
         maxWidth: WindowLayout.connectionFormMaxWidth,
         maxHeight: WindowLayout.connectionFormMaxHeight,
       ),
-      decoration: material.BoxDecoration(
-        color: theme.popover,
-        borderRadius: material.BorderRadius.circular(radius),
-        border: material.Border.all(color: theme.muted),
-      ),
-      child: material.ClipRRect(
-        borderRadius: material.BorderRadius.circular(radius),
-        child: material.Column(
-          crossAxisAlignment: material.CrossAxisAlignment.stretch,
-          children: [
+      borderColor: theme.muted,
+      child: material.Column(
+        crossAxisAlignment: material.CrossAxisAlignment.stretch,
+        children: [
             // Header
             material.Padding(
               padding: const material.EdgeInsets.fromLTRB(24, 24, 24, 16),
@@ -765,7 +758,6 @@ class _PostgresConnectionFormContentState
             ),
           ],
         ),
-      ),
     );
   }
 }

--- a/lib/features/redis/redis_connection_form.dart
+++ b/lib/features/redis/redis_connection_form.dart
@@ -269,24 +269,17 @@ class _RedisConnectionFormContentState
   @override
   material.Widget build(material.BuildContext context) {
     final theme = Theme.of(context).colorScheme;
-    final radius = Theme.of(context).radiusXxl;
 
-    return material.Container(
+    return QueryaDialogCard(
       constraints: WindowLayout.dialogConstraints(
         context,
         maxWidth: WindowLayout.connectionFormMaxWidth,
         maxHeight: WindowLayout.connectionFormMaxHeight,
       ),
-      decoration: material.BoxDecoration(
-        color: theme.popover,
-        borderRadius: material.BorderRadius.circular(radius),
-        border: material.Border.all(color: theme.muted),
-      ),
-      child: material.ClipRRect(
-        borderRadius: material.BorderRadius.circular(radius),
-        child: material.Column(
-          crossAxisAlignment: material.CrossAxisAlignment.stretch,
-          children: [
+      borderColor: theme.muted,
+      child: material.Column(
+        crossAxisAlignment: material.CrossAxisAlignment.stretch,
+        children: [
             material.Padding(
               padding: const material.EdgeInsets.fromLTRB(24, 24, 24, 16),
               child: material.Column(
@@ -563,7 +556,6 @@ class _RedisConnectionFormContentState
             ),
           ],
         ),
-      ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- Migrate PG / MySQL / Mongo / Redis / SQLite / extension connection form shells to `QueryaDialogCard`
- Keep existing constraints and muted border; drop raw `Container` + `ClipRRect` popover chrome

Closes #520

## Test plan
- [ ] Open create + edit for each built-in driver and an extension driver — layout/chrome match other dialogs
- [ ] Save / Cancel / Test still work
- [ ] No text bloat / overflow in dense forms
- [ ] `flutter test test/features/postgresql/postgresql_connection_form_test.dart`