### PR TITLE
perf(workspace): harden memory lifecycle, staging buffer disposal, and grid row cache cleanup

### DIFF
--- a/lib/features/extensions/extension_table_view.dart
+++ b/lib/features/extensions/extension_table_view.dart
@@ -124,6 +124,7 @@ class _ExtensionTableViewState extends material.State<ExtensionTableView> {
       _totalRows = null;
       _filterController.clear();
       _filterActive = false;
+      _stagingBuffer?.dispose();
       _stagingBuffer = null;
       unawaited(_loadPage(refreshCount: true));
     }
@@ -131,6 +132,8 @@ class _ExtensionTableViewState extends material.State<ExtensionTableView> {
 
   @override
   void dispose() {
+    _stagingBuffer?.dispose();
+    _stagingBuffer = null;
     _filterController.dispose();
     super.dispose();
   }
@@ -208,6 +211,7 @@ class _ExtensionTableViewState extends material.State<ExtensionTableView> {
         _columns = dataResult.columns;
         _rows = dataResult.rows;
         _loading = false;
+        _stagingBuffer?.dispose();
         if (!widget.isView && (_capabilities?.supportsMutations == true)) {
           _stagingBuffer =
               DataGridStagingBuffer(columns: _columns, rows: _rows);

--- a/lib/features/mysql/mysql_sql_workspace.dart
+++ b/lib/features/mysql/mysql_sql_workspace.dart
@@ -149,6 +149,8 @@ class _MysqlSqlWorkspaceState extends material.State<MysqlSqlWorkspace> {
       );
     }
     _lease?.release();
+    _stagingBuffer?.dispose();
+    _stagingBuffer = null;
     _sqlController.dispose();
     super.dispose();
   }
@@ -244,6 +246,7 @@ class _MysqlSqlWorkspaceState extends material.State<MysqlSqlWorkspace> {
         _rows = outRows;
         _affectedRows = affected;
         _lastExecutedSql = userSql;
+        _stagingBuffer?.dispose();
         _stagingBuffer = cols.isNotEmpty
             ? DataGridStagingBuffer(columns: cols, rows: outRows)
             : null;
@@ -325,8 +328,10 @@ class _MysqlSqlWorkspaceState extends material.State<MysqlSqlWorkspace> {
       }
 
       if (!mounted) return;
+      final newRows = _stagingBuffer!.effectiveRows;
+      _stagingBuffer?.dispose();
       setState(() {
-        _rows = _stagingBuffer!.effectiveRows;
+        _rows = newRows;
         _stagingBuffer = DataGridStagingBuffer(columns: _columns, rows: _rows);
         _savingChanges = false;
       });

--- a/lib/features/postgresql/postgres_sql_workspace.dart
+++ b/lib/features/postgresql/postgres_sql_workspace.dart
@@ -296,6 +296,8 @@ class _PostgresSqlWorkspaceState extends material.State<PostgresSqlWorkspace> {
       );
     }
     _dropLease();
+    _stagingBuffer?.dispose();
+    _stagingBuffer = null;
     _sqlController.dispose();
     super.dispose();
   }
@@ -388,6 +390,7 @@ class _PostgresSqlWorkspaceState extends material.State<PostgresSqlWorkspace> {
         _rows = outRows;
         _affectedRows = result.affectedRows;
         _lastExecutedSql = userSql;
+        _stagingBuffer?.dispose();
         _stagingBuffer = cols.isNotEmpty
             ? DataGridStagingBuffer(columns: cols, rows: outRows)
             : null;
@@ -478,8 +481,10 @@ class _PostgresSqlWorkspaceState extends material.State<PostgresSqlWorkspace> {
       await conn.execute(txSql, timeout: to);
 
       if (!mounted) return;
+      final newRows = _stagingBuffer!.effectiveRows;
+      _stagingBuffer?.dispose();
       setState(() {
-        _rows = _stagingBuffer!.effectiveRows;
+        _rows = newRows;
         _stagingBuffer = DataGridStagingBuffer(columns: _columns, rows: _rows);
         _savingChanges = false;
       });

--- a/lib/features/sqlite/sqlite_sql_workspace.dart
+++ b/lib/features/sqlite/sqlite_sql_workspace.dart
@@ -125,6 +125,8 @@ class _SqliteSqlWorkspaceState extends material.State<SqliteSqlWorkspace> {
         .removeListener(_appSettingsListener);
     _topFraction.dispose();
     _lease?.release();
+    _stagingBuffer?.dispose();
+    _stagingBuffer = null;
     _sqlController.dispose();
     super.dispose();
   }
@@ -206,6 +208,7 @@ class _SqliteSqlWorkspaceState extends material.State<SqliteSqlWorkspace> {
         _rows = outRows;
         _affectedRows = null;
         _lastExecutedSql = userSql;
+        _stagingBuffer?.dispose();
         _stagingBuffer = cols.isNotEmpty
             ? DataGridStagingBuffer(columns: cols, rows: outRows)
             : null;
@@ -285,8 +288,10 @@ class _SqliteSqlWorkspaceState extends material.State<SqliteSqlWorkspace> {
       }
 
       if (!mounted) return;
+      final newRows = _stagingBuffer!.effectiveRows;
+      _stagingBuffer?.dispose();
       setState(() {
-        _rows = _stagingBuffer!.effectiveRows;
+        _rows = newRows;
         _stagingBuffer = DataGridStagingBuffer(columns: _columns, rows: _rows);
         _savingChanges = false;
       });

--- a/lib/features/workspace/data_grid_staging_buffer.dart
+++ b/lib/features/workspace/data_grid_staging_buffer.dart
@@ -315,5 +315,13 @@ class DataGridStagingBuffer extends ChangeNotifier {
     }
     return result;
   }
+
+  @override
+  void dispose() {
+    _modifiedCells.clear();
+    _insertedRows.clear();
+    _deletedRowIndices.clear();
+    super.dispose();
+  }
 }
 

--- a/lib/features/workspace/result_grid_view.dart
+++ b/lib/features/workspace/result_grid_view.dart
@@ -470,6 +470,9 @@ class _VirtualResultGridState extends material.State<VirtualResultGrid> {
     _horizontalController.dispose();
     _verticalController.dispose();
     _focusNode.dispose();
+    _sortedRows = const [];
+    _columnWidths = const [];
+    _columnOffsets = const [0];
     super.dispose();
   }
 

--- a/lib/features/workspace/results_tab.dart
+++ b/lib/features/workspace/results_tab.dart
@@ -102,6 +102,14 @@ class _ResultsTabState extends material.State<ResultsTab> {
   }
 
   @override
+  void dispose() {
+    _memoColumns = null;
+    _memoEffectiveRows = null;
+    _cachedFilteredRows = const [];
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return QueryaFadeSlide(
       alignment: material.Alignment.center,

--- a/test/features/workspace/data_grid_staging_buffer_test.dart
+++ b/test/features/workspace/data_grid_staging_buffer_test.dart
@@ -154,5 +154,22 @@ void main() {
       expect(plan.statements[2].type, MutationType.delete);
       expect(plan.statements[2].sql, 'DELETE FROM "public"."users" WHERE "id" = 3');
     });
+
+    test('dispose clears internal collections and prevents further listener notifications', () {
+      buffer.setCell(0, 1, 'Alice Modified');
+      buffer.addRow(['4', 'Diana', 'diana@test.com']);
+      buffer.toggleDeleteRow(2);
+
+      expect(buffer.isDirty, isTrue);
+      expect(buffer.changeCount, 3);
+
+      buffer.dispose();
+
+      expect(buffer.isDirty, isFalse);
+      expect(buffer.changeCount, 0);
+      expect(buffer.modifiedCellCount, 0);
+      expect(buffer.insertedRowCount, 0);
+      expect(buffer.deletedRowCount, 0);
+    });
   });
 }


### PR DESCRIPTION
Closes #670

### Summary of Changes
- **`DataGridStagingBuffer`**: Implemented explicit `dispose()` override that clears modified cells, inserted rows, and deleted row indices, immediately freeing heap allocations when staging is reset or discarded.
- **Workspaces (`PostgresSqlWorkspace`, `MysqlSqlWorkspace`, `SqliteSqlWorkspace`, `ExtensionTableView`)**:
  - Added explicit `_stagingBuffer?.dispose()` before allocating a new staging buffer on subsequent query executions, mutation saves, and table pagination.
  - Added clean disposal of `_stagingBuffer` in workspace `dispose()` lifecycle methods.
- **`ResultsTab`**: Added `dispose()` override in `_ResultsTabState` to unbind memoized filtered rows (`_cachedFilteredRows`, `_memoEffectiveRows`) upon unmounting.
- **`VirtualResultGrid`**: Added cache resets (`_sortedRows = const []`, `_columnWidths = const []`, `_columnOffsets = const [0]`) in `VirtualResultGridState.dispose()` to immediately release large matrix references to the GC.
- **Unit Tests**: Added test in `data_grid_staging_buffer_test.dart` validating that `dispose()` clears internal collections and resets change tracking.