### PR TITLE
perf(workspace): debounce filter input in DataGridFilterBar

### DIFF
--- a/lib/features/workspace/data_grid_filter_bar.dart
+++ b/lib/features/workspace/data_grid_filter_bar.dart
@@ -1,3 +1,4 @@
+import 'dart:async' show Timer;
 import 'package:flutter/material.dart' as material;
 import 'package:shadcn_flutter/shadcn_flutter.dart';
 
@@ -118,6 +119,7 @@ class DataGridFilterBar extends material.StatefulWidget {
     required this.totalRowCount,
     required this.filteredRowCount,
     this.columns = const [],
+    this.debounceDuration = const Duration(milliseconds: 150),
   });
 
   final String filterText;
@@ -125,6 +127,7 @@ class DataGridFilterBar extends material.StatefulWidget {
   final int totalRowCount;
   final int filteredRowCount;
   final List<String> columns;
+  final Duration debounceDuration;
 
   @override
   material.State<DataGridFilterBar> createState() => _DataGridFilterBarState();
@@ -136,6 +139,7 @@ class _DataGridFilterBarState extends material.State<DataGridFilterBar> {
   material.OverlayEntry? _overlayEntry;
   List<FilterSuggestion> _suggestions = [];
   int _highlightedIndex = 0;
+  Timer? _debounceTimer;
 
   @override
   void initState() {
@@ -154,14 +158,30 @@ class _DataGridFilterBarState extends material.State<DataGridFilterBar> {
 
   @override
   void dispose() {
+    _debounceTimer?.cancel();
     _hideSuggestions();
     _controller.dispose();
     super.dispose();
   }
 
   void _onChanged(String val) {
-    widget.onFilterChanged(val);
     _updateSuggestions(val);
+    if (widget.debounceDuration == Duration.zero) {
+      widget.onFilterChanged(val);
+      return;
+    }
+    _debounceTimer?.cancel();
+    _debounceTimer = Timer(widget.debounceDuration, () {
+      if (mounted) {
+        widget.onFilterChanged(val);
+      }
+    });
+  }
+
+  void _onSubmitted(String val) {
+    _debounceTimer?.cancel();
+    _hideSuggestions();
+    widget.onFilterChanged(val);
   }
 
   void _updateSuggestions(String val) {
@@ -333,6 +353,7 @@ class _DataGridFilterBarState extends material.State<DataGridFilterBar> {
               child: material.TextField(
                 controller: _controller,
                 onChanged: _onChanged,
+                onSubmitted: _onSubmitted,
                 style: TextStyle(
                   fontSize: 12,
                   color: cs.foreground,
@@ -373,6 +394,7 @@ class _DataGridFilterBarState extends material.State<DataGridFilterBar> {
                 constraints: const material.BoxConstraints(minWidth: 20, minHeight: 20),
                 color: cs.mutedForeground,
                 onPressed: () {
+                  _debounceTimer?.cancel();
                   _controller.clear();
                   _hideSuggestions();
                   widget.onFilterChanged('');

--- a/test/features/workspace/data_grid_filter_bar_test.dart
+++ b/test/features/workspace/data_grid_filter_bar_test.dart
@@ -71,5 +71,99 @@ void main() {
       expect(currentFilter, 'stat');
       expect(find.text('status'), findsOneWidget);
     });
+
+    testWidgets('debounces rapid keystrokes and notifies only once after debounce duration', (tester) async {
+      final changeNotifications = <String>[];
+
+      await tester.pumpWidget(
+        queryaThemeTestShell(
+          child: material.Material(
+            child: DataGridFilterBar(
+              filterText: '',
+              onFilterChanged: (text) => changeNotifications.add(text),
+              totalRowCount: 100,
+              filteredRowCount: 20,
+              columns: const ['id', 'name', 'status'],
+              debounceDuration: const Duration(milliseconds: 150),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Type first letter 'a'
+      await tester.enterText(find.byType(material.TextField), 'a');
+      await tester.pump(const Duration(milliseconds: 50));
+      // No notification yet
+      expect(changeNotifications, isEmpty);
+
+      // Type second letter 'ab' before timer expires
+      await tester.enterText(find.byType(material.TextField), 'ab');
+      await tester.pump(const Duration(milliseconds: 50));
+      expect(changeNotifications, isEmpty);
+
+      // Type third letter 'abc'
+      await tester.enterText(find.byType(material.TextField), 'abc');
+      await tester.pump(const Duration(milliseconds: 50));
+      expect(changeNotifications, isEmpty);
+
+      // Wait remaining debounce duration (100ms more => 150ms since last keystroke)
+      await tester.pump(const Duration(milliseconds: 100));
+      expect(changeNotifications, ['abc']);
+    });
+
+    testWidgets('notifies immediately on submit without waiting for debounce duration', (tester) async {
+      final changeNotifications = <String>[];
+
+      await tester.pumpWidget(
+        queryaThemeTestShell(
+          child: material.Material(
+            child: DataGridFilterBar(
+              filterText: '',
+              onFilterChanged: (text) => changeNotifications.add(text),
+              totalRowCount: 100,
+              filteredRowCount: 20,
+              columns: const ['id', 'name', 'status'],
+              debounceDuration: const Duration(milliseconds: 150),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(material.TextField), 'active');
+      // Submit immediately
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pump();
+
+      expect(changeNotifications, ['active']);
+    });
+
+    testWidgets('cancels pending timer and notifies empty on clear button tap', (tester) async {
+      final changeNotifications = <String>[];
+
+      await tester.pumpWidget(
+        queryaThemeTestShell(
+          child: material.Material(
+            child: DataGridFilterBar(
+              filterText: 'prefilled',
+              onFilterChanged: (text) => changeNotifications.add(text),
+              totalRowCount: 100,
+              filteredRowCount: 10,
+              columns: const ['id', 'name', 'status'],
+              debounceDuration: const Duration(milliseconds: 150),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(material.Icons.close), findsOneWidget);
+
+      await tester.tap(find.byIcon(material.Icons.close));
+      await tester.pumpAndSettle();
+
+      expect(changeNotifications, ['']);
+    });
   });
 }


### PR DESCRIPTION
## Description

Resolves #651 by introducing a debounce timer for filter text input in `DataGridFilterBar`:

1. **Debounce Mechanism**:
   - Added a 150ms debounce `Timer` to `_DataGridFilterBarState`.
   - Rapid keystrokes no longer trigger sequential full dataset filtering on each character.
   - Autocomplete suggestions continue to update instantly for zero typing lag.

2. **Immediate Executions & Cleanup**:
   - Enter key submission (`onSubmitted`) cancels pending debounce and immediately triggers filtering.
   - Clear button tap cancels pending debounce and immediately clears the filter.
   - Timer is cleanly cancelled on widget `dispose()`.

3. **Testing**:
   - Added unit and widget tests in `test/features/workspace/data_grid_filter_bar_test.dart` verifying debounced emission, immediate Enter submission, and clear button cancellation.
   - All 183 tests pass with 0 analyze issues.

Closes #651