### PR TITLE
fix(sqlite): configure busy_timeout on SQLite connections

### DIFF
--- a/lib/core/database/sqlite_connection.dart
+++ b/lib/core/database/sqlite_connection.dart
@@ -45,6 +45,7 @@ class SqliteConnection {
         options: OpenDatabaseOptions(
           readOnly: readOnly,
           onOpen: (db) async {
+            await db.execute('PRAGMA busy_timeout = 5000');
             if (!readOnly) {
               await db.execute('PRAGMA foreign_keys = ON');
             }

--- a/test/core/database/sqlite_connection_test.dart
+++ b/test/core/database/sqlite_connection_test.dart
@@ -69,6 +69,13 @@ void main() {
       expect(conn.isConnected, false);
     });
 
+    test('configures PRAGMA busy_timeout to 5000 on connection open', () async {
+      await conn.connect();
+      final res = await conn.execute('PRAGMA busy_timeout');
+      expect(res, isNotEmpty);
+      expect(res.first['timeout'], 5000);
+    });
+
     test('testConnection connects, queries and cleans up', () async {
       final ok = await conn.testConnection();
       expect(ok, true);


### PR DESCRIPTION
## Description

Resolves #656 by configuring `PRAGMA busy_timeout = 5000;` on SQLite connections:

1. **Lock Resilience**:
   - Added `PRAGMA busy_timeout = 5000;` to the `onOpen` callback in `SqliteConnection.connect()`.
   - Prevents immediate `DatabaseException(database is locked / SQLITE_BUSY)` failures when the SQLite file is concurrently accessed by background threads, file watchers, or other processes.

2. **Testing**:
   - Added unit test in `test/core/database/sqlite_connection_test.dart` verifying that `PRAGMA busy_timeout` returns 5000 on connection open.
   - All tests pass with 0 analyze warnings.

Closes #656