### PR TITLE
fix(redis): guard disconnect against null check operator exceptions on uninitialized socket close

### DIFF
--- a/lib/core/database/redis_connection.dart
+++ b/lib/core/database/redis_connection.dart
@@ -123,7 +123,9 @@ class RedisConnection {
     }
     final result = await _command!.send_object(['PING']);
     if (result == null || result.toString().toUpperCase() != 'PONG') {
-      await _conn?.close();
+      try {
+        await _conn?.close();
+      } catch (_) {}
       _conn = null;
       _command = null;
       throw RedisConnectionException('PING failed');
@@ -133,16 +135,23 @@ class RedisConnection {
   }
 
   Future<void> disconnect() async {
+    final wasConnected = _isConnected;
     _isConnected = false;
     _command = null;
     final c = _conn;
     _conn = null;
-    try {
-      await c?.close();
-    } catch (e) {
-      debugPrint('RedisConnection.disconnect: $e');
+    if (c != null && wasConnected) {
+      try {
+        await c.close();
+      } catch (e) {
+        if (e is! TypeError && !e.toString().contains('Null check operator')) {
+          debugPrint('RedisConnection.disconnect: $e');
+        }
+      }
     }
   }
+
+  Future<void> forceClose() => disconnect();
 
   Future<String> info() async {
     if (!isConnected || _command == null) {
@@ -464,10 +473,10 @@ class RedisConnectionTestFake extends RedisConnection {
     final c = _conn;
     _conn = null;
     _command = null;
-    try {
-      await c?.close();
-    } catch (e) {
-      debugPrint('RedisConnection.disconnect: $e');
+    if (c != null) {
+      try {
+        await c.close();
+      } catch (_) {}
     }
   }
 

--- a/test/core/database/redis_connection_test.dart
+++ b/test/core/database/redis_connection_test.dart
@@ -82,6 +82,16 @@ void main() {
       await conn.disconnect();
       expect(conn.isConnected, false);
     });
+
+    test('forceClose delegates to disconnect cleanly', () async {
+      final conn = RedisConnection(
+        id: 1,
+        name: 'test',
+        host: 'localhost',
+      );
+      await conn.forceClose();
+      expect(conn.isConnected, false);
+    });
   });
 
   group('RedisConnection.info', () {


### PR DESCRIPTION
## Description

Resolves #657 by guarding `RedisConnection.disconnect()` against internal socket null-assertions:

1. **Idempotent & Safe Disconnect**:
   - Guarded `close()` calls in `RedisConnection.disconnect()` and `FakeRedisConnection.disconnect()`.
   - Prevents `Null check operator used on a null value` exceptions when closing uninitialized or already-closed Redis connections.
   - Added `forceClose()` method on `RedisConnection`.

2. **Testing**:
   - Added unit test `forceClose delegates to disconnect cleanly` in `test/core/database/redis_connection_test.dart`.
   - Verified that all Redis unit tests pass cleanly with zero console warnings.

Closes #657