### PR TITLE
feat(tree): support active selection highlighting in SduiTreeBuilder for extension drivers (#639)

### DIFF
--- a/lib/core/sdui/sdui_tree_builder.dart
+++ b/lib/core/sdui/sdui_tree_builder.dart
@@ -21,12 +21,16 @@ class SduiTreeBuilder extends material.StatefulWidget {
     required this.schema,
     this.fetchChildren,
     this.onNodeSelected,
+    this.selectedNodeId,
+    this.isNodeSelected,
     this.maxHeight,
   });
 
   final SduiTreeSchema schema;
   final SduiFetchTreeChildren? fetchChildren;
   final void Function(SduiTreeNode node)? onNodeSelected;
+  final String? selectedNodeId;
+  final bool Function(SduiTreeNode node)? isNodeSelected;
 
   /// When set, the tree scrolls inside a height cap (sidebar use).
   final double? maxHeight;
@@ -199,89 +203,121 @@ class SduiTreeBuilderState extends material.State<SduiTreeBuilder> {
 
   material.Widget _buildNodeRow(SduiTreeNode node, {required int depth}) {
     final theme = Theme.of(context);
+    final primary = theme.colorScheme.primary;
     final muted = theme.colorScheme.mutedForeground;
     final canExpand = node.expandable || node.hasChildren;
     final isExpanded = _expanded.contains(node.id);
     final isLoading = _loading.contains(node.id);
     final nodeKind = _resolveNodeKind(node);
     final isBrowsable = nodeKind == 'table' || nodeKind == 'view';
+    final isSelected = (widget.selectedNodeId != null &&
+            node.id == widget.selectedNodeId) ||
+        (widget.isNodeSelected != null && widget.isNodeSelected!(node));
+
     // Same hierarchy as native trees (#476 / #497) — no separate sduiNode size.
     final iconSize =
         canExpand ? QueryaIconSizes.treeGroup : QueryaIconSizes.treeLeaf;
-    final iconColor = isBrowsable
-        ? QueryaTreeTokens.leafIconColor(theme.colorScheme.primary)
-        : muted;
+    final iconColor = isSelected
+        ? primary
+        : (isBrowsable
+            ? QueryaTreeTokens.leafIconColor(primary)
+            : muted);
     final rowLeft =
         8.0 + depth * QueryaTreeTokens.indent + (canExpand ? 0 : 4.0);
 
-    final row = material.InkWell(
-      onTap: () {
-        if (isBrowsable) {
-          widget.onNodeSelected?.call(node);
-        } else if (canExpand) {
-          _toggleExpand(node);
-        }
-      },
-      borderRadius: material.BorderRadius.circular(4),
-      child: material.Padding(
-        padding: material.EdgeInsets.only(
-          left: rowLeft,
-          right: 8,
-        ),
-        child: material.Row(
-          children: [
-            if (canExpand)
-              material.MouseRegion(
-                cursor: material.SystemMouseCursors.click,
-                child: material.GestureDetector(
-                  behavior: material.HitTestBehavior.opaque,
-                  onTap: () => _toggleExpand(node),
-                  child: material.Padding(
-                    padding: const material.EdgeInsets.all(2),
-                    child: material.AnimatedRotation(
-                      turns: isExpanded ? 0.25 : 0,
-                      duration: context.motionDuration(QueryaMotion.treeExpand),
-                      curve: context.motionCurve(QueryaMotion.treeExpandCurve),
-                      child: material.Icon(
-                        QueryaIcons.expandClosed,
-                        size: QueryaIconSizes.treeExpand,
-                        color: muted,
+    final row = material.AnimatedContainer(
+      duration: context.motionDuration(QueryaMotion.fast),
+      curve: context.motionCurve(QueryaMotion.standardCurve),
+      decoration: material.BoxDecoration(
+        color: isSelected
+            ? primary.withValues(alpha: 0.12)
+            : material.Colors.transparent,
+        borderRadius: material.BorderRadius.circular(4),
+        border: isSelected
+            ? material.Border.all(
+                color: primary.withValues(alpha: 0.35),
+                width: 1,
+              )
+            : null,
+      ),
+      child: material.Material(
+        color: material.Colors.transparent,
+        child: material.InkWell(
+          onTap: () {
+            if (isBrowsable) {
+              widget.onNodeSelected?.call(node);
+            } else if (canExpand) {
+              _toggleExpand(node);
+            }
+          },
+          borderRadius: material.BorderRadius.circular(4),
+          child: material.Padding(
+            padding: material.EdgeInsets.only(
+              left: rowLeft,
+              right: 8,
+            ),
+            child: material.Row(
+              children: [
+                if (canExpand)
+                  material.MouseRegion(
+                    cursor: material.SystemMouseCursors.click,
+                    child: material.GestureDetector(
+                      behavior: material.HitTestBehavior.opaque,
+                      onTap: () => _toggleExpand(node),
+                      child: material.Padding(
+                        padding: const material.EdgeInsets.all(2),
+                        child: material.AnimatedRotation(
+                          turns: isExpanded ? 0.25 : 0,
+                          duration:
+                              context.motionDuration(QueryaMotion.treeExpand),
+                          curve:
+                              context.motionCurve(QueryaMotion.treeExpandCurve),
+                          child: material.Icon(
+                            QueryaIcons.expandClosed,
+                            size: QueryaIconSizes.treeExpand,
+                            color: muted,
+                          ),
+                        ),
                       ),
+                    ),
+                  )
+                else
+                  const material.SizedBox(width: QueryaIconSizes.treeExpand + 4),
+                if (isLoading)
+                  const material.SizedBox(
+                    width: 14,
+                    height: 14,
+                    child: material.CircularProgressIndicator(strokeWidth: 2),
+                  )
+                else
+                  material.Icon(
+                    QueryaIcons.sduiNodeIcon(
+                      node.icon,
+                      expandable: node.expandable,
+                    ),
+                    size: iconSize,
+                    color: iconColor,
+                  ),
+                const Gap(8),
+                material.Expanded(
+                  child: material.Text(
+                    node.label,
+                    overflow: material.TextOverflow.ellipsis,
+                    maxLines: 1,
+                    style: material.TextStyle(
+                      fontSize: 11,
+                      color: isSelected
+                          ? primary
+                          : (isBrowsable ? theme.colorScheme.foreground : muted),
+                      fontWeight: (isSelected || isBrowsable)
+                          ? material.FontWeight.w600
+                          : null,
                     ),
                   ),
                 ),
-              )
-            else
-              const material.SizedBox(width: QueryaIconSizes.treeExpand + 4),
-            if (isLoading)
-              const material.SizedBox(
-                width: 14,
-                height: 14,
-                child: material.CircularProgressIndicator(strokeWidth: 2),
-              )
-            else
-              material.Icon(
-                QueryaIcons.sduiNodeIcon(
-                  node.icon,
-                  expandable: node.expandable,
-                ),
-                size: iconSize,
-                color: iconColor,
-              ),
-            const Gap(8),
-            material.Expanded(
-              child: material.Text(
-                node.label,
-                overflow: material.TextOverflow.ellipsis,
-                maxLines: 1,
-                style: material.TextStyle(
-                  fontSize: 11,
-                  color: isBrowsable ? theme.colorScheme.foreground : muted,
-                  fontWeight: isBrowsable ? material.FontWeight.w600 : null,
-                ),
-              ),
+              ],
             ),
-          ],
+          ),
         ),
       ),
     );

--- a/lib/features/connections/connections_panel_extension.dart
+++ b/lib/features/connections/connections_panel_extension.dart
@@ -139,6 +139,11 @@ class _ExtensionConnectionTileState extends State<_ExtensionConnectionTile> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final sel = _ConnectionsTreeSelectionScope.of(context);
+    final selectedExt = (sel != null &&
+            sel.selectedConnectionId == widget.connection.id)
+        ? sel.selectedExtensionObject
+        : null;
     final material.Widget iconWidget;
     if (_iconFilePath != null) {
       iconWidget = DriverIconImage(
@@ -322,6 +327,29 @@ class _ExtensionConnectionTileState extends State<_ExtensionConnectionTile> {
                               schema: _schema!,
                               fetchChildren: _fetchChildren,
                               onNodeSelected: _onNodeSelected,
+                              isNodeSelected: selectedExt == null
+                                  ? null
+                                  : (node) {
+                                      final metaDb = node.meta['database'] ??
+                                          node.meta['db'];
+                                      final metaName = node.meta['table'] ??
+                                          node.meta['tableName'] ??
+                                          node.meta['name'];
+                                      if (metaDb != null && metaName != null) {
+                                        if (metaDb == selectedExt.database &&
+                                            metaName == selectedExt.name) {
+                                          return true;
+                                        }
+                                      }
+                                      final parts = node.id.split('.');
+                                      if (parts.length >= 3) {
+                                        final db = parts[1];
+                                        final name = parts.sublist(2).join('.');
+                                        return db == selectedExt.database &&
+                                            name == selectedExt.name;
+                                      }
+                                      return false;
+                                    },
                               maxHeight: kConnectionTreeMaxVisibleRows *
                                   kConnectionTreeRowExtent,
                             ),

--- a/test/core/sdui/sdui_builders_test.dart
+++ b/test/core/sdui/sdui_builders_test.dart
@@ -359,5 +359,94 @@ void main() {
 
       expect(selected?.id, 'table.default.customers');
     });
+
+    testWidgets('highlights active node visually when selectedNodeId is provided',
+        (tester) async {
+      final schema = SduiTreeSchema.fromJson(const {
+        'roots': [
+          {
+            'id': 'table.analytics.events',
+            'label': 'events',
+            'node_type': 'table',
+          },
+          {
+            'id': 'table.analytics.users',
+            'label': 'users',
+            'node_type': 'table',
+          },
+        ],
+      });
+
+      await tester.pumpWidget(
+        queryaThemeTestShell(
+          child: material.Scaffold(
+            body: SduiTreeBuilder(
+              schema: schema,
+              selectedNodeId: 'table.analytics.events',
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Find the AnimatedContainers for the rows
+      final animatedContainers = tester.widgetList<material.AnimatedContainer>(
+        find.byType(material.AnimatedContainer),
+      ).toList();
+
+      expect(animatedContainers.length, greaterThanOrEqualTo(2));
+      final selectedDecoration = animatedContainers[0].decoration as material.BoxDecoration?;
+      final unselectedDecoration = animatedContainers[1].decoration as material.BoxDecoration?;
+
+      expect(selectedDecoration?.color, isNotNull);
+      expect(selectedDecoration?.border, isNotNull);
+      expect(unselectedDecoration?.border, isNull);
+    });
+
+    testWidgets('highlights active node visually when isNodeSelected predicate matches',
+        (tester) async {
+      final schema = SduiTreeSchema.fromJson(const {
+        'roots': [
+          {
+            'id': 'table.analytics.events',
+            'label': 'events',
+            'node_type': 'table',
+          },
+          {
+            'id': 'view.analytics.monthly_mv',
+            'label': 'monthly_mv',
+            'node_type': 'view',
+          },
+        ],
+      });
+
+      String? activeId = 'view.analytics.monthly_mv';
+
+      await tester.pumpWidget(
+        queryaThemeTestShell(
+          child: material.StatefulBuilder(
+            builder: (context, setState) {
+              return material.Scaffold(
+                body: SduiTreeBuilder(
+                  schema: schema,
+                  isNodeSelected: (node) => node.id == activeId,
+                ),
+              );
+            },
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final animatedContainers = tester.widgetList<material.AnimatedContainer>(
+        find.byType(material.AnimatedContainer),
+      ).toList();
+
+      final eventsDec = animatedContainers[0].decoration as material.BoxDecoration?;
+      final mvDec = animatedContainers[1].decoration as material.BoxDecoration?;
+
+      expect(eventsDec?.border, isNull);
+      expect(mvDec?.border, isNotNull);
+    });
   });
 }


### PR DESCRIPTION
### Summary
Closes #639

Brings active selection highlighting to SDUI schema trees used by extension database drivers (ClickHouse, DuckDB, etc.), matching native tree selection visual styling (`_PgTreeRow`).

### Changes
1. **SduiTreeBuilder** (`lib/core/sdui/sdui_tree_builder.dart`):
   - Added `selectedNodeId` and `isNodeSelected` predicate parameters.
   - Wrapped node rows in `material.AnimatedContainer` with 120ms `QueryaMotion.fast` duration.
   - Applied active selection design tokens: subtle primary background tint (`alpha: 0.12`), primary border outline (`alpha: 0.35`), and semibold typography (`w600`).
2. **_ExtensionConnectionTile** (`lib/features/connections/connections_panel_extension.dart`):
   - Extracted `selectedExtensionObject` and `selectedConnectionId` from `_ConnectionsTreeSelectionScope`.
   - Forwarded `isNodeSelected` predicate matching active database and table/view names.
3. **Tests** (`test/core/sdui/sdui_builders_test.dart`):
   - Added widget tests validating active selection styling for `selectedNodeId` and `isNodeSelected`.