### PR TITLE
Perf: Replace `.length > 0` with `.isNotEmpty` on iterables

### DIFF
--- a/lib/core/extensions/rpc/json_rpc_payload_limits.dart
+++ b/lib/core/extensions/rpc/json_rpc_payload_limits.dart
@@ -91,7 +91,7 @@ class _BoundedUtf8LineSplitter
       },
       onError: fail,
       onDone: () {
-        if (pending.length > 0) {
+        if (pending.isNotEmpty) {
           if (pending.length > maxLineBytes) {
             fail(
               JsonRpcPayloadTooLargeException(


### PR DESCRIPTION
Resolves #533