### PR TITLE
fix(theme): expand typography monospace fallback stack with Cascadia Code and Consolas (#613)

### DIFF
--- a/lib/core/editor/highlighter_theme_from_querya.dart
+++ b/lib/core/editor/highlighter_theme_from_querya.dart
@@ -12,6 +12,7 @@ HighlighterTheme highlighterThemeFromQueryaEditor(
   final wrapper = TextStyle(
     color: editor.foreground,
     fontFamily: editor.fontFamily,
+    fontFamilyFallback: editor.fontFamilyFallback,
     fontSize: editor.fontSize,
   );
 

--- a/lib/core/editor/querya_code_editor.dart
+++ b/lib/core/editor/querya_code_editor.dart
@@ -270,6 +270,7 @@ class _QueryaCodeEditorState extends State<QueryaCodeEditor> {
     final size = widget.fontSize ?? editor.fontSize;
     return material.TextStyle(
       fontFamily: editor.fontFamily,
+      fontFamilyFallback: editor.fontFamilyFallback,
       fontSize: size,
       color: editor.foreground,
       height: widget.language == QueryaCodeLanguage.json ? 1.5 : null,

--- a/lib/core/theme/querya_editor_theme.dart
+++ b/lib/core/theme/querya_editor_theme.dart
@@ -1,5 +1,6 @@
 import 'dart:ui';
 
+import 'package:flutter/foundation.dart';
 import 'querya_colors.dart';
 import 'querya_typography.dart';
 
@@ -21,6 +22,7 @@ class QueryaEditorTheme {
     required this.type,
     this.widgetBorder,
     this.fontFamily = QueryaTypography.mono,
+    this.fontFamilyFallback = QueryaTypography.monoFontFamilyFallback,
     this.fontSize = 13,
   });
 
@@ -41,6 +43,7 @@ class QueryaEditorTheme {
   final Color function;
   final Color type;
   final String fontFamily;
+  final List<String>? fontFamilyFallback;
   final double fontSize;
 
   /// Aligned with dark workbench; VS Code Dark+–like token hues.
@@ -93,6 +96,7 @@ class QueryaEditorTheme {
     Color? function,
     Color? type,
     String? fontFamily,
+    List<String>? fontFamilyFallback,
     double? fontSize,
   }) {
     return QueryaEditorTheme(
@@ -112,6 +116,7 @@ class QueryaEditorTheme {
       function: function ?? this.function,
       type: type ?? this.type,
       fontFamily: fontFamily ?? this.fontFamily,
+      fontFamilyFallback: fontFamilyFallback ?? this.fontFamilyFallback,
       fontSize: fontSize ?? this.fontSize,
     );
   }
@@ -138,6 +143,8 @@ class QueryaEditorTheme {
       function: c(a.function, b.function),
       type: c(a.type, b.type),
       fontFamily: t < 0.5 ? a.fontFamily : b.fontFamily,
+      fontFamilyFallback:
+          t < 0.5 ? a.fontFamilyFallback : b.fontFamilyFallback,
       fontSize: a.fontSize + (b.fontSize - a.fontSize) * t,
     );
   }
@@ -161,6 +168,7 @@ class QueryaEditorTheme {
           function == other.function &&
           type == other.type &&
           fontFamily == other.fontFamily &&
+          listEquals(fontFamilyFallback, other.fontFamilyFallback) &&
           fontSize == other.fontSize;
 
   @override
@@ -180,6 +188,7 @@ class QueryaEditorTheme {
         function,
         type,
         fontFamily,
+        fontFamilyFallback,
         fontSize,
       );
 }

--- a/lib/core/theme/querya_typography.dart
+++ b/lib/core/theme/querya_typography.dart
@@ -1,6 +1,28 @@
-/// Monospace stack for SQL editors (bundled font can replace this later).
+/// Monospace font stack for SQL editors, cell inspectors, and code preview dialogs.
 abstract class QueryaTypography {
   QueryaTypography._();
 
-  static const String mono = 'monospace';
+  /// Primary monospace font family identifier.
+  static const String mono = 'Cascadia Code';
+
+  /// Cross-platform prioritized monospace font fallback list.
+  ///
+  /// Prioritizes modern programming fonts across operating systems:
+  /// - Windows 11 / Terminal: Cascadia Code
+  /// - Windows 10 / legacy: Consolas, Courier New
+  /// - macOS: Menlo, SF Mono, Monaco
+  /// - Linux / BSD: Fira Code, Ubuntu Mono, DejaVu Sans Mono
+  /// - Generic system fallback: monospace
+  static const List<String> monoFontFamilyFallback = <String>[
+    'Cascadia Code',
+    'Consolas',
+    'Menlo',
+    'SF Mono',
+    'Monaco',
+    'Fira Code',
+    'Ubuntu Mono',
+    'DejaVu Sans Mono',
+    'Courier New',
+    'monospace',
+  ];
 }

--- a/test/core/theme/querya_typography_test.dart
+++ b/test/core/theme/querya_typography_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:querya_desktop/core/theme/querya_editor_theme.dart';
+import 'package:querya_desktop/core/theme/querya_typography.dart';
+
+void main() {
+  group('QueryaTypography font stack', () {
+    test('defines modern primary monospace and cross-platform fallback stack', () {
+      expect(QueryaTypography.mono, equals('Cascadia Code'));
+
+      const stack = QueryaTypography.monoFontFamilyFallback;
+      expect(stack, contains('Cascadia Code'));
+      expect(stack, contains('Consolas'));
+      expect(stack, contains('Menlo'));
+      expect(stack, contains('SF Mono'));
+      expect(stack, contains('Fira Code'));
+      expect(stack, contains('Ubuntu Mono'));
+      expect(stack, contains('DejaVu Sans Mono'));
+      expect(stack, contains('monospace'));
+
+      // Ensure fallback ends with generic 'monospace'
+      expect(stack.last, equals('monospace'));
+    });
+
+    test('QueryaEditorTheme wires monospace typography stack by default', () {
+      const theme = QueryaEditorTheme.darkDefault;
+      expect(theme.fontFamily, equals(QueryaTypography.mono));
+      expect(theme.fontFamilyFallback, equals(QueryaTypography.monoFontFamilyFallback));
+    });
+
+    test('QueryaEditorTheme copyWith and lerp preserve or override fontFamilyFallback', () {
+      const base = QueryaEditorTheme.darkDefault;
+      final custom = base.copyWith(
+        fontFamily: 'Fira Code',
+        fontFamilyFallback: ['Fira Code', 'monospace'],
+      );
+      expect(custom.fontFamily, equals('Fira Code'));
+      expect(custom.fontFamilyFallback, equals(['Fira Code', 'monospace']));
+
+      final lerped = QueryaEditorTheme.lerp(base, custom, 0.7);
+      expect(lerped.fontFamily, equals('Fira Code'));
+      expect(lerped.fontFamilyFallback, equals(['Fira Code', 'monospace']));
+    });
+  });
+}


### PR DESCRIPTION
Closes #613

### Summary
- Expanded `QueryaTypography.mono` and added prioritized cross-platform `QueryaTypography.monoFontFamilyFallback` with `Cascadia Code` (Windows 11), `Consolas` (Windows 10), `Menlo` / `SF Mono` / `Monaco` (macOS), `Fira Code` / `Ubuntu Mono` / `DejaVu Sans Mono` (Linux), followed by fallback `monospace`.
- Wired `fontFamilyFallback` into `QueryaEditorTheme`, `highlighterThemeFromQueryaEditor`, and `QueryaCodeEditor`.
- Added unit tests in `test/core/theme/querya_typography_test.dart` validating font fallback definitions, copyWith, and lerp behaviors.