### PR TITLE
fix(storage): ensure single-flight thread-safe LocalDb._open initialization

### DIFF
--- a/lib/core/storage/local_db.dart
+++ b/lib/core/storage/local_db.dart
@@ -33,6 +33,7 @@ class LocalDb {
 
   Database? _db;
   String? _cachedDbPath;
+  Future<Database>? _openFuture;
 
   static Future<void> initFfi() async {
     if (Platform.isLinux || Platform.isWindows || Platform.isMacOS) {
@@ -42,6 +43,19 @@ class LocalDb {
 
   Future<Database> _open() async {
     if (_db != null && _db!.isOpen) return _db!;
+    if (_openFuture != null) return _openFuture!;
+
+    final future = _doOpen();
+    _openFuture = future;
+    try {
+      return await future;
+    } catch (_) {
+      _openFuture = null;
+      rethrow;
+    }
+  }
+
+  Future<Database> _doOpen() async {
     await initFfi();
     if (_cachedDbPath == null) {
       final dir = await AppDataRoot.applicationSupportDirectory();
@@ -49,7 +63,7 @@ class LocalDb {
       if (!await sub.exists()) await sub.create(recursive: true);
       _cachedDbPath = p.join(sub.path, _dbName);
     }
-    _db = await databaseFactoryFfi.openDatabase(
+    final db = await databaseFactoryFfi.openDatabase(
       _cachedDbPath!,
       options: OpenDatabaseOptions(
         version: _dbVersion,
@@ -63,7 +77,9 @@ class LocalDb {
         },
       ),
     );
-    return _db!;
+    _db = db;
+    _openFuture = null;
+    return db;
   }
 
   /// Queries an active PRAGMA setting from the database for verification and diagnostic purposes.
@@ -537,6 +553,7 @@ class LocalDb {
   }
 
   Future<void> close() async {
+    _openFuture = null;
     await _db?.close();
     _db = null;
     _cachedDbPath = null;

--- a/test/core/storage/local_db_concurrency_test.dart
+++ b/test/core/storage/local_db_concurrency_test.dart
@@ -119,5 +119,23 @@ void main() {
       await LocalDb.instance.removeConnection(connId);
       await LocalDb.instance.removeFolder('Concurrency Test Folder');
     });
+
+    test('deduplicates parallel cold-start open calls via single-flight memoization', () async {
+      // Close database to simulate completely cold state
+      await LocalDb.instance.close();
+
+      // Launch multiple simultaneous queries on a closed database
+      final parallelOperations = [
+        LocalDb.instance.getFolders(),
+        LocalDb.instance.getConnections(),
+        LocalDb.instance.getAppSetting('theme_preset'),
+        LocalDb.instance.getPragma('journal_mode'),
+      ];
+
+      final results = await Future.wait(parallelOperations);
+      expect(results[0], isA<List<String>>());
+      expect(results[1], isA<List<ConnectionRow>>());
+      expect(results[3].toString().toLowerCase(), equals('wal'));
+    });
   });
 }


### PR DESCRIPTION
## Description

Resolves #645 by protecting `LocalDb._open()` against simultaneous opening attempts on cold startup:

1. **Single-Flight Open Memoization**:
   - Stored an active open task in `_openFuture` during database opening.
   - All concurrent parallel callers await the shared `_openFuture`.
   - Safely reset `_openFuture = null` when opening fails (re-allowing retries) or when `LocalDb.instance.close()` is called.

2. **Testing**:
   - Added unit test in `test/core/storage/local_db_concurrency_test.dart` verifying multiple simultaneous operations from a cold, closed database state without lock conflicts.
   - All tests in `test/core/storage/` passed.
   - `flutter analyze` passed with 0 issues.

Closes #645