### PR TITLE
ui(motion): harmonize connection workspace motion to prevent dual-axis wobble (#631)

### DIFF
--- a/lib/features/main_screen/workspace_panel.dart
+++ b/lib/features/main_screen/workspace_panel.dart
@@ -11,7 +11,8 @@ import 'package:flutter/material.dart' as material
         MainAxisSize,
         SizedBox,
         Widget,
-        Column;
+        Column,
+        Offset;
 import 'package:querya_desktop/core/extensions/extension_driver_catalog.dart';
 import 'package:querya_desktop/core/motion/querya_fade_slide.dart';
 import 'package:querya_desktop/core/motion/querya_switching_body.dart';
@@ -372,10 +373,12 @@ class _WorkspacePanelState extends State<WorkspacePanel> {
     required material.Widget? object,
   }) {
     return QueryaSwitchingBody(
+      slide: material.Offset.zero,
       index: showingObject ? 1 : 0,
       children: [
         home,
         QueryaFadeSlide(
+          offset: const material.Offset(0, 0.015),
           child: object ??
               const material.SizedBox.expand(
                 key: ValueKey('workspace_object_placeholder'),

--- a/test/features/main_screen/workspace_panel_layout_test.dart
+++ b/test/features/main_screen/workspace_panel_layout_test.dart
@@ -255,5 +255,30 @@ void main() {
       expect(find.byType(RedisView), findsOneWidget);
       expect(find.byType(QueryaSwitchingBody), findsNWidgets(2));
     });
+
+    testWidgets(
+        'home↔object morph uses slide: Offset.zero to prevent dual-axis wobble',
+        (tester) async {
+      await pumpWidgetWithSurfaceSize(
+        tester,
+        const material.Size(800, 600),
+        queryaThemeTestShell(
+          child: const material.SizedBox.expand(
+            child: WorkspacePanel(activeConnection: redisConnection),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+
+      final switchingBodies = tester
+          .widgetList<QueryaSwitchingBody>(find.byType(QueryaSwitchingBody))
+          .toList();
+      final homeObjectSwitchingBody = switchingBodies.firstWhere(
+        (sb) => sb.slide == material.Offset.zero,
+        orElse: () => throw StateError('No switching body with Offset.zero'),
+      );
+      expect(homeObjectSwitchingBody.slide, material.Offset.zero);
+    });
   });
 }


### PR DESCRIPTION
Closes #631

Eliminates conflicting dual-axis translation during home-object morphing in `WorkspacePanel` by setting `slide: Offset.zero` on `QueryaSwitchingBody` and delegating entrance elevation exclusively to `QueryaFadeSlide`.