### PR TITLE
feat(data-grid): integrate TableMutationPlan generator with staging buffer (#564)

### DIFF
--- a/lib/features/main_screen/data_grid_staging_buffer.dart
+++ b/lib/features/main_screen/data_grid_staging_buffer.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart';
+import 'package:querya_desktop/core/database/table_mutation_engine.dart';
 
 /// Status of a row within the staging buffer.
 enum StagedRowStatus {
@@ -231,6 +232,37 @@ class DataGridStagingBuffer extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// Read-only snapshot of modified cells mapping.
+  Map<int, Map<int, String>> get modifiedCells =>
+      Map.unmodifiable(_modifiedCells.map((k, v) => MapEntry(k, Map.unmodifiable(v))));
+
+  /// Read-only list of newly inserted rows.
+  List<List<String>> get insertedRows =>
+      List.unmodifiable(_insertedRows.map((r) => List<String>.unmodifiable(r)));
+
+  /// Read-only set of deleted row indices.
+  Set<int> get deletedRowIndices => Set.unmodifiable(_deletedRowIndices);
+
+  /// Generates an atomic [TableMutationPlan] for the current staged changes.
+  TableMutationPlan generateMutationPlan({
+    required SqlDialect dialect,
+    required String tableName,
+    String? schema,
+    List<String> primaryKeys = const [],
+  }) {
+    return TableMutationEngine.generatePlan(
+      dialect: dialect,
+      tableName: tableName,
+      schema: schema,
+      columns: _originalColumns,
+      primaryKeys: primaryKeys,
+      originalRows: _originalRows,
+      modifiedCells: _modifiedCells,
+      insertedRows: _insertedRows,
+      deletedRowIndices: _deletedRowIndices,
+    );
+  }
+
   /// Returns the full list of effective rows (original with modifications applied + inserted rows).
   List<List<String>> get effectiveRows {
     final result = <List<String>>[];
@@ -252,3 +284,4 @@ class DataGridStagingBuffer extends ChangeNotifier {
     return result;
   }
 }
+

--- a/test/features/main_screen/data_grid_staging_buffer_test.dart
+++ b/test/features/main_screen/data_grid_staging_buffer_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:querya_desktop/core/database/table_mutation_engine.dart';
 import 'package:querya_desktop/features/main_screen/data_grid_staging_buffer.dart';
 
 void main() {
@@ -118,6 +119,27 @@ void main() {
       expect(eff[1], ['2', 'Bob', 'bob@test.com']);
       expect(eff[2], ['3', 'Charlie', 'charlie@test.com']);
       expect(eff[3], ['4', 'David', 'david@test.com']);
+    });
+
+    test('generateMutationPlan builds correct DML statements from staged modifications', () {
+      buffer.setCell(0, 1, 'Alice Updated');
+      buffer.addRow(['4', 'Diana', 'diana@test.com']);
+      buffer.toggleDeleteRow(2);
+
+      final plan = buffer.generateMutationPlan(
+        dialect: SqlDialect.postgres,
+        tableName: 'users',
+        schema: 'public',
+        primaryKeys: ['id'],
+      );
+
+      expect(plan.statementCount, 3);
+      expect(plan.statements[0].type, MutationType.update);
+      expect(plan.statements[0].sql, 'UPDATE "public"."users" SET "name" = \'Alice Updated\' WHERE "id" = 1');
+      expect(plan.statements[1].type, MutationType.insert);
+      expect(plan.statements[1].sql, 'INSERT INTO "public"."users" ("id", "name", "email") VALUES (4, \'Diana\', \'diana@test.com\')');
+      expect(plan.statements[2].type, MutationType.delete);
+      expect(plan.statements[2].sql, 'DELETE FROM "public"."users" WHERE "id" = 3');
     });
   });
 }


### PR DESCRIPTION
### Summary

Connects `DataGridStagingBuffer` with `TableMutationEngine` to allow generating atomic SQL DML mutation plans (`UPDATE`, `INSERT`, `DELETE`) per dialect (Postgres, MySQL, SQLite) directly from in-memory staged changes.

Closes #564

### Verification
- `flutter analyze lib/features/main_screen/ lib/core/database/` passes with 0 issues.
- `flutter test test/features/main_screen/data_grid_staging_buffer_test.dart test/core/database/table_mutation_engine_test.dart` passes all 15 unit tests.