### PR TITLE
perf(calc): optimize GridSelectionCalcEngine median calculation with QuickSelect (#603)

### DIFF
--- a/lib/features/main_screen/grid_selection_calc_engine.dart
+++ b/lib/features/main_screen/grid_selection_calc_engine.dart
@@ -132,15 +132,25 @@ abstract final class GridSelectionCalcEngine {
     final numericCount = numericList.length;
     final avg = numericCount > 0 ? sum / numericCount : null;
 
-    // Calculate median
+    // Calculate median using QuickSelect (O(N)) for large datasets (> 500 elements) or fast sort (<= 500)
     double? median;
     if (numericCount > 0) {
-      numericList.sort();
       final mid = numericCount ~/ 2;
-      if (numericCount.isOdd) {
-        median = numericList[mid];
+      if (numericCount <= 500) {
+        numericList.sort();
+        if (numericCount.isOdd) {
+          median = numericList[mid];
+        } else {
+          median = (numericList[mid - 1] + numericList[mid]) / 2.0;
+        }
       } else {
-        median = (numericList[mid - 1] + numericList[mid]) / 2.0;
+        if (numericCount.isOdd) {
+          median = _quickSelect(numericList, 0, numericCount - 1, mid);
+        } else {
+          final m1 = _quickSelect(numericList, 0, numericCount - 1, mid - 1);
+          final m2 = _quickSelect(numericList, mid, numericCount - 1, mid);
+          median = (m1 + m2) / 2.0;
+        }
       }
     }
 
@@ -166,6 +176,63 @@ abstract final class GridSelectionCalcEngine {
       max: maxVal,
       stdDev: stdDev,
     );
+  }
+
+  /// Linear-time QuickSelect algorithm to find the k-th smallest element.
+  static double _quickSelect(List<double> list, int left, int right, int k) {
+    while (left < right) {
+      if (right - left < 10) {
+        // Insertion sort for small sub-arrays
+        for (var i = left + 1; i <= right; i++) {
+          final temp = list[i];
+          var j = i - 1;
+          while (j >= left && list[j] > temp) {
+            list[j + 1] = list[j];
+            j--;
+          }
+          list[j + 1] = temp;
+        }
+        return list[k];
+      }
+
+      final pivotIndex = _partition(list, left, right);
+      if (pivotIndex == k) {
+        return list[k];
+      } else if (pivotIndex > k) {
+        right = pivotIndex - 1;
+      } else {
+        left = pivotIndex + 1;
+      }
+    }
+    return list[left];
+  }
+
+  static int _partition(List<double> list, int left, int right) {
+    // Median-of-three pivot selection for optimal partitioning
+    final mid = left + ((right - left) >> 1);
+    if (list[left] > list[mid]) _swap(list, left, mid);
+    if (list[left] > list[right]) _swap(list, left, right);
+    if (list[mid] > list[right]) _swap(list, mid, right);
+
+    final pivotValue = list[mid];
+    _swap(list, mid, right - 1);
+    var i = left;
+    var j = right - 1;
+
+    while (true) {
+      while (list[++i] < pivotValue) {}
+      while (list[--j] > pivotValue) {}
+      if (i >= j) break;
+      _swap(list, i, j);
+    }
+    _swap(list, i, right - 1);
+    return i;
+  }
+
+  static void _swap(List<double> list, int i, int j) {
+    final temp = list[i];
+    list[i] = list[j];
+    list[j] = temp;
   }
 
   /// Formats a numeric stat cleanly for UI display.

--- a/test/features/main_screen/data_grid_engines_test.dart
+++ b/test/features/main_screen/data_grid_engines_test.dart
@@ -194,6 +194,21 @@ void main() {
       expect(stats.min, equals(10.0));
       expect(stats.max, equals(50.5));
     });
+
+    test('computes correct QuickSelect median for large odd and even selections (> 500)', () {
+      // Odd length > 500 (1001 items)
+      final oddData = List<String>.generate(1001, (i) => '${(i * 3) % 1000}');
+      final oddStats = GridSelectionCalcEngine.compute(oddData);
+      final oddParsed = oddData.map(double.parse).toList()..sort();
+      expect(oddStats.median, equals(oddParsed[500]));
+
+      // Even length > 500 (1000 items)
+      final evenData = List<String>.generate(1000, (i) => '${(i * 7) % 2000}');
+      final evenStats = GridSelectionCalcEngine.compute(evenData);
+      final evenParsed = evenData.map(double.parse).toList()..sort();
+      final expectedEvenMedian = (evenParsed[499] + evenParsed[500]) / 2.0;
+      expect(evenStats.median, equals(expectedEvenMedian));
+    });
   });
 
   group('GridGroupingsEngine', () {


### PR DESCRIPTION
Closes #603

### Summary
- Replaced full $O(K \log K)$ sorting with linear-time QuickSelect ($O(K)$ average) in `GridSelectionCalcEngine.compute` (`lib/features/main_screen/grid_selection_calc_engine.dart`) for selections exceeding 500 numeric items.
- Retained standard fast sort for small selections ($\le 500$ items) to leverage native VM sorting speed.
- Added comprehensive unit tests in `test/features/main_screen/data_grid_engines_test.dart` validating median calculation for large odd and even numeric selections.