### PR TITLE
perf(workspace): offload massive grid selection statistics calculation to background compute

### DIFF
--- a/lib/features/workspace/grid_selection_calc_engine.dart
+++ b/lib/features/workspace/grid_selection_calc_engine.dart
@@ -1,5 +1,6 @@
 import 'dart:math' as math;
-import 'package:flutter/foundation.dart';
+import 'package:flutter/foundation.dart' as foundation;
+import 'package:flutter/foundation.dart' show immutable;
 
 /// Aggregated statistical results for a selection of grid cell values.
 @immutable
@@ -93,6 +94,22 @@ class GridCalcStats {
 
 /// Calculation engine for computing stats (Count, Distinct, Sum, Avg, Median, Min, Max, StdDev) on grid selections.
 abstract final class GridSelectionCalcEngine {
+  /// Default threshold for offloading stats calculation to a background isolate.
+  static const int computeThreshold = 5000;
+
+  /// Computes statistics adaptively: synchronously for small lists (< [computeThreshold]),
+  /// and offloaded to a background isolate using [compute] for large selections.
+  static Future<GridCalcStats> computeAdaptive(
+    List<String> values, {
+    int threshold = computeThreshold,
+  }) async {
+    if (values.isEmpty) return GridCalcStats.empty;
+    if (values.length < threshold) {
+      return compute(values);
+    }
+    return foundation.compute(compute, values);
+  }
+
   /// Computes statistics for a list of string cell values.
   static GridCalcStats compute(List<String> values) {
     if (values.isEmpty) return GridCalcStats.empty;

--- a/lib/features/workspace/results_tab.dart
+++ b/lib/features/workspace/results_tab.dart
@@ -371,9 +371,23 @@ class _ResultsTabState extends material.State<ResultsTab> {
                         stagingBuffer: widget.stagingBuffer,
                         onRowSelected: (row) => setState(() => _selectedRowIndex = row),
                         onSelectionValuesChanged: (values) {
-                          setState(() {
-                            _selectionStats = GridSelectionCalcEngine.compute(values);
-                          });
+                          if (values.isEmpty) {
+                            setState(() => _selectionStats = GridCalcStats.empty);
+                            return;
+                          }
+                          if (values.length < GridSelectionCalcEngine.computeThreshold) {
+                            setState(() {
+                              _selectionStats = GridSelectionCalcEngine.compute(values);
+                            });
+                          } else {
+                            unawaited(
+                              GridSelectionCalcEngine.computeAdaptive(values).then((stats) {
+                                if (mounted) {
+                                  setState(() => _selectionStats = stats);
+                                }
+                              }),
+                            );
+                          }
                         },
                         onCellFocused: (colName, cellVal, rowIdx) {
                           setState(() {

--- a/test/features/workspace/data_grid_engines_test.dart
+++ b/test/features/workspace/data_grid_engines_test.dart
@@ -209,6 +209,28 @@ void main() {
       final expectedEvenMedian = (evenParsed[499] + evenParsed[500]) / 2.0;
       expect(evenStats.median, equals(expectedEvenMedian));
     });
+
+    test('computeAdaptive returns empty stats for empty list', () async {
+      final stats = await GridSelectionCalcEngine.computeAdaptive(const []);
+      expect(stats, equals(GridCalcStats.empty));
+    });
+
+    test('computeAdaptive computes synchronously below threshold', () async {
+      final values = ['10', '20', '30'];
+      final stats = await GridSelectionCalcEngine.computeAdaptive(values, threshold: 10);
+      expect(stats.totalCount, 3);
+      expect(stats.sum, 60.0);
+      expect(stats.average, 20.0);
+    });
+
+    test('computeAdaptive computes via background isolate above threshold', () async {
+      final values = List<String>.generate(100, (i) => '$i');
+      final stats = await GridSelectionCalcEngine.computeAdaptive(values, threshold: 50);
+      expect(stats.totalCount, 100);
+      expect(stats.min, 0.0);
+      expect(stats.max, 99.0);
+      expect(stats.sum, 4950.0);
+    });
   });
 
   group('GridGroupingsEngine', () {


### PR DESCRIPTION
## Description

Resolves #652 by adding adaptive background isolate calculation for DataGrid selection statistics:

1. **Adaptive Computation Engine**:
   - Added `GridSelectionCalcEngine.computeAdaptive` with a threshold of 5,000 values.
   - For regular cell selections (<5,000 cells), statistics continue to compute synchronously on the main thread for 0ms immediate feedback.
   - For massive selections (>5,000 cells), calculation is offloaded to a background isolate via `foundation.compute`, preventing UI thread stutter and frame drops.

2. **Workspace Integration**:
   - Integrated `computeAdaptive` into `ResultsTab.onSelectionValuesChanged`.

3. **Testing**:
   - Added unit tests for `computeAdaptive` (empty list, synchronous threshold, background isolate) in `test/features/workspace/data_grid_engines_test.dart`.
   - All 186 workspace and feature tests pass; `flutter analyze` reports 0 issues.

Closes #652