### PR TITLE
perf(grid): optimize sortResultGridRows with precomputed sort keys (#602)

### DIFF
--- a/lib/features/main_screen/result_grid_view.dart
+++ b/lib/features/main_screen/result_grid_view.dart
@@ -287,47 +287,90 @@ enum ResultGridSortOrder {
   descending,
 }
 
+enum _SortKeyType { nullOrEmpty, numeric, dateTime, string }
+
+class _SortKey implements Comparable<_SortKey> {
+  final _SortKeyType type;
+  final num? numVal;
+  final DateTime? dtVal;
+  final String strLower;
+  final String strRaw;
+
+  _SortKey._({
+    required this.type,
+    this.numVal,
+    this.dtVal,
+    this.strLower = '',
+    this.strRaw = '',
+  });
+
+  factory _SortKey.parse(String val) {
+    if (val == 'NULL' || val.isEmpty) {
+      return _SortKey._(type: _SortKeyType.nullOrEmpty);
+    }
+    final n = num.tryParse(val);
+    if (n != null) {
+      return _SortKey._(type: _SortKeyType.numeric, numVal: n, strRaw: val);
+    }
+    final dt = DateTime.tryParse(val);
+    if (dt != null) {
+      return _SortKey._(type: _SortKeyType.dateTime, dtVal: dt, strRaw: val);
+    }
+    return _SortKey._(
+      type: _SortKeyType.string,
+      strLower: val.toLowerCase(),
+      strRaw: val,
+    );
+  }
+
+  @override
+  int compareTo(_SortKey other) {
+    if (type == _SortKeyType.nullOrEmpty && other.type == _SortKeyType.nullOrEmpty) {
+      return 0;
+    }
+    if (type == _SortKeyType.nullOrEmpty) return 1;
+    if (other.type == _SortKeyType.nullOrEmpty) return -1;
+
+    if (type == _SortKeyType.numeric && other.type == _SortKeyType.numeric) {
+      return numVal!.compareTo(other.numVal!);
+    }
+    if (type == _SortKeyType.dateTime && other.type == _SortKeyType.dateTime) {
+      return dtVal!.compareTo(other.dtVal!);
+    }
+
+    final aLower = type == _SortKeyType.string ? strLower : strRaw.toLowerCase();
+    final bLower = other.type == _SortKeyType.string ? other.strLower : other.strRaw.toLowerCase();
+    final cmp = aLower.compareTo(bLower);
+    if (cmp != 0) return cmp;
+
+    return strRaw.compareTo(other.strRaw);
+  }
+}
+
 /// Sorts rows by the specified column index with natural numeric / temporal / lexicographic comparison.
+/// Uses Schwartzian transform (Decorate-Sort-Undecorate) to precompute sort keys in O(N) time.
 List<List<String>> sortResultGridRows({
   required List<List<String>> rows,
   required int columnIndex,
   required ResultGridSortOrder order,
 }) {
   if (rows.isEmpty || columnIndex < 0) return rows;
-  final sorted = List<List<String>>.from(rows);
+  final n = rows.length;
 
-  sorted.sort((a, b) {
-    final valA = columnIndex < a.length ? a[columnIndex] : '';
-    final valB = columnIndex < b.length ? b[columnIndex] : '';
+  final keys = List<_SortKey>.generate(n, (i) {
+    final row = rows[i];
+    final val = columnIndex < row.length ? row[columnIndex] : '';
+    return _SortKey.parse(val);
+  }, growable: false);
 
-    final isNullA = valA == 'NULL' || valA.isEmpty;
-    final isNullB = valB == 'NULL' || valB.isEmpty;
-    if (isNullA && isNullB) return 0;
-    if (isNullA) return 1;
-    if (isNullB) return -1;
+  final indices = List<int>.generate(n, (i) => i, growable: false);
 
-    final numA = num.tryParse(valA);
-    final numB = num.tryParse(valB);
-    int cmp;
-    if (numA != null && numB != null) {
-      cmp = numA.compareTo(numB);
-    } else {
-      final dtA = DateTime.tryParse(valA);
-      final dtB = DateTime.tryParse(valB);
-      if (dtA != null && dtB != null) {
-        cmp = dtA.compareTo(dtB);
-      } else {
-        cmp = valA.toLowerCase().compareTo(valB.toLowerCase());
-        if (cmp == 0) {
-          cmp = valA.compareTo(valB);
-        }
-      }
-    }
-
+  indices.sort((a, b) {
+    final cmp = keys[a].compareTo(keys[b]);
     return order == ResultGridSortOrder.ascending ? cmp : -cmp;
   });
 
-  return sorted;
+  return List<List<String>>.generate(n, (i) => rows[indices[i]], growable: false);
 }
 
 /// Virtualized read-only or interactive grid for SQL query results (rows + columns).

--- a/test/features/main_screen/results_tab_test.dart
+++ b/test/features/main_screen/results_tab_test.dart
@@ -99,6 +99,58 @@ void main() {
       expect(sorted.map((r) => r[0]).toList(), ['Apple', 'banana', 'cherry']);
     });
 
+    test('sorts temporally for ISO-8601 date strings', () {
+      final rows = [
+        ['2026-12-31 23:59:59'],
+        ['2025-01-01 00:00:00'],
+        ['2026-08-26 10:30:00'],
+      ];
+      final sorted = sortResultGridRows(
+        rows: rows,
+        columnIndex: 0,
+        order: ResultGridSortOrder.ascending,
+      );
+      expect(sorted.map((r) => r[0]).toList(), [
+        '2025-01-01 00:00:00',
+        '2026-08-26 10:30:00',
+        '2026-12-31 23:59:59',
+      ]);
+    });
+
+    test('handles case-insensitive sorting with exact tie-breaking', () {
+      final rows = [
+        ['alpha'],
+        ['Alpha'],
+        ['BETA'],
+        ['beta'],
+      ];
+      final sorted = sortResultGridRows(
+        rows: rows,
+        columnIndex: 0,
+        order: ResultGridSortOrder.ascending,
+      );
+      expect(sorted.map((r) => r[0]).toList(), ['Alpha', 'alpha', 'BETA', 'beta']);
+    });
+
+    test('handles large 5000-row dataset efficiently with Schwartzian transform', () {
+      final rows = List<List<String>>.generate(
+        5000,
+        (i) => ['${(5000 - i) * 3}', 'user_$i'],
+      );
+      final stopwatch = Stopwatch()..start();
+      final sorted = sortResultGridRows(
+        rows: rows,
+        columnIndex: 0,
+        order: ResultGridSortOrder.ascending,
+      );
+      stopwatch.stop();
+
+      expect(sorted.first[0], '3');
+      expect(sorted.last[0], '15000');
+      // Performance expectation: 5000 rows should easily sort within 50ms with precomputed keys
+      expect(stopwatch.elapsedMilliseconds, lessThan(300));
+    });
+
     test('handles NULL and empty values gracefully', () {
       final rows = [
         ['100'],


### PR DESCRIPTION
Closes #602

### Summary
- Implemented the Schwartzian Transform (Decorate-Sort-Undecorate) in `sortResultGridRows` (`lib/features/main_screen/result_grid_view.dart`).
- Precomputed `_SortKey` for every row in a single $O(N)$ pass, avoiding repetitive `num.tryParse`, `DateTime.tryParse`, and `toLowerCase()` invocations during comparisons.
- Added comprehensive unit and benchmark tests in `test/features/main_screen/results_tab_test.dart` validating temporal, case-insensitive, and 5000-row dataset sorting performance.