### PR TITLE
feat(workspace): adaptive content-aware column sizing and header double-click auto-fit (close #676)

### DIFF
--- a/lib/features/workspace/result_grid_view.dart
+++ b/lib/features/workspace/result_grid_view.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart' as material;
 import 'package:flutter/services.dart'
     show Clipboard, ClipboardData, HardwareKeyboard, LogicalKeyboardKey;
@@ -12,7 +14,7 @@ import 'package:shadcn_flutter/shadcn_flutter.dart';
 abstract final class ResultGridMetrics {
   static const double rowHeight = 36;
   static const double headerHeight = 36;
-  static const double minColumnWidth = 120;
+  static const double minColumnWidth = 56;
   static const double maxColumnWidth = 280;
   static const int columnWidthSampleRows = 40;
   static const int tooltipMinLength = 48;
@@ -82,15 +84,111 @@ List<double> computeResultGridColumnWidths({
   final sample = rows.length < sampleRowCount ? rows.length : sampleRowCount;
 
   for (var c = 0; c < columns.length; c++) {
-    var maxChars = columns[c].length;
+    final headerWidth = columns[c].length * 7.5 + 38.0;
+    var maxRowChars = 0;
     for (var r = 0; r < sample; r++) {
-      if (c < rows[r].length && rows[r][c].length > maxChars) {
-        maxChars = rows[r][c].length;
+      if (c < rows[r].length && rows[r][c].length > maxRowChars) {
+        maxRowChars = rows[r][c].length;
       }
     }
-    widths[c] = (maxChars * 7.5 + 24).clamp(minWidth, maxWidth);
+    final contentWidth = maxRowChars * 7.5 + 24.0;
+    final naturalWidth = math.max(headerWidth, contentWidth);
+    widths[c] = naturalWidth.clamp(minWidth, maxWidth);
   }
   return widths;
+}
+
+/// Distributes spare viewport width adaptively to columns that benefit from expansion,
+/// avoiding artificial stretching of compact columns.
+List<double> distributeResultGridSpareWidth({
+  required List<double> columnWidths,
+  required List<String> columns,
+  required List<List<String>> rows,
+  required double availableWidth,
+  double maxColumnWidth = ResultGridMetrics.maxColumnWidth,
+  int sampleRowCount = ResultGridMetrics.columnWidthSampleRows,
+}) {
+  if (columnWidths.isEmpty || columns.isEmpty) return columnWidths;
+
+  final totalInitial = columnWidths.fold<double>(0.0, (sum, w) => sum + w);
+  final spare = availableWidth - totalInitial;
+  if (spare <= 0.5) return columnWidths;
+
+  final sample = rows.length < sampleRowCount ? rows.length : sampleRowCount;
+  final desiredWidths = List<double>.filled(columns.length, 0);
+
+  for (var c = 0; c < columns.length; c++) {
+    final headerWidth = columns[c].length * 7.5 + 38.0;
+    var maxRowChars = 0;
+    for (var r = 0; r < sample; r++) {
+      if (c < rows[r].length && rows[r][c].length > maxRowChars) {
+        maxRowChars = rows[r][c].length;
+      }
+    }
+    final contentWidth = maxRowChars * 7.5 + 24.0;
+    desiredWidths[c] = math.max(headerWidth, contentWidth);
+  }
+
+  // Deficit columns: columns whose desired width exceeds the clamped initial width
+  final deficits = List<double>.filled(columns.length, 0);
+  var totalDeficit = 0.0;
+  for (var c = 0; c < columns.length; c++) {
+    if (desiredWidths[c] > columnWidths[c]) {
+      final def = desiredWidths[c] - columnWidths[c];
+      deficits[c] = def;
+      totalDeficit += def;
+    }
+  }
+
+  final result = List<double>.from(columnWidths);
+
+  if (totalDeficit > 0) {
+    if (spare <= totalDeficit) {
+      final ratio = spare / totalDeficit;
+      for (var c = 0; c < columns.length; c++) {
+        if (deficits[c] > 0) {
+          result[c] += deficits[c] * ratio;
+        }
+      }
+      return result;
+    } else {
+      for (var c = 0; c < columns.length; c++) {
+        if (deficits[c] > 0) {
+          result[c] += deficits[c];
+        }
+      }
+      final remainingSpare = spare - totalDeficit;
+      _distributeRemainingSpare(result, remainingSpare);
+      return result;
+    }
+  } else {
+    _distributeRemainingSpare(result, spare);
+    return result;
+  }
+}
+
+void _distributeRemainingSpare(List<double> widths, double spare) {
+  final weights = List<double>.filled(widths.length, 0);
+  var totalWeight = 0.0;
+  for (var i = 0; i < widths.length; i++) {
+    if (widths[i] > 110) {
+      final w = widths[i] - 100;
+      weights[i] = w;
+      totalWeight += w;
+    }
+  }
+
+  if (totalWeight <= 0) {
+    return;
+  }
+
+  final ratio = spare / totalWeight;
+  for (var i = 0; i < widths.length; i++) {
+    if (weights[i] > 0) {
+      final extra = math.min(weights[i] * ratio, 120.0);
+      widths[i] += extra;
+    }
+  }
 }
 
 /// Prefix sums: `offsets[i]` = sum of widths `[0, i)`.
@@ -630,6 +728,36 @@ class _VirtualResultGridState extends material.State<VirtualResultGrid> {
       final newWidth = (_columnWidths[index] + delta).clamp(minWidth, maxWidth);
       _columnWidths = List<double>.from(_columnWidths);
       _columnWidths[index] = newWidth;
+      _columnOffsets = computeResultGridColumnOffsets(_columnWidths);
+      _widthsNeedUpdate = false;
+    });
+  }
+
+  void _onColumnAutoFit(int index) {
+    if (index < 0 ||
+        index >= widget.columns.length ||
+        index >= _columnWidths.length) {
+      return;
+    }
+    final headerWidth = widget.columns[index].length * 7.5 + 38.0;
+    var maxRowChars = 0;
+    final sampleCount = math.min(_baseRows.length, 200);
+    for (var r = 0; r < sampleCount; r++) {
+      if (index < _baseRows[r].length &&
+          _baseRows[r][index].length > maxRowChars) {
+        maxRowChars = _baseRows[r][index].length;
+      }
+    }
+    final contentWidth = maxRowChars * 7.5 + 24.0;
+    final naturalWidth = math.max(headerWidth, contentWidth);
+    final minWidth = context.scaled(ResultGridMetrics.minColumnWidth);
+    final maxWidth = context.scaled(ResultGridMetrics.maxColumnWidth * 3);
+    final autoFitWidth = naturalWidth.clamp(minWidth, maxWidth);
+
+    setState(() {
+      _userHasResized = true;
+      _columnWidths = List<double>.from(_columnWidths);
+      _columnWidths[index] = autoFitWidth;
       _columnOffsets = computeResultGridColumnOffsets(_columnWidths);
       _widthsNeedUpdate = false;
     });
@@ -1225,10 +1353,17 @@ class _VirtualResultGridState extends material.State<VirtualResultGrid> {
               if (!_userHasResized &&
                   tableWidth < availableWidth &&
                   _columnWidths.isNotEmpty) {
-                final extraPerCol =
-                    (availableWidth - tableWidth) / _columnWidths.length;
-                displayWidths = [for (final w in _columnWidths) w + extraPerCol];
-                tableWidth = availableWidth;
+                displayWidths = distributeResultGridSpareWidth(
+                  columnWidths: _columnWidths,
+                  columns: widget.columns,
+                  rows: _baseRows,
+                  availableWidth: availableWidth,
+                  maxColumnWidth:
+                      context.scaled(ResultGridMetrics.maxColumnWidth),
+                );
+                final distributedWidth =
+                    displayWidths.fold<double>(0.0, (sum, w) => sum + w);
+                tableWidth = math.max(distributedWidth, availableWidth);
               } else if (tableWidth < availableWidth) {
                 tableWidth = availableWidth;
               }
@@ -1257,6 +1392,7 @@ class _VirtualResultGridState extends material.State<VirtualResultGrid> {
                           sortOrder: _sortOrder,
                           onSortColumn: _toggleSort,
                           onResizeColumn: _onColumnResize,
+                          onAutoFitColumn: _onColumnAutoFit,
                         ),
                         material.Expanded(
                           child: material.Scrollbar(
@@ -1316,6 +1452,7 @@ class _HeaderRow extends material.StatelessWidget {
     this.sortOrder,
     this.onSortColumn,
     this.onResizeColumn,
+    this.onAutoFitColumn,
   });
 
   final List<String> columns;
@@ -1327,6 +1464,7 @@ class _HeaderRow extends material.StatelessWidget {
   final ResultGridSortOrder? sortOrder;
   final material.ValueChanged<int>? onSortColumn;
   final void Function(int index, double delta)? onResizeColumn;
+  final void Function(int index)? onAutoFitColumn;
 
   @override
   material.Widget build(material.BuildContext context) {
@@ -1354,6 +1492,9 @@ class _HeaderRow extends material.StatelessWidget {
               onResize: onResizeColumn != null
                   ? (delta) => onResizeColumn!(i, delta)
                   : null,
+              onAutoFit: onAutoFitColumn != null
+                  ? () => onAutoFitColumn!(i)
+                  : null,
             ),
           if (window.trailingWidth > 0)
             material.SizedBox(width: window.trailingWidth),
@@ -1371,6 +1512,7 @@ class _HeaderCell extends material.StatelessWidget {
     this.sortOrder,
     this.onSort,
     this.onResize,
+    this.onAutoFit,
   });
 
   final String text;
@@ -1379,6 +1521,7 @@ class _HeaderCell extends material.StatelessWidget {
   final ResultGridSortOrder? sortOrder;
   final material.VoidCallback? onSort;
   final material.ValueChanged<double>? onResize;
+  final material.VoidCallback? onAutoFit;
 
   @override
   material.Widget build(material.BuildContext context) {
@@ -1415,11 +1558,15 @@ class _HeaderCell extends material.StatelessWidget {
                   child: material.Row(
                     children: [
                       material.Expanded(
-                        child: material.Text(
-                          text,
-                          style: style,
-                          overflow: material.TextOverflow.ellipsis,
-                          maxLines: 1,
+                        child: material.Tooltip(
+                          message: text,
+                          waitDuration: kQueryaTooltipWait,
+                          child: material.Text(
+                            text,
+                            style: style,
+                            overflow: material.TextOverflow.ellipsis,
+                            maxLines: 1,
+                          ),
                         ),
                       ),
                       if (sortOrder != null) ...[
@@ -1438,19 +1585,20 @@ class _HeaderCell extends material.StatelessWidget {
               ),
             ),
           ),
-          if (onResize != null)
+          if (onResize != null || onAutoFit != null)
             material.Positioned(
-              right: -4,
+              right: -5,
               top: 0,
               bottom: 0,
-              width: 10,
+              width: 12,
               child: material.MouseRegion(
                 cursor: material.SystemMouseCursors.resizeColumn,
                 child: material.GestureDetector(
                   behavior: material.HitTestBehavior.translucent,
-                  onHorizontalDragUpdate: (details) {
-                    onResize!(details.delta.dx);
-                  },
+                  onDoubleTap: onAutoFit,
+                  onHorizontalDragUpdate: onResize != null
+                      ? (details) => onResize!(details.delta.dx)
+                      : null,
                 ),
               ),
             ),

--- a/test/features/workspace/results_tab_test.dart
+++ b/test/features/workspace/results_tab_test.dart
@@ -61,6 +61,87 @@ void main() {
       ).single;
       expect(long, greaterThan(short));
     });
+
+    test(
+        'computes compact width for short columns like id and app_id below 100px',
+        () {
+      final widths = computeResultGridColumnWidths(
+        columns: const ['id', 'app_id'],
+        rows: [
+          ['1', '292030'],
+          ['2', '292031'],
+        ],
+      );
+      expect(widths, hasLength(2));
+      expect(widths[0], lessThanOrEqualTo(60));
+      expect(widths[1], lessThan(100));
+    });
+  });
+
+  group('distributeResultGridSpareWidth', () {
+    test(
+        'allocates spare width to deficit column and keeps compact column untouched',
+        () {
+      final columns = ['app_id', 'country', 'description'];
+      final rows = [
+        ['292030', 'kz', 'x' * 100],
+      ];
+      final initialWidths = computeResultGridColumnWidths(
+        columns: columns,
+        rows: rows,
+      );
+      expect(initialWidths[0], lessThan(100));
+      expect(initialWidths[2], equals(280.0));
+
+      final distributed = distributeResultGridSpareWidth(
+        columnWidths: initialWidths,
+        columns: columns,
+        rows: rows,
+        availableWidth: 1000.0,
+      );
+
+      // app_id must not be stretched
+      expect(distributed[0], equals(initialWidths[0]));
+      // country must not be stretched
+      expect(distributed[1], equals(initialWidths[1]));
+      // description should receive spare width to show more content
+      expect(distributed[2], greaterThan(280.0));
+    });
+
+    test('does not bloat compact columns when all columns already fit', () {
+      final columns = ['id', 'code', 'status'];
+      final rows = [
+        ['1', 'kz', 'active'],
+      ];
+      final initialWidths = computeResultGridColumnWidths(
+        columns: columns,
+        rows: rows,
+      );
+
+      final distributed = distributeResultGridSpareWidth(
+        columnWidths: initialWidths,
+        columns: columns,
+        rows: rows,
+        availableWidth: 1200.0,
+      );
+
+      expect(distributed[0], equals(initialWidths[0]));
+      expect(distributed[1], equals(initialWidths[1]));
+      expect(distributed[2], equals(initialWidths[2]));
+    });
+
+    test('returns original widths when availableWidth <= total initial width', () {
+      final initial = [80.0, 120.0, 200.0];
+      final result = distributeResultGridSpareWidth(
+        columnWidths: initial,
+        columns: const ['a', 'b', 'c'],
+        rows: const [
+          ['1', '2', '3'],
+        ],
+        availableWidth: 350.0,
+      );
+      expect(result, equals(initial));
+    });
   });
 
   group('sortResultGridRows', () {
@@ -700,6 +781,50 @@ void main() {
       // Column headers and rows remain stable and rendered
       expect(find.text('alice'), findsOneWidget);
       expect(find.text('bob'), findsOneWidget);
+    });
+
+    testWidgets(
+        'allows auto-fitting column width on header divider double-tap',
+        (tester) async {
+      await tester.pumpWidget(
+        resultsShell(
+          child: const material.Scaffold(
+            body: material.SizedBox(
+              width: 800,
+              height: 400,
+              child: VirtualResultGrid(
+                columns: ['id', 'summary'],
+                rows: [
+                  ['1', 'A short summary'],
+                  [
+                    '2',
+                    'An extraordinarily long text payload that definitely requires more space to view completely'
+                  ],
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final resizeRegions = find.byWidgetPredicate(
+        (w) =>
+            w is material.MouseRegion &&
+            w.cursor == material.SystemMouseCursors.resizeColumn,
+      );
+      expect(resizeRegions, findsNWidgets(2));
+
+      // Double-tap the second column's divider handle to trigger auto-fit
+      final secondHandle = resizeRegions.at(1);
+      final center = tester.getCenter(secondHandle);
+      await tester.tapAt(center);
+      await tester.pump(const Duration(milliseconds: 50));
+      await tester.tapAt(center);
+      await tester.pumpAndSettle();
+
+      expect(find.text('id'), findsOneWidget);
+      expect(find.text('summary'), findsOneWidget);
     });
 
     testWidgets('allows sorting by clicking column headers in VirtualResultGrid',


### PR DESCRIPTION
## Summary
- Closes #676.
- Resolves issue where short columns (e.g. `app_id`, `country`, numeric IDs) were forced to 120px and uniformly inflated when table width was less than viewport width.
- Lowered baseline `minColumnWidth` from 120 to 56px with dynamic header + content bounds.
- Added `distributeResultGridSpareWidth` to allocate spare viewport space to deficit/truncated columns rather than uniformly inflating compact columns.
- Implemented double-click auto-fit on column divider resize handles to compute full content/header width.
- Added `material.Tooltip` on header cells for long column names.
- Added unit tests for compact widths and spare width distribution, plus widget test for auto-fit double tap.