### PR TITLE
fix(sandbox): prevent false-positive SIGKILL in SandboxWatchdog during heavy RPC

### DIFF
--- a/lib/core/extensions/rpc/json_rpc_stdio_client.dart
+++ b/lib/core/extensions/rpc/json_rpc_stdio_client.dart
@@ -41,6 +41,12 @@ class JsonRpcStdioClient {
   StreamSubscription<String>? _subscription;
   Object? _fatalError;
 
+  /// Number of RPC requests currently in-flight waiting for a response.
+  int get pendingRequestCount => _pending.length;
+
+  /// Returns true when there is at least one active RPC request in-flight.
+  bool get hasPendingRequests => _pending.isNotEmpty;
+
   /// Serializes async line handling so large-line isolate decode stays ordered.
   Future<void> _lineChain = Future<void>.value();
 

--- a/lib/core/extensions/rpc/plugin_rpc_bridge.dart
+++ b/lib/core/extensions/rpc/plugin_rpc_bridge.dart
@@ -117,6 +117,7 @@ class PluginRpcBridge {
     if (enableWatchdog) {
       _watchdog = SandboxWatchdog(
         recovery: _recovery,
+        isBusy: () => client.hasPendingRequests,
         onStopped: (reason) {
           if (reason == SandboxWatchdogStopReason.deadlock) {
             unawaited(_audit?.record(

--- a/lib/core/extensions/sandbox/sandbox_watchdog.dart
+++ b/lib/core/extensions/sandbox/sandbox_watchdog.dart
@@ -25,16 +25,19 @@ enum SandboxWatchdogStopReason {
 class SandboxWatchdog {
   SandboxWatchdog({
     this.pingInterval = const Duration(seconds: 30),
-    this.pongTimeout = const Duration(seconds: 5),
+    this.pongTimeout = const Duration(seconds: 15),
     this.recovery,
+    bool Function()? isBusy,
     Future<Object?> Function()? ping,
     void Function(SandboxWatchdogStopReason reason)? onStopped,
-  })  : _pingOverride = ping,
+  })  : _isBusy = isBusy,
+        _pingOverride = ping,
         _onStopped = onStopped;
 
   final Duration pingInterval;
   final Duration pongTimeout;
   final SandboxAutoRecovery? recovery;
+  final bool Function()? _isBusy;
   final Future<Object?> Function()? _pingOverride;
   final void Function(SandboxWatchdogStopReason reason)? _onStopped;
 
@@ -107,6 +110,7 @@ class SandboxWatchdog {
 
   Future<void> _tick() async {
     if (!_running || _pingInFlight) return;
+    if (_isBusy?.call() ?? false) return;
     _pingInFlight = true;
     try {
       final result = await _sendPing().timeout(pongTimeout);

--- a/test/core/extensions/sandbox/sandbox_watchdog_test.dart
+++ b/test/core/extensions/sandbox/sandbox_watchdog_test.dart
@@ -254,6 +254,34 @@ void main() {
       await client.close();
       await handle.dispose();
     });
+
+    test('skips ping tick when isBusy returns true', () async {
+      final process = _FakeProcess();
+      final handle = await _handle(process, tempBase);
+      var pings = 0;
+      var busy = true;
+
+      final watchdog = SandboxWatchdog(
+        pingInterval: const Duration(milliseconds: 15),
+        pongTimeout: const Duration(seconds: 1),
+        isBusy: () => busy,
+        ping: () async {
+          pings++;
+          return 'pong';
+        },
+      );
+
+      watchdog.start(handle);
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(pings, 0, reason: 'Pings should be skipped while busy');
+
+      busy = false;
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(pings, greaterThan(0), reason: 'Pings should resume when idle');
+
+      watchdog.stop();
+      await handle.dispose();
+    });
   });
 
   group('SandboxWatchdog.isPong', () {


### PR DESCRIPTION
Closes #526

## Summary of Changes
- Added `hasPendingRequests` and `pendingRequestCount` to `JsonRpcStdioClient`.
- Added `isBusy` callback capability to `SandboxWatchdog`, skipping heartbeats when the plugin is busy executing RPC requests.
- Passed `isBusy: () => client.hasPendingRequests` from `PluginRpcBridge` into `SandboxWatchdog`.
- Increased default `pongTimeout` from 5s to 15s.
- Added unit tests for `isBusy` handling in `test/core/extensions/sandbox/sandbox_watchdog_test.dart`.

## Verification
- `flutter test test/core/extensions/sandbox/sandbox_watchdog_test.dart` passed (10/10 tests).