### PR TITLE
feat(filter): support LIKE, ILIKE, IN, IS NULL, BETWEEN, and escaped quotes in filter engine (#569)

### DIFF
--- a/lib/features/main_screen/grid_filter_engine.dart
+++ b/lib/features/main_screen/grid_filter_engine.dart
@@ -1,7 +1,8 @@
 /// Client-side filter engine for Data Grid.
 ///
 /// Evaluates complex multi-clause expressions with AND / OR / NOT, parentheses,
-/// column predicates (`col = val`, `col > 10`), and free-text substring search.
+/// column predicates (`col = val`, `col > 10`, `col LIKE '%test%'`, `col IN ('a', 'b')`,
+/// `col IS NULL`, `col BETWEEN x AND y`), and free-text substring search.
 abstract final class GridFilterEngine {
   /// Evaluates [filterText] against [rows] with respect to [columns].
   /// Returns the list of matching row indices.
@@ -121,16 +122,74 @@ class _PredicateNode extends _FilterAstNode {
     required this.colIndex,
     required this.op,
     required this.targetValue,
+    this.inValues = const [],
+    this.betweenMin,
+    this.betweenMax,
   });
 
   final int colIndex;
   final String op;
   final String targetValue;
+  final List<String> inValues;
+  final String? betweenMin;
+  final String? betweenMax;
 
   @override
   bool evaluate(List<String> row, List<String> lowerColumns) {
     if (colIndex < 0 || colIndex >= row.length) return false;
     final cellValue = row[colIndex];
+    final isNull = cellValue == 'NULL' || cellValue == 'null' || cellValue.isEmpty;
+    final upperOp = op.toUpperCase().trim();
+
+    // IS NULL / IS NOT NULL
+    if (upperOp == 'IS NULL') {
+      return isNull;
+    }
+    if (upperOp == 'IS NOT NULL') {
+      return !isNull;
+    }
+
+    // IN / NOT IN
+    if (upperOp == 'IN') {
+      final lowerCell = cellValue.toLowerCase().trim();
+      return inValues.any((v) => v.toLowerCase().trim() == lowerCell);
+    }
+    if (upperOp == 'NOT IN') {
+      final lowerCell = cellValue.toLowerCase().trim();
+      return !inValues.any((v) => v.toLowerCase().trim() == lowerCell);
+    }
+
+    // BETWEEN x AND y
+    if (upperOp == 'BETWEEN' && betweenMin != null && betweenMax != null) {
+      final numCell = double.tryParse(cellValue.trim());
+      final numMin = double.tryParse(betweenMin!.trim());
+      final numMax = double.tryParse(betweenMax!.trim());
+      if (numCell != null && numMin != null && numMax != null) {
+        return numCell >= numMin && numCell <= numMax;
+      }
+      return cellValue.compareTo(betweenMin!) >= 0 && cellValue.compareTo(betweenMax!) <= 0;
+    }
+
+    // LIKE / NOT LIKE
+    if (upperOp == 'LIKE') {
+      final regex = _likeToRegExp(targetValue, caseSensitive: true);
+      return regex.hasMatch(cellValue);
+    }
+    if (upperOp == 'NOT LIKE') {
+      final regex = _likeToRegExp(targetValue, caseSensitive: true);
+      return !regex.hasMatch(cellValue);
+    }
+
+    // ILIKE / NOT ILIKE
+    if (upperOp == 'ILIKE') {
+      final regex = _likeToRegExp(targetValue, caseSensitive: false);
+      return regex.hasMatch(cellValue);
+    }
+    if (upperOp == 'NOT ILIKE') {
+      final regex = _likeToRegExp(targetValue, caseSensitive: false);
+      return !regex.hasMatch(cellValue);
+    }
+
     final lowerCell = cellValue.toLowerCase();
     final lowerTarget = targetValue.toLowerCase();
 
@@ -179,6 +238,22 @@ class _PredicateNode extends _FilterAstNode {
       default:
         return lowerCell.contains(lowerTarget);
     }
+  }
+
+  static RegExp _likeToRegExp(String pattern, {required bool caseSensitive}) {
+    final buffer = StringBuffer('^');
+    for (var i = 0; i < pattern.length; i++) {
+      final char = pattern[i];
+      if (char == '%') {
+        buffer.write('.*');
+      } else if (char == '_') {
+        buffer.write('.');
+      } else {
+        buffer.write(RegExp.escape(char));
+      }
+    }
+    buffer.write(r'$');
+    return RegExp(buffer.toString(), caseSensitive: caseSensitive);
   }
 }
 
@@ -231,6 +306,15 @@ abstract final class _FilterLexer {
         continue;
       }
 
+      // Check for extended predicates with keywords (IS NULL, IS NOT NULL, LIKE, ILIKE, IN, BETWEEN)
+      final remaining = input.substring(i);
+      final kwPredicate = _tryMatchKeywordPredicate(remaining, lowerColumns);
+      if (kwPredicate != null) {
+        tokens.add(_FilterToken(_TokenType.predicate, predicate: kwPredicate.node));
+        i += kwPredicate.consumedChars;
+        continue;
+      }
+
       // Parentheses
       if (input[i] == '(') {
         tokens.add(const _FilterToken(_TokenType.lparen, value: '('));
@@ -253,14 +337,21 @@ abstract final class _FilterLexer {
         if (input[i] == '\'' || input[i] == '"') {
           final quote = input[i];
           i++;
-          while (i < input.length && input[i] != quote) {
+          while (i < input.length) {
             if (input[i] == '\\' && i + 1 < input.length) {
               i += 2;
+            } else if (input[i] == quote) {
+              if (i + 1 < input.length && input[i + 1] == quote) {
+                // SQL-style doubled quote escape: ''
+                i += 2;
+              } else {
+                i++; // closing quote
+                break;
+              }
             } else {
               i++;
             }
           }
-          if (i < input.length) i++; // consume closing quote
         } else {
           i++;
         }
@@ -292,13 +383,11 @@ abstract final class _FilterLexer {
       }
 
       // If word is just a column name and the NEXT word is an operator (e.g. "amount", ">", "100")
-      // or "status", "=", "'ACTIVE'"
       final colIdx = lowerColumns.indexOf(word.toLowerCase());
       if (colIdx != -1) {
-        // Peek ahead for operator and value
-        final remaining = input.substring(i).trimLeft();
+        final rem = input.substring(i).trimLeft();
         final opMatch = RegExp(r'^(>=|<=|!=|<>|==|=|>|<|:)\s*([^\s()]+)')
-            .firstMatch(remaining);
+            .firstMatch(rem);
         if (opMatch != null) {
           final op = opMatch.group(1)!;
           var val = opMatch.group(2)!;
@@ -319,12 +408,107 @@ abstract final class _FilterLexer {
         }
       }
 
-      // Strip quotes from free text if present
       word = _stripQuotes(word);
       tokens.add(_FilterToken(_TokenType.text, value: word));
     }
 
     return tokens;
+  }
+
+  static ({_PredicateNode node, int consumedChars})? _tryMatchKeywordPredicate(
+    String remaining,
+    List<String> lowerColumns,
+  ) {
+    // 1. IS NULL / IS NOT NULL (e.g. "status IS NULL", "email IS NOT NULL")
+    final isNullMatch = RegExp(r'^([a-zA-Z_]\w*)\s+IS\s+(NOT\s+)?NULL\b', caseSensitive: false)
+        .firstMatch(remaining);
+    if (isNullMatch != null) {
+      final colName = isNullMatch.group(1)!.toLowerCase();
+      final colIdx = lowerColumns.indexOf(colName);
+      if (colIdx != -1) {
+        final isNot = isNullMatch.group(2) != null;
+        return (
+          node: _PredicateNode(
+            colIndex: colIdx,
+            op: isNot ? 'IS NOT NULL' : 'IS NULL',
+            targetValue: '',
+          ),
+          consumedChars: isNullMatch.group(0)!.length,
+        );
+      }
+    }
+
+    // 2. IN / NOT IN (e.g. "status IN ('ACTIVE', 'PENDING')", "id NOT IN (1, 2, 3)")
+    final inMatch = RegExp(r'^([a-zA-Z_]\w*)\s+(NOT\s+)?IN\s*\(([^)]+)\)', caseSensitive: false)
+        .firstMatch(remaining);
+    if (inMatch != null) {
+      final colName = inMatch.group(1)!.toLowerCase();
+      final colIdx = lowerColumns.indexOf(colName);
+      if (colIdx != -1) {
+        final isNot = inMatch.group(2) != null;
+        final listStr = inMatch.group(3)!;
+        final items = listStr
+            .split(',')
+            .map((s) => _stripQuotes(s.trim()))
+            .where((s) => s.isNotEmpty)
+            .toList();
+        return (
+          node: _PredicateNode(
+            colIndex: colIdx,
+            op: isNot ? 'NOT IN' : 'IN',
+            targetValue: '',
+            inValues: items,
+          ),
+          consumedChars: inMatch.group(0)!.length,
+        );
+      }
+    }
+
+    // 3. BETWEEN x AND y (e.g. "amount BETWEEN 10 AND 100")
+    final betweenMatch = RegExp(r'^([a-zA-Z_]\w*)\s+BETWEEN\s+([^\s]+)\s+AND\s+([^\s()]+)', caseSensitive: false)
+        .firstMatch(remaining);
+    if (betweenMatch != null) {
+      final colName = betweenMatch.group(1)!.toLowerCase();
+      final colIdx = lowerColumns.indexOf(colName);
+      if (colIdx != -1) {
+        final minVal = _stripQuotes(betweenMatch.group(2)!.trim());
+        final maxVal = _stripQuotes(betweenMatch.group(3)!.trim());
+        return (
+          node: _PredicateNode(
+            colIndex: colIdx,
+            op: 'BETWEEN',
+            targetValue: '',
+            betweenMin: minVal,
+            betweenMax: maxVal,
+          ),
+          consumedChars: betweenMatch.group(0)!.length,
+        );
+      }
+    }
+
+    // 4. LIKE / ILIKE / NOT LIKE / NOT ILIKE (e.g. "name LIKE '%John%'", "email ILIKE '%.org'")
+    final likeMatch = RegExp(r'^([a-zA-Z_]\w*)\s+(NOT\s+)?(ILIKE|LIKE)\s+([^\s()]+)', caseSensitive: false)
+        .firstMatch(remaining);
+    if (likeMatch != null) {
+      final colName = likeMatch.group(1)!.toLowerCase();
+      final colIdx = lowerColumns.indexOf(colName);
+      if (colIdx != -1) {
+        final isNot = likeMatch.group(2) != null;
+        final likeType = likeMatch.group(3)!.toUpperCase();
+        final pattern = _stripQuotes(likeMatch.group(4)!.trim());
+        final op = isNot ? 'NOT $likeType' : likeType;
+        return (
+          node: _PredicateNode(
+            colIndex: colIdx,
+            op: op,
+            targetValue: pattern,
+          ),
+          consumedChars: likeMatch.group(0)!.length,
+        );
+      }
+    }
+
+    return null;
   }
 
   static _PredicateNode? _tryExtractPredicate(
@@ -354,7 +538,11 @@ abstract final class _FilterLexer {
     if ((s.startsWith("'") && s.endsWith("'")) ||
         (s.startsWith('"') && s.endsWith('"'))) {
       if (s.length >= 2) {
-        return s.substring(1, s.length - 1).replaceAll(r"\'", "'").replaceAll(r'\"', '"');
+        return s
+            .substring(1, s.length - 1)
+            .replaceAll("''", "'")
+            .replaceAll(r"\'", "'")
+            .replaceAll(r'\"', '"');
       }
     }
     return s;
@@ -396,7 +584,6 @@ class _FilterParser {
   bool _isImplicitAnd() {
     if (_pos >= tokens.length) return false;
     final type = tokens[_pos].type;
-    // Two terms or predicates in a row without explicit OR are treated as implicit AND
     return type == _TokenType.predicate ||
         type == _TokenType.text ||
         type == _TokenType.lparen ||

--- a/test/features/main_screen/data_grid_engines_test.dart
+++ b/test/features/main_screen/data_grid_engines_test.dart
@@ -84,6 +84,81 @@ void main() {
       );
       expect(res, equals([0, 1]));
     });
+
+    test('filters with LIKE and ILIKE wildcards', () {
+      final resLike = GridFilterEngine.filterRowIndices(
+        filterText: "status LIKE 'ACT%'",
+        columns: columns,
+        rows: rows,
+      );
+      expect(resLike, equals([0, 2]));
+
+      final resIlike = GridFilterEngine.filterRowIndices(
+        filterText: "status ILIKE '%pend%'",
+        columns: columns,
+        rows: rows,
+      );
+      expect(resIlike, equals([1]));
+    });
+
+    test('filters with IN and NOT IN list of literals', () {
+      final resIn = GridFilterEngine.filterRowIndices(
+        filterText: "status IN ('PENDING', 'CANCELLED')",
+        columns: columns,
+        rows: rows,
+      );
+      expect(resIn, equals([1, 3]));
+
+      final resNotIn = GridFilterEngine.filterRowIndices(
+        filterText: "status NOT IN ('ACTIVE')",
+        columns: columns,
+        rows: rows,
+      );
+      expect(resNotIn, equals([1, 3]));
+    });
+
+    test('filters with IS NULL and IS NOT NULL', () {
+      final rowsWithNull = [
+        ['1', 'ACTIVE', '100'],
+        ['2', 'NULL', '200'],
+        ['3', '', '300'],
+      ];
+      final resNull = GridFilterEngine.filterRowIndices(
+        filterText: 'status IS NULL',
+        columns: columns,
+        rows: rowsWithNull,
+      );
+      expect(resNull, equals([1, 2]));
+
+      final resNotNull = GridFilterEngine.filterRowIndices(
+        filterText: 'status IS NOT NULL',
+        columns: columns,
+        rows: rowsWithNull,
+      );
+      expect(resNotNull, equals([0]));
+    });
+
+    test('filters with BETWEEN range', () {
+      final res = GridFilterEngine.filterRowIndices(
+        filterText: 'amount BETWEEN 50 AND 200',
+        columns: columns,
+        rows: rows,
+      );
+      expect(res, equals([0, 1]));
+    });
+
+    test('handles escaped quotes inside string literals', () {
+      final rowsWithQuotes = [
+        ['1', "O'Connor", '100'],
+        ['2', 'Smith', '200'],
+      ];
+      final res = GridFilterEngine.filterRowIndices(
+        filterText: "status = 'O''Connor'",
+        columns: columns,
+        rows: rowsWithQuotes,
+      );
+      expect(res, equals([0]));
+    });
   });
 
   group('GridSelectionCalcEngine', () {


### PR DESCRIPTION
### Summary

- Implements extended SQL filter operators in `GridFilterEngine`:
  - `LIKE` and `ILIKE` with `%` and `_` wildcard pattern matching.
  - `IN (...)` and `NOT IN (...)` with comma-separated literal sets.
  - `IS NULL` and `IS NOT NULL` checks.
  - `BETWEEN min AND max` range evaluation.
- Added support for escaped quotes (`''`, `\'`, `\"`) within single and double-quoted string literals.
- Full unit test coverage for all extended operators.

Closes #569

### Verification
- `flutter analyze lib/features/main_screen/` passed with 0 issues.
- `flutter test test/features/main_screen/data_grid_engines_test.dart` passed all 16 tests.