### PR TITLE
fix(ui): resolve workspace pane width overflow, sqlite dialog layout break, and responsive view issues (close #677)

### DIFF
--- a/lib/core/layout/window_layout.dart
+++ b/lib/core/layout/window_layout.dart
@@ -106,14 +106,16 @@ abstract class WindowLayout {
 
   /// Grid area width (right of sidebar, inner padding applied separately).
   static int dbTypeGridCrossAxisCount(double gridInnerWidth) {
-    if (gridInnerWidth >= 460) return 4;
-    if (gridInnerWidth >= 240) return 2;
+    if (gridInnerWidth >= 620) return 4;
+    if (gridInnerWidth >= 440) return 3;
+    if (gridInnerWidth >= 260) return 2;
     return 1;
   }
 
   static double dbTypeCardHeight(BuildContext context, int crossAxisCount) {
     final base = switch (crossAxisCount) {
       4 => 144.0,
+      3 => 140.0,
       2 => 138.0,
       _ => 132.0,
     };

--- a/lib/features/connections/new_connection_dialog.dart
+++ b/lib/features/connections/new_connection_dialog.dart
@@ -205,7 +205,6 @@ class _NewConnectionDialogContentState
                                   mainAxisSpacing: spacing,
                                   crossAxisSpacing: spacing,
                                   childAspectRatio: aspect.clamp(0.4, 4.0),
-                                  shrinkWrap: true,
                                   physics: const material.ClampingScrollPhysics(),
                                   children: [
                                     for (final t in _filteredTypes)

--- a/lib/features/connections/sqlite_connection_form.dart
+++ b/lib/features/connections/sqlite_connection_form.dart
@@ -183,9 +183,8 @@ class _SqliteConnectionFormContentState
   @override
   material.Widget build(material.BuildContext context) {
     final theme = context.colors;
-    final dialogMaxW = WindowLayout.newConnectionDialogMaxWidth(context);
+    const dialogMaxW = WindowLayout.connectionFormMaxWidth;
     final dialogH = WindowLayout.newConnectionDialogHeight(context);
-    final scrollH = dialogH - 120.0; // Subtract header and footer heights
 
     return material.SizedBox(
       width: dialogMaxW,
@@ -220,10 +219,7 @@ class _SqliteConnectionFormContentState
                 ),
               ),
               // Form body
-              material.ConstrainedBox(
-                constraints: material.BoxConstraints(
-                  maxHeight: scrollH,
-                ),
+              material.Flexible(
                 child: material.FocusTraversalGroup(
                   policy: material.WidgetOrderTraversalPolicy(),
                   child: material.SingleChildScrollView(

--- a/lib/features/extensions/extension_stats_view.dart
+++ b/lib/features/extensions/extension_stats_view.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math' as math;
 
 import 'package:flutter/material.dart' as material;
 import 'package:querya_desktop/core/extensions/extension_driver_session.dart';
@@ -124,7 +125,6 @@ class _ExtensionStatsViewState extends material.State<ExtensionStatsView> {
     );
 
     final cs = Theme.of(context).colorScheme;
-    final width = MediaQuery.sizeOf(context).width;
 
     if (_loading) {
       return material.Center(
@@ -178,28 +178,33 @@ class _ExtensionStatsViewState extends material.State<ExtensionStatsView> {
       color: cs.background,
       child: material.RefreshIndicator(
         onRefresh: _fetch,
-        child: material.SingleChildScrollView(
-          physics: const material.AlwaysScrollableScrollPhysics(),
-          padding: const material.EdgeInsets.all(24),
-          child: material.SizedBox(
-            width: width,
-            child: material.Column(
-              mainAxisSize: material.MainAxisSize.min,
-              crossAxisAlignment: material.CrossAxisAlignment.stretch,
-              children: [
-                _header(context),
-                const Gap(24),
-                _summaryChips(context, stats),
-                const Gap(24),
-                if (stats.databaseSizes.isNotEmpty) ...[
-                  _databasesCard(context, stats),
-                  const Gap(24),
-                ],
-                if (stats.extraMetrics.isNotEmpty)
-                  _extraMetricsCard(context, stats),
-              ],
-            ),
-          ),
+        child: material.LayoutBuilder(
+          builder: (context, constraints) {
+            final contentWidth = math.max(0.0, constraints.maxWidth - 48);
+            return material.SingleChildScrollView(
+              physics: const material.AlwaysScrollableScrollPhysics(),
+              padding: const material.EdgeInsets.all(24),
+              child: material.SizedBox(
+                width: contentWidth,
+                child: material.Column(
+                  mainAxisSize: material.MainAxisSize.min,
+                  crossAxisAlignment: material.CrossAxisAlignment.stretch,
+                  children: [
+                    _header(context),
+                    const Gap(24),
+                    _summaryChips(context, stats),
+                    const Gap(24),
+                    if (stats.databaseSizes.isNotEmpty) ...[
+                      _databasesCard(context, stats),
+                      const Gap(24),
+                    ],
+                    if (stats.extraMetrics.isNotEmpty)
+                      _extraMetricsCard(context, stats),
+                  ],
+                ),
+              ),
+            );
+          },
         ),
       ),
     );

--- a/lib/features/help/about_dialog.dart
+++ b/lib/features/help/about_dialog.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart' as material;
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:querya_desktop/core/app/external_link.dart';
 import 'package:querya_desktop/core/layout/window_layout.dart';
+import 'package:querya_desktop/core/ui/querya_icons.dart';
 import 'package:querya_desktop/shared/widgets/widgets.dart';
 
 /// Shows the About Querya dialog.
@@ -47,7 +48,7 @@ class _AboutDialogContentState extends material.State<_AboutDialogContent> {
             child: material.Column(
               children: [
                 material.Icon(
-                  material.Icons.search_rounded,
+                  QueryaIcons.database,
                   size: 48,
                   color: wb.accent,
                 ),

--- a/lib/features/mongodb/mongo_stats_view.dart
+++ b/lib/features/mongodb/mongo_stats_view.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math' as math;
 
 import 'package:flutter/material.dart' as material;
 import 'package:querya_desktop/core/motion/ticker_gated_polling.dart';
@@ -200,7 +201,6 @@ class _MongoStatsViewState extends material.State<MongoStatsView> {
     }
 
     final cs = Theme.of(context).colorScheme;
-    final width = MediaQuery.sizeOf(context).width;
 
     if (_loading) {
       return material.Center(
@@ -279,67 +279,73 @@ class _MongoStatsViewState extends material.State<MongoStatsView> {
       color: cs.background,
       child: material.RefreshIndicator(
         onRefresh: _refreshNow,
-        child: material.SingleChildScrollView(
-          physics: const material.AlwaysScrollableScrollPhysics(),
-          padding: const material.EdgeInsets.all(24),
-          child: material.SizedBox(
-            width: width,
-            child: material.Column(
-              mainAxisSize: material.MainAxisSize.min,
-              crossAxisAlignment: material.CrossAxisAlignment.stretch,
-              children: [
-                _header(context),
-                const Gap(24),
-                _summaryChips(context, status),
-                const Gap(24),
-                _gridRow(
-                  _memoryCard(context, status),
-                  _operationsCard(context, status),
-                ),
-                const Gap(16),
-                _gridRow(
-                  _connectionsCard(context, status),
-                  _networkCard(context, status),
-                ),
-                const Gap(24),
-                _sectionCard(context, 'Server', _extractServerInfo(status)),
-                const Gap(12),
-                material.LayoutBuilder(
-                  builder: (context, constraints) {
-                    final wide = constraints.maxWidth >= 900;
-                    final storage = _extractStorageInfo(status);
-                    final replication = _extractReplicationInfo(status);
-                    if (!wide) {
-                      return material.Column(
-                        crossAxisAlignment: material.CrossAxisAlignment.stretch,
-                        children: [
-                          _sectionCard(context, 'Storage', storage),
-                          const Gap(12),
-                          _sectionCard(context, 'Replication', replication),
-                        ],
-                      );
-                    }
-                    return material.Row(
-                      crossAxisAlignment: material.CrossAxisAlignment.start,
-                      children: [
-                        material.Expanded(
-                          child: _sectionCard(context, 'Storage', storage),
-                        ),
-                        const Gap(16),
-                        material.Expanded(
-                          child:
+        child: material.LayoutBuilder(
+          builder: (context, constraints) {
+            final contentWidth = math.max(0.0, constraints.maxWidth - 48);
+            return material.SingleChildScrollView(
+              physics: const material.AlwaysScrollableScrollPhysics(),
+              padding: const material.EdgeInsets.all(24),
+              child: material.SizedBox(
+                width: contentWidth,
+                child: material.Column(
+                  mainAxisSize: material.MainAxisSize.min,
+                  crossAxisAlignment: material.CrossAxisAlignment.stretch,
+                  children: [
+                    _header(context),
+                    const Gap(24),
+                    _summaryChips(context, status),
+                    const Gap(24),
+                    _gridRow(
+                      _memoryCard(context, status),
+                      _operationsCard(context, status),
+                    ),
+                    const Gap(16),
+                    _gridRow(
+                      _connectionsCard(context, status),
+                      _networkCard(context, status),
+                    ),
+                    const Gap(24),
+                    _sectionCard(context, 'Server', _extractServerInfo(status)),
+                    const Gap(12),
+                    material.LayoutBuilder(
+                      builder: (context, constraints) {
+                        final wide = constraints.maxWidth >= 900;
+                        final storage = _extractStorageInfo(status);
+                        final replication = _extractReplicationInfo(status);
+                        if (!wide) {
+                          return material.Column(
+                            crossAxisAlignment:
+                                material.CrossAxisAlignment.stretch,
+                            children: [
+                              _sectionCard(context, 'Storage', storage),
+                              const Gap(12),
                               _sectionCard(context, 'Replication', replication),
-                        ),
-                      ],
-                    );
-                  },
+                            ],
+                          );
+                        }
+                        return material.Row(
+                          crossAxisAlignment: material.CrossAxisAlignment.start,
+                          children: [
+                            material.Expanded(
+                              child: _sectionCard(context, 'Storage', storage),
+                            ),
+                            const Gap(16),
+                            material.Expanded(
+                              child:
+                                  _sectionCard(context, 'Replication', replication),
+                            ),
+                          ],
+                        );
+                      },
+                    ),
+                    const Gap(12),
+                    _sectionCard(
+                        context, 'WiredTiger', _extractWiredTigerInfo(status)),
+                  ],
                 ),
-                const Gap(12),
-                _sectionCard(
-                    context, 'WiredTiger', _extractWiredTigerInfo(status)),
-              ],
-            ),
-          ),
+              ),
+            );
+          },
         ),
       ),
     );

--- a/lib/features/mysql/mysql_stats_view.dart
+++ b/lib/features/mysql/mysql_stats_view.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math' as math;
 
 import 'package:flutter/material.dart' as material;
 import 'package:querya_desktop/core/motion/ticker_gated_polling.dart';
@@ -147,7 +148,6 @@ class _MysqlStatsViewState extends material.State<MysqlStatsView> {
     );
 
     final cs = Theme.of(context).colorScheme;
-    final width = MediaQuery.sizeOf(context).width;
 
     if (_loading) {
       return material.Center(
@@ -207,33 +207,41 @@ class _MysqlStatsViewState extends material.State<MysqlStatsView> {
       color: cs.background,
       child: material.RefreshIndicator(
         onRefresh: _fetch,
-        child: material.SingleChildScrollView(
-          physics: const material.AlwaysScrollableScrollPhysics(),
-          padding: const material.EdgeInsets.all(24),
-          child: material.SizedBox(
-            width: width,
-            child: material.Column(
-              mainAxisSize: material.MainAxisSize.min,
-              crossAxisAlignment: material.CrossAxisAlignment.stretch,
-              children: [
-                _header(context),
-                const Gap(24),
-                _summaryChips(context, stats),
-                const Gap(24),
-                _gridRow(
-                  _connectionsCard(context, stats),
-                  _queriesCard(context, stats),
+        child: material.LayoutBuilder(
+          builder: (context, constraints) {
+            final contentWidth = math.max(0.0, constraints.maxWidth - 48);
+            final isNarrow = contentWidth < 560;
+            return material.SingleChildScrollView(
+              physics: const material.AlwaysScrollableScrollPhysics(),
+              padding: const material.EdgeInsets.all(24),
+              child: material.SizedBox(
+                width: contentWidth,
+                child: material.Column(
+                  mainAxisSize: material.MainAxisSize.min,
+                  crossAxisAlignment: material.CrossAxisAlignment.stretch,
+                  children: [
+                    _header(context),
+                    const Gap(24),
+                    _summaryChips(context, stats),
+                    const Gap(24),
+                    _gridRow(
+                      _connectionsCard(context, stats),
+                      _queriesCard(context, stats),
+                      isNarrow: isNarrow,
+                    ),
+                    const Gap(16),
+                    _gridRow(
+                      _networkCard(context, stats),
+                      _settingsCard(context, stats),
+                      isNarrow: isNarrow,
+                    ),
+                    const Gap(24),
+                    _databasesCard(context, stats),
+                  ],
                 ),
-                const Gap(16),
-                _gridRow(
-                  _networkCard(context, stats),
-                  _settingsCard(context, stats),
-                ),
-                const Gap(24),
-                _databasesCard(context, stats),
-              ],
-            ),
-          ),
+              ),
+            );
+          },
         ),
       ),
     );
@@ -289,7 +297,21 @@ class _MysqlStatsViewState extends material.State<MysqlStatsView> {
     );
   }
 
-  material.Widget _gridRow(material.Widget left, material.Widget right) {
+  material.Widget _gridRow(
+    material.Widget left,
+    material.Widget right, {
+    bool isNarrow = false,
+  }) {
+    if (isNarrow) {
+      return material.Column(
+        crossAxisAlignment: material.CrossAxisAlignment.stretch,
+        children: [
+          left,
+          const Gap(16),
+          right,
+        ],
+      );
+    }
     return material.IntrinsicHeight(
       child: material.Row(
         crossAxisAlignment: material.CrossAxisAlignment.stretch,

--- a/lib/features/postgresql/postgres_stats_view.dart
+++ b/lib/features/postgresql/postgres_stats_view.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math' as math;
 
 import 'package:flutter/material.dart' as material;
 import 'package:querya_desktop/core/motion/ticker_gated_polling.dart';
@@ -164,7 +165,6 @@ class _PostgresStatsViewState extends material.State<PostgresStatsView> {
     );
 
     final cs = Theme.of(context).colorScheme;
-    final width = MediaQuery.sizeOf(context).width;
 
     if (_loading) {
       return material.Center(
@@ -218,33 +218,50 @@ class _PostgresStatsViewState extends material.State<PostgresStatsView> {
       color: cs.background,
       child: material.RefreshIndicator(
         onRefresh: _fetch,
-        child: material.SingleChildScrollView(
-          physics: const material.AlwaysScrollableScrollPhysics(),
-          padding: const material.EdgeInsets.all(24),
-          child: material.SizedBox(
-            width: width,
-            child: material.Column(
-              mainAxisSize: material.MainAxisSize.min,
-              crossAxisAlignment: material.CrossAxisAlignment.stretch,
-              children: [
-                _header(context),
-                const Gap(24),
-                _summaryChips(context, stats),
-                const Gap(24),
-                material.Row(
-                  crossAxisAlignment: material.CrossAxisAlignment.start,
+        child: material.LayoutBuilder(
+          builder: (context, constraints) {
+            final contentWidth = math.max(0.0, constraints.maxWidth - 48);
+            final isNarrow = contentWidth < 560;
+            return material.SingleChildScrollView(
+              physics: const material.AlwaysScrollableScrollPhysics(),
+              padding: const material.EdgeInsets.all(24),
+              child: material.SizedBox(
+                width: contentWidth,
+                child: material.Column(
+                  mainAxisSize: material.MainAxisSize.min,
+                  crossAxisAlignment: material.CrossAxisAlignment.stretch,
                   children: [
-                    material.Expanded(child: _connectionsCard(context, stats)),
+                    _header(context),
+                    const Gap(24),
+                    _summaryChips(context, stats),
+                    const Gap(24),
+                    if (isNarrow)
+                      material.Column(
+                        crossAxisAlignment: material.CrossAxisAlignment.stretch,
+                        children: [
+                          _connectionsCard(context, stats),
+                          const Gap(16),
+                          _serverSettingsCard(context, stats),
+                        ],
+                      )
+                    else
+                      material.Row(
+                        crossAxisAlignment: material.CrossAxisAlignment.start,
+                        children: [
+                          material.Expanded(
+                              child: _connectionsCard(context, stats)),
+                          const Gap(16),
+                          material.Expanded(
+                              child: _serverSettingsCard(context, stats)),
+                        ],
+                      ),
                     const Gap(16),
-                    material.Expanded(
-                        child: _serverSettingsCard(context, stats)),
+                    _databasesCard(context, stats),
                   ],
                 ),
-                const Gap(16),
-                _databasesCard(context, stats),
-              ],
-            ),
-          ),
+              ),
+            );
+          },
         ),
       ),
     );

--- a/lib/features/redis/redis_view.dart
+++ b/lib/features/redis/redis_view.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math' as math;
 
 import 'package:flutter/material.dart' as material;
 import 'package:querya_desktop/core/motion/ticker_gated_polling.dart';
@@ -177,7 +178,6 @@ class _RedisViewState extends material.State<RedisView> {
     );
 
     final cs = Theme.of(context).colorScheme;
-    final width = MediaQuery.sizeOf(context).width;
 
     if (_loading) {
       return material.Center(
@@ -256,33 +256,39 @@ class _RedisViewState extends material.State<RedisView> {
       color: cs.background,
       child: material.RefreshIndicator(
         onRefresh: _fetch,
-        child: material.SingleChildScrollView(
-          physics: const material.AlwaysScrollableScrollPhysics(),
-          padding: const material.EdgeInsets.all(24),
-          child: material.SizedBox(
-            width: width,
-            child: material.Column(
-              mainAxisSize: material.MainAxisSize.min,
-              crossAxisAlignment: material.CrossAxisAlignment.stretch,
-              children: [
-                _header(context),
-                const Gap(24),
-                _summaryChips(context, info),
-                const Gap(24),
-                _gridRow(
-                  _memoryCard(context, info),
-                  _statsCard(context, info),
-                ),
-                const Gap(16),
-                _gridRow(
-                  _cpuCard(context, info),
-                  _keyspaceCard(context, info),
-                ),
-                const Gap(24),
-                _sectionCard(context, 'Server', info['Server'], keys: const [
-                  'redis_version',
-                  'redis_mode',
-                  'os',
+        child: material.LayoutBuilder(
+          builder: (context, constraints) {
+            final contentWidth = math.max(0.0, constraints.maxWidth - 48);
+            final isNarrow = contentWidth < 560;
+            return material.SingleChildScrollView(
+              physics: const material.AlwaysScrollableScrollPhysics(),
+              padding: const material.EdgeInsets.all(24),
+              child: material.SizedBox(
+                width: contentWidth,
+                child: material.Column(
+                  mainAxisSize: material.MainAxisSize.min,
+                  crossAxisAlignment: material.CrossAxisAlignment.stretch,
+                  children: [
+                    _header(context),
+                    const Gap(24),
+                    _summaryChips(context, info),
+                    const Gap(24),
+                    _gridRow(
+                      _memoryCard(context, info),
+                      _statsCard(context, info),
+                      isNarrow: isNarrow,
+                    ),
+                    const Gap(16),
+                    _gridRow(
+                      _cpuCard(context, info),
+                      _keyspaceCard(context, info),
+                      isNarrow: isNarrow,
+                    ),
+                    const Gap(24),
+                    _sectionCard(context, 'Server', info['Server'], keys: const [
+                      'redis_version',
+                      'redis_mode',
+                      'os',
                   'tcp_port',
                   'uptime_in_days',
                   'config_file',
@@ -339,9 +345,11 @@ class _RedisViewState extends material.State<RedisView> {
               ],
             ),
           ),
-        ),
-      ),
-    );
+        );
+      },
+    ),
+  ),
+);
   }
 
   material.Widget _header(material.BuildContext context) {
@@ -390,7 +398,21 @@ class _RedisViewState extends material.State<RedisView> {
     );
   }
 
-  material.Widget _gridRow(material.Widget left, material.Widget right) {
+  material.Widget _gridRow(
+    material.Widget left,
+    material.Widget right, {
+    bool isNarrow = false,
+  }) {
+    if (isNarrow) {
+      return material.Column(
+        crossAxisAlignment: material.CrossAxisAlignment.stretch,
+        children: [
+          left,
+          const Gap(16),
+          right,
+        ],
+      );
+    }
     return material.IntrinsicHeight(
       child: material.Row(
         crossAxisAlignment: material.CrossAxisAlignment.stretch,

--- a/lib/features/sqlite/sqlite_overview_tab.dart
+++ b/lib/features/sqlite/sqlite_overview_tab.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:math' as math;
 
 import 'package:flutter/material.dart' as material;
 import 'package:querya_desktop/core/database/sqlite_connection.dart';
@@ -133,7 +134,6 @@ class _SqliteOverviewTabState extends material.State<SqliteOverviewTab> {
   @override
   material.Widget build(material.BuildContext context) {
     final cs = Theme.of(context).colorScheme;
-    final width = material.MediaQuery.sizeOf(context).width;
 
     if (_loading && _overview == null) {
       return material.Center(
@@ -195,23 +195,29 @@ class _SqliteOverviewTabState extends material.State<SqliteOverviewTab> {
       color: cs.background,
       child: material.RefreshIndicator(
         onRefresh: _fetch,
-        child: material.SingleChildScrollView(
-          physics: const material.AlwaysScrollableScrollPhysics(),
-          padding: const material.EdgeInsets.all(24),
-          child: material.SizedBox(
-            width: width,
-            child: material.Column(
-              mainAxisSize: material.MainAxisSize.min,
-              crossAxisAlignment: material.CrossAxisAlignment.stretch,
-              children: [
-                _header(context),
-                const Gap(24),
-                _summaryChips(context, versionStr, sizeStr, journalStr, pageCount, pageSize),
-                const Gap(24),
-                _tablesCard(context),
-              ],
-            ),
-          ),
+        child: material.LayoutBuilder(
+          builder: (context, constraints) {
+            final contentWidth = math.max(0.0, constraints.maxWidth - 48);
+            return material.SingleChildScrollView(
+              physics: const material.AlwaysScrollableScrollPhysics(),
+              padding: const material.EdgeInsets.all(24),
+              child: material.SizedBox(
+                width: contentWidth,
+                child: material.Column(
+                  mainAxisSize: material.MainAxisSize.min,
+                  crossAxisAlignment: material.CrossAxisAlignment.stretch,
+                  children: [
+                    _header(context),
+                    const Gap(24),
+                    _summaryChips(context, versionStr, sizeStr, journalStr,
+                        pageCount, pageSize),
+                    const Gap(24),
+                    _tablesCard(context),
+                  ],
+                ),
+              ),
+            );
+          },
         ),
       ),
     );

--- a/test/core/layout/window_layout_scale_test.dart
+++ b/test/core/layout/window_layout_scale_test.dart
@@ -53,4 +53,16 @@ void main() {
       ),
     );
   });
+
+  test(
+      'dbTypeGridCrossAxisCount returns correct column counts across thresholds',
+      () {
+    expect(WindowLayout.dbTypeGridCrossAxisCount(700), 4);
+    expect(WindowLayout.dbTypeGridCrossAxisCount(620), 4);
+    expect(WindowLayout.dbTypeGridCrossAxisCount(600), 3);
+    expect(WindowLayout.dbTypeGridCrossAxisCount(440), 3);
+    expect(WindowLayout.dbTypeGridCrossAxisCount(300), 2);
+    expect(WindowLayout.dbTypeGridCrossAxisCount(260), 2);
+    expect(WindowLayout.dbTypeGridCrossAxisCount(200), 1);
+  });
 }

--- a/test/features/connections/sqlite_connection_form_test.dart
+++ b/test/features/connections/sqlite_connection_form_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart' as material;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:querya_desktop/core/storage/local_db.dart';
+import 'package:querya_desktop/core/theme/app_theme.dart';
+import 'package:querya_desktop/features/connections/sqlite_connection_form.dart';
+import 'package:shadcn_flutter/shadcn_flutter.dart';
+
+void main() {
+  group('showSqliteConnectionForm', () {
+    testWidgets('dialog shows SQLite Connection title and controls without overflow',
+        (tester) async {
+      await tester.binding.setSurfaceSize(const Size(800, 600));
+      await tester.pumpWidget(
+        ShadcnApp(
+          theme: AppTheme.dark,
+          darkTheme: AppTheme.dark,
+          themeMode: ThemeMode.dark,
+          home: material.Builder(
+            builder: (context) => material.ElevatedButton(
+              onPressed: () => showSqliteConnectionForm(context),
+              child: const material.Text('Open SQLite Form'),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Open SQLite Form'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('New SQLite Connection'), findsOneWidget);
+      expect(find.text('Connection name'), findsOneWidget);
+      expect(find.text('Database file path'), findsOneWidget);
+      expect(find.text('Test Connection'), findsOneWidget);
+      expect(find.text('Cancel'), findsOneWidget);
+      expect(find.text('Save'), findsOneWidget);
+
+      // Verify no RenderFlex overflow
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('dialog opens in edit mode when initial connection row is provided',
+        (tester) async {
+      await tester.binding.setSurfaceSize(const Size(800, 600));
+      final conn = ConnectionRow(
+        id: 1,
+        name: 'My Cache',
+        type: 'sqlite',
+        databaseName: '/tmp/test.db',
+        createdAt: DateTime.now().toIso8601String(),
+      );
+
+      await tester.pumpWidget(
+        ShadcnApp(
+          theme: AppTheme.dark,
+          darkTheme: AppTheme.dark,
+          themeMode: ThemeMode.dark,
+          home: material.Builder(
+            builder: (context) => material.ElevatedButton(
+              onPressed: () =>
+                  showSqliteConnectionForm(context, initial: conn),
+              child: const material.Text('Edit SQLite Form'),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Edit SQLite Form'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Edit SQLite Connection'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+  });
+}

--- a/test/features/help/about_dialog_test.dart
+++ b/test/features/help/about_dialog_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart' as material;
 import 'package:flutter_test/flutter_test.dart';
+import 'package:querya_desktop/core/ui/querya_icons.dart';
 import 'package:querya_desktop/features/help/about_dialog.dart';
 
 import '../../support/querya_theme_test_shell.dart';
@@ -22,6 +23,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Querya'), findsOneWidget);
+      expect(find.byIcon(QueryaIcons.database), findsOneWidget);
       expect(find.textContaining('Version'), findsOneWidget);
       expect(find.text('Licensed under the MIT License.'), findsOneWidget);
       expect(find.text('View repository'), findsOneWidget);


### PR DESCRIPTION
### Summary of Changes

Closes #677.

- **Workspace Pane Horizontal Overflow**: Replaced hardcoded `MediaQuery.sizeOf(context).width` with container-aware `LayoutBuilder` in:
  - `lib/features/sqlite/sqlite_overview_tab.dart`
  - `lib/features/extensions/extension_stats_view.dart`
  - `lib/features/redis/redis_view.dart` (also added responsive vertical stacking for narrow widths)
  - `lib/features/mongodb/mongo_stats_view.dart`
  - `lib/features/postgresql/postgres_stats_view.dart` (responsive connection/settings grid)
  - `lib/features/mysql/mysql_stats_view.dart` (responsive card stacking)
- **SQLite Connection Dialog**:
  - Replaced rigid `ConstrainedBox(maxHeight: scrollH)` calculation with flex-based `Flexible(child: SingleChildScrollView(...))` preventing 70-80px bottom overflow during test banner display.
  - Normalized maxWidth to `WindowLayout.connectionFormMaxWidth`.
- **Database Type Picker Responsive Grid**:
  - Updated breakpoints in `WindowLayout.dbTypeGridCrossAxisCount` and card height to prevent text clipping on smaller screens.
- **About Dialog Branding**:
  - Replaced generic search icon (`Icons.search_rounded`) with product logo (`QueryaIcons.database`).
- **Tests**:
  - Added SQLite connection form layout tests under various window heights.
  - Added About dialog branding tests.
  - Updated responsive layout scale tests.