### PR TITLE
feat(editor): multi-tab query sessions in SQL workspace (close #679)

### DIFF
--- a/lib/core/actions/sql_editor_actions.dart
+++ b/lib/core/actions/sql_editor_actions.dart
@@ -11,3 +11,15 @@ class OpenSqlIntent extends Intent {
 class SaveSqlIntent extends Intent {
   const SaveSqlIntent();
 }
+
+class CloseSqlTabIntent extends Intent {
+  const CloseSqlTabIntent();
+}
+
+class NextSqlTabIntent extends Intent {
+  const NextSqlTabIntent();
+}
+
+class PrevSqlTabIntent extends Intent {
+  const PrevSqlTabIntent();
+}

--- a/lib/core/actions/sql_editor_command_bridge.dart
+++ b/lib/core/actions/sql_editor_command_bridge.dart
@@ -14,11 +14,15 @@ class SqlEditorCommandBridge {
   VoidCallback? _onOpen;
   VoidCallback? _onSave;
   VoidCallback? _onExecute;
+  VoidCallback? _onCloseTab;
+  VoidCallback? _onNextTab;
+  VoidCallback? _onPrevTab;
 
   SqlEditorPendingAction pendingAction = SqlEditorPendingAction.none;
 
   bool get isActive => _onNew != null;
   bool get canExecute => _onExecute != null;
+  bool get canCloseTab => _onCloseTab != null;
 
   void register({
     required int? connectionId,
@@ -26,12 +30,18 @@ class SqlEditorCommandBridge {
     required VoidCallback onOpen,
     required VoidCallback onSave,
     VoidCallback? onExecute,
+    VoidCallback? onCloseTab,
+    VoidCallback? onNextTab,
+    VoidCallback? onPrevTab,
   }) {
     _ownerConnectionId = connectionId;
     _onNew = onNew;
     _onOpen = onOpen;
     _onSave = onSave;
     _onExecute = onExecute;
+    _onCloseTab = onCloseTab;
+    _onNextTab = onNextTab;
+    _onPrevTab = onPrevTab;
     _flushPending();
   }
 
@@ -42,6 +52,9 @@ class SqlEditorCommandBridge {
     _onOpen = null;
     _onSave = null;
     _onExecute = null;
+    _onCloseTab = null;
+    _onNextTab = null;
+    _onPrevTab = null;
   }
 
   void queuePending(SqlEditorPendingAction action) {
@@ -80,6 +93,18 @@ class SqlEditorCommandBridge {
     pendingAction = SqlEditorPendingAction.executeQuery;
   }
 
+  void invokeCloseTab() {
+    _onCloseTab?.call();
+  }
+
+  void invokeNextTab() {
+    _onNextTab?.call();
+  }
+
+  void invokePrevTab() {
+    _onPrevTab?.call();
+  }
+
   void _flushPending() {
     final action = pendingAction;
     if (action == SqlEditorPendingAction.none) return;
@@ -106,6 +131,9 @@ class SqlEditorCommandBridge {
     _onOpen = null;
     _onSave = null;
     _onExecute = null;
+    _onCloseTab = null;
+    _onNextTab = null;
+    _onPrevTab = null;
     pendingAction = SqlEditorPendingAction.none;
   }
 }

--- a/lib/features/extensions/extension_sql_workspace.dart
+++ b/lib/features/extensions/extension_sql_workspace.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:flutter/material.dart' as material;
 import 'package:flutter/services.dart' show LogicalKeyboardKey;
 import 'package:file_selector/file_selector.dart';
+import 'package:querya_desktop/core/actions/sql_editor_actions.dart';
 import 'package:querya_desktop/core/actions/sql_editor_command_bridge.dart';
 import 'package:querya_desktop/core/database/destructive_sql_detector.dart';
 import 'package:querya_desktop/core/extensions/extension_driver_session.dart';
@@ -41,15 +42,13 @@ class ExtensionSqlWorkspace extends material.StatefulWidget {
 
 class _ExtensionSqlWorkspaceState
     extends material.State<ExtensionSqlWorkspace> {
-  final _sqlController = material.TextEditingController();
-  final ValueNotifier<double> _topFraction = ValueNotifier(0.6);
+  final List<SqlQueryTabSession> _sessions = [];
+  int _activeSessionIndex = 0;
+  int _nextSessionId = 1;
 
-  bool _running = false;
+  SqlQueryTabSession get _activeSession => _sessions[_activeSessionIndex];
+
   bool _restartingDriver = false;
-  String? _error;
-  List<String> _columns = [];
-  List<List<String>> _rows = [];
-  String? _statusLine;
 
   int _historyMaxEntries = kDefaultSqlHistoryMaxEntries;
   int _resultMaxRows = kDefaultSqlResultMaxRows;
@@ -57,8 +56,7 @@ class _ExtensionSqlWorkspaceState
 
   static const _previewRowLimit = 200;
 
-  bool get _isDriverError {
-    final err = _error;
+  bool _isDriverError(String? err) {
     if (err == null) return false;
     return err.contains('PluginCrashedException') ||
         err.contains('PluginDeadlockException') ||
@@ -86,13 +84,13 @@ class _ExtensionSqlWorkspaceState
       );
       setState(() {
         _restartingDriver = false;
-        _error = null;
+        _activeSession.error = null;
       });
-      await _execute();
+      await _execute(_activeSession);
     } catch (e) {
       if (!mounted) return;
       setState(() {
-        _error = 'Driver restart failed: $e';
+        _activeSession.error = 'Driver restart failed: $e';
         _restartingDriver = false;
       });
       showAppToast(
@@ -106,9 +104,13 @@ class _ExtensionSqlWorkspaceState
   @override
   void initState() {
     super.initState();
-    if (widget.initialSql != null && widget.initialSql!.isNotEmpty) {
-      _sqlController.text = widget.initialSql!;
-    }
+    _sessions.add(
+      SqlQueryTabSession(
+        id: 'ext_tab_1',
+        title: widget.selectedObject?.name ?? 'Query 1',
+        initialSql: widget.initialSql,
+      ),
+    );
     material.WidgetsBinding.instance.addPostFrameCallback((_) {
       unawaited(_loadWorkspaceSettings());
       _applySelectedObject();
@@ -120,8 +122,10 @@ class _ExtensionSqlWorkspaceState
   void dispose() {
     SqlEditorCommandBridge.instance
         .unregister(connectionId: widget.connectionRow.id);
-    _sqlController.dispose();
-    _topFraction.dispose();
+    for (final s in _sessions) {
+      s.dispose();
+    }
+    _sessions.clear();
     super.dispose();
   }
 
@@ -129,13 +133,72 @@ class _ExtensionSqlWorkspaceState
     if (!mounted) return;
     SqlEditorCommandBridge.instance.register(
       connectionId: widget.connectionRow.id,
-      onNew: () => _sqlController.clear(),
+      onNew: _addNewTab,
       onOpen: () => unawaited(_openSqlFile()),
       onSave: () => unawaited(_saveSqlFile()),
+      onCloseTab: () {
+        if (_sessions.length > 1) {
+          unawaited(_closeTab(_activeSessionIndex));
+        }
+      },
+      onNextTab: _nextTab,
+      onPrevTab: _prevTab,
       onExecute: () {
-        if (!_running) unawaited(_execute());
+        if (!_activeSession.running) unawaited(_execute(_activeSession));
       },
     );
+  }
+
+  void _addNewTab({String? initialSql, String? title, String? filePath}) {
+    setState(() {
+      _nextSessionId++;
+      final session = SqlQueryTabSession(
+        id: 'ext_tab_$_nextSessionId',
+        title: title ?? 'Query $_nextSessionId',
+        initialSql: initialSql,
+        filePath: filePath,
+        initialFraction:
+            _sessions.isNotEmpty ? _activeSession.topFraction.value : 0.6,
+      );
+      _sessions.add(session);
+      _activeSessionIndex = _sessions.length - 1;
+    });
+  }
+
+  Future<void> _closeTab(int index) async {
+    if (index < 0 || index >= _sessions.length) return;
+    if (_sessions.length <= 1) return;
+    final session = _sessions[index];
+    if (session.stagingBuffer != null && session.stagingBuffer!.isDirty) {
+      final confirmed = await showUnsavedTabChangesDialog(
+        context: context,
+        tabTitle: session.title,
+      );
+      if (confirmed != true) return;
+    }
+    if (!mounted) return;
+    setState(() {
+      _sessions.removeAt(index);
+      session.dispose();
+      if (_activeSessionIndex >= _sessions.length) {
+        _activeSessionIndex = _sessions.length - 1;
+      }
+    });
+  }
+
+  void _nextTab() {
+    if (_sessions.length <= 1) return;
+    setState(() {
+      _activeSessionIndex = (_activeSessionIndex + 1) % _sessions.length;
+    });
+  }
+
+  void _prevTab() {
+    if (_sessions.length <= 1) return;
+    setState(() {
+      _activeSessionIndex =
+          (_activeSessionIndex - 1 + _sessions.length) % _sessions.length;
+    });
   }
 
   @override
@@ -155,11 +218,19 @@ class _ExtensionSqlWorkspaceState
     if (obj == null) return;
     final sql =
         'SELECT * FROM `${obj.database}`.`${obj.name}` LIMIT $_previewRowLimit';
-    _sqlController.value = material.TextEditingValue(
-      text: sql,
-      selection: material.TextSelection.collapsed(offset: sql.length),
-    );
-    unawaited(_execute());
+    if (_activeSession.controller.text.trim().isEmpty &&
+        _activeSession.rows.isEmpty) {
+      _activeSession.controller.value = material.TextEditingValue(
+        text: sql,
+        selection: material.TextSelection.collapsed(offset: sql.length),
+      );
+      _activeSession.title = obj.name;
+      setState(() {});
+      unawaited(_execute(_activeSession));
+    } else {
+      _addNewTab(initialSql: sql, title: obj.name);
+      unawaited(_execute(_activeSession));
+    }
   }
 
   Future<void> _loadWorkspaceSettings() async {
@@ -174,16 +245,15 @@ class _ExtensionSqlWorkspaceState
     });
   }
 
-
-
-  Future<void> _execute() async {
-    if (_running) return;
-    final selection = _sqlController.selection;
+  Future<void> _execute([SqlQueryTabSession? targetSession]) async {
+    final session = targetSession ?? _activeSession;
+    if (session.running) return;
+    final selection = session.controller.selection;
     String userSql;
     if (selection.isValid && !selection.isCollapsed) {
-      userSql = selection.textInside(_sqlController.text).trim();
+      userSql = selection.textInside(session.controller.text).trim();
     } else {
-      userSql = _sqlController.text.trim();
+      userSql = session.controller.text.trim();
     }
     if (userSql.isEmpty) return;
 
@@ -204,11 +274,11 @@ class _ExtensionSqlWorkspaceState
     }
 
     setState(() {
-      _running = true;
-      _error = null;
-      _columns = [];
-      _rows = [];
-      _statusLine = null;
+      session.running = true;
+      session.error = null;
+      session.columns = [];
+      session.rows = [];
+      session.statusLine = null;
     });
 
     try {
@@ -220,19 +290,19 @@ class _ExtensionSqlWorkspaceState
       if (!mounted) return;
 
       setState(() {
-        _columns = result.columns;
-        _rows = result.rows;
+        session.columns = result.columns;
+        session.rows = result.rows;
         if (result.columns.isEmpty && result.rows.isEmpty) {
-          _statusLine = result.message ?? 'Command completed.';
+          session.statusLine = result.message ?? 'Command completed.';
         } else {
           final elapsed =
               result.elapsedMs != null ? ' in ${result.elapsedMs}ms' : '';
           final capped = result.rows.length >= _resultMaxRows;
-          _statusLine = capped
+          session.statusLine = capped
               ? 'Showing first $_resultMaxRows row(s)$elapsed (result capped).'
               : '${result.rows.length} row(s)$elapsed.';
         }
-        _running = false;
+        session.running = false;
       });
 
       final cid = widget.connectionRow.id;
@@ -249,8 +319,8 @@ class _ExtensionSqlWorkspaceState
     } catch (e) {
       if (mounted) {
         setState(() {
-          _error = e.toString();
-          _running = false;
+          session.error = e.toString();
+          session.running = false;
         });
       }
     }
@@ -266,10 +336,18 @@ class _ExtensionSqlWorkspaceState
       if (file == null) return;
       final text = await file.readAsString();
       if (!mounted) return;
-      _sqlController.value = material.TextEditingValue(
-        text: text,
-        selection: material.TextSelection.collapsed(offset: text.length),
-      );
+      final session = _activeSession;
+      if (session.controller.text.trim().isEmpty && session.rows.isEmpty) {
+        session.controller.value = material.TextEditingValue(
+          text: text,
+          selection: material.TextSelection.collapsed(offset: text.length),
+        );
+        session.title = file.name;
+        session.filePath = file.path;
+        setState(() {});
+      } else {
+        _addNewTab(initialSql: text, title: file.name, filePath: file.path);
+      }
     } catch (e) {
       if (!mounted) return;
       showAppToast(
@@ -282,17 +360,41 @@ class _ExtensionSqlWorkspaceState
 
   Future<void> _saveSqlFile() async {
     try {
-      final name =
-          'query_${DateTime.now().toIso8601String().replaceAll(':', '-')}.sql';
+      final session = _activeSession;
+      final existingPath = session.filePath;
+      if (existingPath != null && existingPath.isNotEmpty) {
+        await File(existingPath).writeAsString(session.controller.text);
+        if (!mounted) return;
+        showAppToast(
+          context: context,
+          message: 'Saved ${session.title}',
+          variant: AppToastVariant.success,
+        );
+        return;
+      }
+
+      final suggested = session.title.endsWith('.sql')
+          ? session.title
+          : '${session.title}.sql';
       final location = await getSaveLocation(
         acceptedTypeGroups: const [
           XTypeGroup(label: 'SQL', extensions: ['sql']),
         ],
-        suggestedName: name,
+        suggestedName: suggested,
       );
       final path = location?.path;
       if (path == null || path.isEmpty) return;
-      await File(path).writeAsString(_sqlController.text);
+      await File(path).writeAsString(session.controller.text);
+      if (!mounted) return;
+      setState(() {
+        session.filePath = path;
+        session.title = File(path).uri.pathSegments.last;
+      });
+      showAppToast(
+        context: context,
+        message: 'Saved to ${session.title}',
+        variant: AppToastVariant.success,
+      );
     } catch (e) {
       if (!mounted) return;
       showAppToast(
@@ -305,117 +407,198 @@ class _ExtensionSqlWorkspaceState
 
   @override
   material.Widget build(material.BuildContext context) {
-    final theme = Theme.of(context);
-
-    return material.CallbackShortcuts(
-      bindings: {
-        const material.SingleActivator(LogicalKeyboardKey.f5): () {
-          if (!_running) unawaited(_execute());
-        },
-        const material.SingleActivator(
-          LogicalKeyboardKey.enter,
-          control: true,
-        ): () {
-          if (!_running) unawaited(_execute());
-        },
-        const material.SingleActivator(
-          LogicalKeyboardKey.enter,
-          meta: true,
-        ): () {
-          if (!_running) unawaited(_execute());
-        },
-        const material.SingleActivator(
-          LogicalKeyboardKey.numpadEnter,
-          control: true,
-        ): () {
-          if (!_running) unawaited(_execute());
-        },
-        const material.SingleActivator(
-          LogicalKeyboardKey.numpadEnter,
-          meta: true,
-        ): () {
-          if (!_running) unawaited(_execute());
-        },
-        const material.SingleActivator(
-          LogicalKeyboardKey.keyR,
-          control: true,
-        ): () {
-          if (!_running) unawaited(_execute());
-        },
-        const material.SingleActivator(
-          LogicalKeyboardKey.keyR,
-          meta: true,
-        ): () {
-          if (!_running) unawaited(_execute());
-        },
+    return Actions(
+      actions: <Type, Action<Intent>>{
+        NewSqlIntent: CallbackAction<NewSqlIntent>(
+          onInvoke: (intent) {
+            _addNewTab();
+            return null;
+          },
+        ),
+        CloseSqlTabIntent: CallbackAction<CloseSqlTabIntent>(
+          onInvoke: (intent) {
+            if (_sessions.length > 1) {
+              unawaited(_closeTab(_activeSessionIndex));
+            }
+            return null;
+          },
+        ),
+        NextSqlTabIntent: CallbackAction<NextSqlTabIntent>(
+          onInvoke: (intent) {
+            _nextTab();
+            return null;
+          },
+        ),
+        PrevSqlTabIntent: CallbackAction<PrevSqlTabIntent>(
+          onInvoke: (intent) {
+            _prevTab();
+            return null;
+          },
+        ),
+        OpenSqlIntent: CallbackAction<OpenSqlIntent>(
+          onInvoke: (intent) {
+            unawaited(_openSqlFile());
+            return null;
+          },
+        ),
+        SaveSqlIntent: CallbackAction<SaveSqlIntent>(
+          onInvoke: (intent) {
+            unawaited(_saveSqlFile());
+            return null;
+          },
+        ),
       },
-      child: material.Focus(
-        autofocus: true,
-        child: VerticalSplitPane(
-          fraction: _topFraction,
-          maxFraction: 0.85,
-          top: material.Column(
+      child: material.CallbackShortcuts(
+        bindings: {
+          const material.SingleActivator(LogicalKeyboardKey.keyT, control: true): _addNewTab,
+          const material.SingleActivator(LogicalKeyboardKey.keyT, meta: true): _addNewTab,
+          const material.SingleActivator(LogicalKeyboardKey.keyW, control: true): () {
+            if (_sessions.length > 1) unawaited(_closeTab(_activeSessionIndex));
+          },
+          const material.SingleActivator(LogicalKeyboardKey.keyW, meta: true): () {
+            if (_sessions.length > 1) unawaited(_closeTab(_activeSessionIndex));
+          },
+          const material.SingleActivator(LogicalKeyboardKey.tab, control: true): _nextTab,
+          const material.SingleActivator(LogicalKeyboardKey.tab, control: true, shift: true): _prevTab,
+          const material.SingleActivator(LogicalKeyboardKey.f5): () {
+            if (!_activeSession.running) unawaited(_execute(_activeSession));
+          },
+          const material.SingleActivator(
+            LogicalKeyboardKey.enter,
+            control: true,
+          ): () {
+            if (!_activeSession.running) unawaited(_execute(_activeSession));
+          },
+          const material.SingleActivator(
+            LogicalKeyboardKey.enter,
+            meta: true,
+          ): () {
+            if (!_activeSession.running) unawaited(_execute(_activeSession));
+          },
+          const material.SingleActivator(
+            LogicalKeyboardKey.numpadEnter,
+            control: true,
+          ): () {
+            if (!_activeSession.running) unawaited(_execute(_activeSession));
+          },
+          const material.SingleActivator(
+            LogicalKeyboardKey.numpadEnter,
+            meta: true,
+          ): () {
+            if (!_activeSession.running) unawaited(_execute(_activeSession));
+          },
+          const material.SingleActivator(
+            LogicalKeyboardKey.keyR,
+            control: true,
+          ): () {
+            if (!_activeSession.running) unawaited(_execute(_activeSession));
+          },
+          const material.SingleActivator(
+            LogicalKeyboardKey.keyR,
+            meta: true,
+          ): () {
+            if (!_activeSession.running) unawaited(_execute(_activeSession));
+          },
+        },
+        child: material.Focus(
+          autofocus: true,
+          child: material.Column(
             crossAxisAlignment: material.CrossAxisAlignment.stretch,
             children: [
-              _ExtensionSqlToolbar(
-                connectionName: widget.connectionRow.name,
-                onExecute: _running ? null : () => unawaited(_execute()),
-                running: _running,
-                isRestarting: _restartingDriver,
-                onRestartDriver: _running ? null : () => unawaited(_restartDriver()),
-                onOpenSqlFile: () => unawaited(_openSqlFile()),
-                onSaveSqlFile: () => unawaited(_saveSqlFile()),
-                onOpenHistory: widget.connectionRow.id != null && !_running
-                    ? () {
-                        showSqlQueryHistoryDialog(
-                          context: context,
-                          connectionId: widget.connectionRow.id!,
-                          databaseName: widget.connectionRow.databaseName,
-                          sqlController: _sqlController,
-                        );
-                      }
+              SqlQueryTabBar(
+                sessions: _sessions,
+                selectedIndex: _activeSessionIndex,
+                onSelect: (index) => setState(() => _activeSessionIndex = index),
+                onAdd: _addNewTab,
+                onClose: _sessions.length > 1
+                    ? (index) => unawaited(_closeTab(index))
                     : null,
               ),
-              const Divider(height: 1),
               material.Expanded(
-                child: QueryEditorTab(
-                  controller: _sqlController,
-                  fontSize: _editorFontSize,
-                ),
-              ),
-            ],
-          ),
-          bottom: material.Column(
-            crossAxisAlignment: material.CrossAxisAlignment.stretch,
-            children: [
-              material.Container(
-                constraints: const material.BoxConstraints(minHeight: 44),
-                padding: const material.EdgeInsets.symmetric(horizontal: 12),
-                decoration: material.BoxDecoration(
-                  color: theme.colorScheme.muted.withValues(alpha: 0.6),
-                ),
-                alignment: material.Alignment.centerLeft,
-                child: const Text('Data Output').semiBold().small(),
-              ),
-              const Divider(height: 1),
-              material.Expanded(
-                child: ResultsTab(
-                  columns: _columns,
-                  rows: _rows,
-                  errorMessage: _error,
-                  isLoading: _running,
-                  statusLine: _statusLine,
-                  errorAction: _isDriverError
-                      ? ExtensionDriverRecoveryBanner(
-                          onRestart: () => unawaited(_restartDriver()),
-                          isRestarting: _restartingDriver,
-                        )
-                      : null,
+                child: material.IndexedStack(
+                  index: _activeSessionIndex,
+                  children: [
+                    for (final session in _sessions)
+                      _buildSessionPane(context, session),
+                  ],
                 ),
               ),
             ],
           ),
         ),
+      ),
+    );
+  }
+
+  material.Widget _buildSessionPane(
+    material.BuildContext context,
+    SqlQueryTabSession session,
+  ) {
+    final theme = Theme.of(context);
+    return VerticalSplitPane(
+      fraction: session.topFraction,
+      maxFraction: 0.85,
+      top: material.Column(
+        crossAxisAlignment: material.CrossAxisAlignment.stretch,
+        children: [
+          _ExtensionSqlToolbar(
+            connectionName: widget.connectionRow.name,
+            onExecute: session.running ? null : () => unawaited(_execute(session)),
+            running: session.running,
+            isRestarting: _restartingDriver,
+            onRestartDriver:
+                session.running ? null : () => unawaited(_restartDriver()),
+            onOpenSqlFile: () => unawaited(_openSqlFile()),
+            onSaveSqlFile: () => unawaited(_saveSqlFile()),
+            onOpenHistory: widget.connectionRow.id != null && !session.running
+                ? () {
+                    showSqlQueryHistoryDialog(
+                      context: context,
+                      connectionId: widget.connectionRow.id!,
+                      databaseName: widget.connectionRow.databaseName,
+                      sqlController: session.controller,
+                    );
+                  }
+                : null,
+          ),
+          const Divider(height: 1),
+          material.Expanded(
+            child: QueryEditorTab(
+              controller: session.controller,
+              fontSize: _editorFontSize,
+            ),
+          ),
+        ],
+      ),
+      bottom: material.Column(
+        crossAxisAlignment: material.CrossAxisAlignment.stretch,
+        children: [
+          material.Container(
+            constraints: const material.BoxConstraints(minHeight: 44),
+            padding: const material.EdgeInsets.symmetric(horizontal: 12),
+            decoration: material.BoxDecoration(
+              color: theme.colorScheme.muted.withValues(alpha: 0.6),
+            ),
+            alignment: material.Alignment.centerLeft,
+            child: const Text('Data Output').semiBold().small(),
+          ),
+          const Divider(height: 1),
+          material.Expanded(
+            child: ResultsTab(
+              columns: session.columns,
+              rows: session.rows,
+              errorMessage: session.error,
+              isLoading: session.running,
+              statusLine: session.statusLine,
+              errorAction: _isDriverError(session.error)
+                  ? ExtensionDriverRecoveryBanner(
+                      onRestart: () => unawaited(_restartDriver()),
+                      isRestarting: _restartingDriver,
+                    )
+                  : null,
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/features/main_screen/main_screen.dart
+++ b/lib/features/main_screen/main_screen.dart
@@ -138,6 +138,51 @@ class _MainScreenState extends State<MainScreen> {
       return true;
     }
 
+    // New Query Tab: Ctrl+T / Cmd+T (Physical T, Logical T, Russian 'е')
+    final isKeyT = physical == PhysicalKeyboardKey.keyT ||
+        logical == LogicalKeyboardKey.keyT ||
+        logical == const LogicalKeyboardKey(0x00000435); // Russian 'е'
+    if (isCmdOrCtrl && !isShift && !isAlt && isKeyT) {
+      final ctx = FocusManager.instance.primaryFocus?.context ?? context;
+      final handled = Actions.maybeInvoke(ctx, const NewSqlIntent());
+      if (handled == null) {
+        SqlEditorCommandBridge.instance.invokeNew();
+      }
+      return true;
+    }
+
+    // Close Query Tab: Ctrl+W / Cmd+W (Physical W, Logical W, Russian 'ц')
+    final isKeyW = physical == PhysicalKeyboardKey.keyW ||
+        logical == LogicalKeyboardKey.keyW ||
+        logical == const LogicalKeyboardKey(0x00000446); // Russian 'ц'
+    if (isCmdOrCtrl && !isShift && !isAlt && isKeyW) {
+      final ctx = FocusManager.instance.primaryFocus?.context ?? context;
+      final handled = Actions.maybeInvoke(ctx, const CloseSqlTabIntent());
+      if (handled == null) {
+        SqlEditorCommandBridge.instance.invokeCloseTab();
+      }
+      return true;
+    }
+
+    // Next / Prev Tab: Ctrl+Tab / Ctrl+Shift+Tab
+    final isTab = physical == PhysicalKeyboardKey.tab ||
+        logical == LogicalKeyboardKey.tab;
+    if (isCmdOrCtrl && !isAlt && isTab) {
+      final ctx = FocusManager.instance.primaryFocus?.context ?? context;
+      if (isShift) {
+        final handled = Actions.maybeInvoke(ctx, const PrevSqlTabIntent());
+        if (handled == null) {
+          SqlEditorCommandBridge.instance.invokePrevTab();
+        }
+      } else {
+        final handled = Actions.maybeInvoke(ctx, const NextSqlTabIntent());
+        if (handled == null) {
+          SqlEditorCommandBridge.instance.invokeNextTab();
+        }
+      }
+      return true;
+    }
+
     // 4. Open SQL: Ctrl+O / Cmd+O (Physical O, Logical O, Russian 'щ')
     final isKeyO = physical == PhysicalKeyboardKey.keyO ||
         logical == LogicalKeyboardKey.keyO ||

--- a/lib/features/mysql/mysql_sql_workspace.dart
+++ b/lib/features/mysql/mysql_sql_workspace.dart
@@ -35,20 +35,13 @@ class MysqlSqlWorkspace extends material.StatefulWidget {
 }
 
 class _MysqlSqlWorkspaceState extends material.State<MysqlSqlWorkspace> {
-  final _sqlController = material.TextEditingController();
-  final ValueNotifier<double> _topFraction = ValueNotifier(0.65);
+  final List<SqlQueryTabSession> _sessions = [];
+  int _activeSessionIndex = 0;
+  int _nextSessionId = 1;
+
+  SqlQueryTabSession get _activeSession => _sessions[_activeSessionIndex];
 
   MysqlLease? _lease;
-
-  bool _running = false;
-  String? _error;
-  List<String> _columns = [];
-  List<List<String>> _rows = [];
-  int? _affectedRows;
-  String? _statusLine;
-  DataGridStagingBuffer? _stagingBuffer;
-  String? _lastExecutedSql;
-  bool _savingChanges = false;
 
   int? _queryTimeoutSeconds;
 
@@ -61,6 +54,12 @@ class _MysqlSqlWorkspaceState extends material.State<MysqlSqlWorkspace> {
   @override
   void initState() {
     super.initState();
+    _sessions.add(
+      SqlQueryTabSession(
+        id: 'mysql_tab_1',
+        title: 'Query 1',
+      ),
+    );
     _appSettingsListener = () {
       unawaited(_loadWorkspaceSettings());
     };
@@ -75,13 +74,70 @@ class _MysqlSqlWorkspaceState extends material.State<MysqlSqlWorkspace> {
     if (!mounted) return;
     SqlEditorCommandBridge.instance.register(
       connectionId: widget.connectionRow.id,
-      onNew: () => _sqlController.clear(),
+      onNew: _addNewTab,
       onOpen: () => unawaited(_openSqlFile()),
       onSave: () => unawaited(_saveSqlFile()),
       onExecute: () {
-        if (!_running) unawaited(_execute());
+        if (!_activeSession.running) unawaited(_execute(_activeSession));
       },
+      onCloseTab: () {
+        if (_sessions.length > 1) unawaited(_closeTab(_activeSessionIndex));
+      },
+      onNextTab: _nextTab,
+      onPrevTab: _prevTab,
     );
+  }
+
+  void _addNewTab({String initialSql = '', String? title, String? filePath}) {
+    setState(() {
+      _nextSessionId++;
+      final session = SqlQueryTabSession(
+        id: 'mysql_tab_${DateTime.now().millisecondsSinceEpoch}_$_nextSessionId',
+        title: title ?? 'Query $_nextSessionId',
+        initialSql: initialSql,
+        filePath: filePath,
+        initialFraction:
+            _sessions.isNotEmpty ? _activeSession.topFraction.value : 0.65,
+      );
+      _sessions.add(session);
+      _activeSessionIndex = _sessions.length - 1;
+    });
+  }
+
+  Future<void> _closeTab(int index) async {
+    if (index < 0 || index >= _sessions.length) return;
+    if (_sessions.length <= 1) return;
+    final session = _sessions[index];
+    if (session.stagingBuffer != null && session.stagingBuffer!.isDirty) {
+      final confirmed = await showUnsavedTabChangesDialog(
+        context: context,
+        tabTitle: session.title,
+      );
+      if (confirmed != true) return;
+    }
+    if (!mounted) return;
+    setState(() {
+      _sessions.removeAt(index);
+      session.dispose();
+      if (_activeSessionIndex >= _sessions.length) {
+        _activeSessionIndex = _sessions.length - 1;
+      }
+    });
+  }
+
+  void _nextTab() {
+    if (_sessions.length <= 1) return;
+    setState(() {
+      _activeSessionIndex = (_activeSessionIndex + 1) % _sessions.length;
+    });
+  }
+
+  void _prevTab() {
+    if (_sessions.length <= 1) return;
+    setState(() {
+      _activeSessionIndex =
+          (_activeSessionIndex - 1 + _sessions.length) % _sessions.length;
+    });
   }
 
   @override
@@ -140,8 +196,8 @@ class _MysqlSqlWorkspaceState extends material.State<MysqlSqlWorkspace> {
         .unregister(connectionId: widget.connectionRow.id);
     SqlWorkspaceSettingsRevision.listenable
         .removeListener(_appSettingsListener);
-    _topFraction.dispose();
-    if (_running) {
+    final anyRunning = _sessions.any((s) => s.running);
+    if (anyRunning) {
       MysqlService.instance.interrupt(
         widget.connectionRow,
         database: _poolDatabaseKey(),
@@ -149,19 +205,20 @@ class _MysqlSqlWorkspaceState extends material.State<MysqlSqlWorkspace> {
       );
     }
     _lease?.release();
-    _stagingBuffer?.dispose();
-    _stagingBuffer = null;
-    _sqlController.dispose();
+    for (final s in _sessions) {
+      s.dispose();
+    }
     super.dispose();
   }
 
-  Future<void> _execute() async {
-    final selection = _sqlController.selection;
+  Future<void> _execute([SqlQueryTabSession? targetSession]) async {
+    final session = targetSession ?? _activeSession;
+    final selection = session.controller.selection;
     String userSql;
     if (selection.isValid && !selection.isCollapsed) {
-      userSql = selection.textInside(_sqlController.text).trim();
+      userSql = selection.textInside(session.controller.text).trim();
     } else {
-      userSql = _sqlController.text.trim();
+      userSql = session.controller.text.trim();
     }
     if (userSql.isEmpty) return;
 
@@ -182,12 +239,12 @@ class _MysqlSqlWorkspaceState extends material.State<MysqlSqlWorkspace> {
     }
 
     setState(() {
-      _running = true;
-      _error = null;
-      _columns = [];
-      _rows = [];
-      _affectedRows = null;
-      _statusLine = null;
+      session.running = true;
+      session.error = null;
+      session.columns = [];
+      session.rows = [];
+      session.affectedRows = null;
+      session.statusLine = null;
     });
 
     try {
@@ -196,8 +253,8 @@ class _MysqlSqlWorkspaceState extends material.State<MysqlSqlWorkspace> {
       if (conn == null || !conn.isConnected) {
         if (mounted) {
           setState(() {
-            _error = 'Could not connect to MySQL.';
-            _running = false;
+            session.error = 'Could not connect to MySQL.';
+            session.running = false;
           });
         }
         return;
@@ -242,24 +299,24 @@ class _MysqlSqlWorkspaceState extends material.State<MysqlSqlWorkspace> {
       }
 
       setState(() {
-        _columns = cols;
-        _rows = outRows;
-        _affectedRows = affected;
-        _lastExecutedSql = userSql;
-        _stagingBuffer?.dispose();
-        _stagingBuffer = cols.isNotEmpty
+        session.columns = cols;
+        session.rows = outRows;
+        session.affectedRows = affected;
+        session.lastExecutedSql = userSql;
+        session.stagingBuffer?.dispose();
+        session.stagingBuffer = cols.isNotEmpty
             ? DataGridStagingBuffer(columns: cols, rows: outRows)
             : null;
         if (cols.isEmpty && outRows.isEmpty) {
-          _statusLine = affected != null
+          session.statusLine = affected != null
               ? 'OK. Rows affected: $affected.'
               : 'Command completed.';
         } else {
-          _statusLine = truncated
+          session.statusLine = truncated
               ? 'Showing first $cap row(s) (result capped).'
               : '$n row(s).';
         }
-        _running = false;
+        session.running = false;
       });
       final cid = widget.connectionRow.id;
       if (cid != null) {
@@ -276,35 +333,42 @@ class _MysqlSqlWorkspaceState extends material.State<MysqlSqlWorkspace> {
       unawaited(_lease?.connection.forceClose());
       if (mounted) {
         setState(() {
-          _error = e.toString();
-          _running = false;
+          session.error = e.toString();
+          session.running = false;
         });
       }
     } catch (e) {
       if (mounted) {
         setState(() {
-          _error = e.toString();
-          _running = false;
+          session.error = e.toString();
+          session.running = false;
         });
       }
     }
   }
 
-  Future<void> _applyStagedChanges() async {
-    if (_stagingBuffer == null || !_stagingBuffer!.isDirty || _savingChanges) return;
-    final target = _lastExecutedSql != null ? SqlTableTargetExtractor.extract(_lastExecutedSql!) : null;
+  Future<void> _applyStagedChanges([SqlQueryTabSession? targetSession]) async {
+    final session = targetSession ?? _activeSession;
+    if (session.stagingBuffer == null ||
+        !session.stagingBuffer!.isDirty ||
+        session.savingChanges) {
+      return;
+    }
+    final target = session.lastExecutedSql != null
+        ? SqlTableTargetExtractor.extract(session.lastExecutedSql!)
+        : null;
     final tableName = target?.tableName ?? 'table';
     final schemaName = target?.schema;
 
-    setState(() => _savingChanges = true);
+    setState(() => session.savingChanges = true);
     try {
-      final plan = _stagingBuffer!.generateMutationPlan(
+      final plan = session.stagingBuffer!.generateMutationPlan(
         dialect: SqlDialect.mysql,
         tableName: tableName,
         schema: schemaName,
       );
       if (plan.isEmpty) {
-        setState(() => _savingChanges = false);
+        setState(() => session.savingChanges = false);
         return;
       }
 
@@ -313,7 +377,7 @@ class _MysqlSqlWorkspaceState extends material.State<MysqlSqlWorkspace> {
         plan: plan,
       );
       if (confirmed != true) {
-        setState(() => _savingChanges = false);
+        setState(() => session.savingChanges = false);
         return;
       }
 
@@ -328,16 +392,17 @@ class _MysqlSqlWorkspaceState extends material.State<MysqlSqlWorkspace> {
       }
 
       if (!mounted) return;
-      final newRows = _stagingBuffer!.effectiveRows;
-      _stagingBuffer?.dispose();
+      final newRows = session.stagingBuffer!.effectiveRows;
+      session.stagingBuffer?.dispose();
       setState(() {
-        _rows = newRows;
-        _stagingBuffer = DataGridStagingBuffer(columns: _columns, rows: _rows);
-        _savingChanges = false;
+        session.rows = newRows;
+        session.stagingBuffer =
+            DataGridStagingBuffer(columns: session.columns, rows: session.rows);
+        session.savingChanges = false;
       });
     } catch (e) {
       if (mounted) {
-        setState(() => _savingChanges = false);
+        setState(() => session.savingChanges = false);
         await showAppDialog<void>(
           context: context,
           builder: (ctx) => material.AlertDialog(
@@ -373,10 +438,18 @@ class _MysqlSqlWorkspaceState extends material.State<MysqlSqlWorkspace> {
       if (file == null) return;
       final text = await file.readAsString();
       if (!mounted) return;
-      _sqlController.value = material.TextEditingValue(
-        text: text,
-        selection: material.TextSelection.collapsed(offset: text.length),
-      );
+      final session = _activeSession;
+      if (session.controller.text.trim().isEmpty && session.rows.isEmpty) {
+        session.controller.value = material.TextEditingValue(
+          text: text,
+          selection: material.TextSelection.collapsed(offset: text.length),
+        );
+        session.title = file.name;
+        session.filePath = file.path;
+        setState(() {});
+      } else {
+        _addNewTab(initialSql: text, title: file.name, filePath: file.path);
+      }
     } catch (e) {
       if (!mounted) return;
       showAppToast(
@@ -389,16 +462,41 @@ class _MysqlSqlWorkspaceState extends material.State<MysqlSqlWorkspace> {
 
   Future<void> _saveSqlFile() async {
     try {
-      final name = 'query_${DateTime.now().toIso8601String().replaceAll(':', '-')}.sql';
+      final session = _activeSession;
+      final existingPath = session.filePath;
+      if (existingPath != null && existingPath.isNotEmpty) {
+        await File(existingPath).writeAsString(session.controller.text);
+        if (!mounted) return;
+        showAppToast(
+          context: context,
+          message: 'Saved ${session.title}',
+          variant: AppToastVariant.success,
+        );
+        return;
+      }
+
+      final suggested = session.title.endsWith('.sql')
+          ? session.title
+          : '${session.title}.sql';
       final location = await getSaveLocation(
         acceptedTypeGroups: const [
           XTypeGroup(label: 'SQL', extensions: ['sql']),
         ],
-        suggestedName: name,
+        suggestedName: suggested,
       );
       final path = location?.path;
       if (path == null || path.isEmpty) return;
-      await File(path).writeAsString(_sqlController.text);
+      await File(path).writeAsString(session.controller.text);
+      if (!mounted) return;
+      setState(() {
+        session.filePath = path;
+        session.title = File(path).uri.pathSegments.last;
+      });
+      showAppToast(
+        context: context,
+        message: 'Saved to ${session.title}',
+        variant: AppToastVariant.success,
+      );
     } catch (e) {
       if (!mounted) return;
       showAppToast(
@@ -410,22 +508,40 @@ class _MysqlSqlWorkspaceState extends material.State<MysqlSqlWorkspace> {
   }
 
   Future<void> _runTxCommand(String sql) async {
-    _sqlController.value = material.TextEditingValue(
+    _activeSession.controller.value = material.TextEditingValue(
       text: sql,
       selection: material.TextSelection.collapsed(offset: sql.length),
     );
-    await _execute();
+    await _execute(_activeSession);
   }
 
   @override
   material.Widget build(material.BuildContext context) {
-    final theme = Theme.of(context);
-
     return Actions(
       actions: <Type, Action<Intent>>{
         NewSqlIntent: CallbackAction<NewSqlIntent>(
           onInvoke: (intent) {
-            _sqlController.clear();
+            _addNewTab();
+            return null;
+          },
+        ),
+        CloseSqlTabIntent: CallbackAction<CloseSqlTabIntent>(
+          onInvoke: (intent) {
+            if (_sessions.length > 1) {
+              unawaited(_closeTab(_activeSessionIndex));
+            }
+            return null;
+          },
+        ),
+        NextSqlTabIntent: CallbackAction<NextSqlTabIntent>(
+          onInvoke: (intent) {
+            _nextTab();
+            return null;
+          },
+        ),
+        PrevSqlTabIntent: CallbackAction<PrevSqlTabIntent>(
+          onInvoke: (intent) {
+            _prevTab();
             return null;
           },
         ),
@@ -444,115 +560,156 @@ class _MysqlSqlWorkspaceState extends material.State<MysqlSqlWorkspace> {
       },
       child: material.CallbackShortcuts(
         bindings: {
+          const material.SingleActivator(LogicalKeyboardKey.keyT, control: true): _addNewTab,
+          const material.SingleActivator(LogicalKeyboardKey.keyT, meta: true): _addNewTab,
+          const material.SingleActivator(LogicalKeyboardKey.keyW, control: true): () {
+            if (_sessions.length > 1) unawaited(_closeTab(_activeSessionIndex));
+          },
+          const material.SingleActivator(LogicalKeyboardKey.keyW, meta: true): () {
+            if (_sessions.length > 1) unawaited(_closeTab(_activeSessionIndex));
+          },
+          const material.SingleActivator(LogicalKeyboardKey.tab, control: true): _nextTab,
+          const material.SingleActivator(LogicalKeyboardKey.tab, control: true, shift: true): _prevTab,
           const material.SingleActivator(LogicalKeyboardKey.f5): () {
-            if (!_running) unawaited(_execute());
+            if (!_activeSession.running) unawaited(_execute(_activeSession));
           },
           const material.SingleActivator(
             LogicalKeyboardKey.enter,
             control: true,
           ): () {
-            if (!_running) unawaited(_execute());
+            if (!_activeSession.running) unawaited(_execute(_activeSession));
           },
           const material.SingleActivator(
             LogicalKeyboardKey.enter,
             meta: true,
           ): () {
-            if (!_running) unawaited(_execute());
+            if (!_activeSession.running) unawaited(_execute(_activeSession));
           },
           const material.SingleActivator(
             LogicalKeyboardKey.numpadEnter,
             control: true,
           ): () {
-            if (!_running) unawaited(_execute());
+            if (!_activeSession.running) unawaited(_execute(_activeSession));
           },
           const material.SingleActivator(
             LogicalKeyboardKey.numpadEnter,
             meta: true,
           ): () {
-            if (!_running) unawaited(_execute());
+            if (!_activeSession.running) unawaited(_execute(_activeSession));
           },
           const material.SingleActivator(
             LogicalKeyboardKey.keyR,
             control: true,
           ): () {
-            if (!_running) unawaited(_execute());
+            if (!_activeSession.running) unawaited(_execute(_activeSession));
           },
           const material.SingleActivator(
             LogicalKeyboardKey.keyR,
             meta: true,
           ): () {
-            if (!_running) unawaited(_execute());
+            if (!_activeSession.running) unawaited(_execute(_activeSession));
           },
         },
         child: material.Focus(
           autofocus: true,
-          child: VerticalSplitPane(
-            fraction: _topFraction,
-            maxFraction: 0.85,
-            top: Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                _MysqlSqlToolbar(
-                  onExecute: _running ? null : _execute,
-                  running: _running,
-                  queryTimeoutSeconds: _queryTimeoutSeconds,
-                  onQueryTimeoutChanged: _onStmtTimeoutChanged,
-                  onOpenPreferences: () => showPreferencesDialog(context),
-                  onOpenHistory: widget.connectionRow.id != null && !_running
-                      ? () {
-                          showSqlQueryHistoryDialog(
-                            context: context,
-                            connectionId: widget.connectionRow.id!,
-                            databaseName: widget.connectionRow.databaseName,
-                            sqlController: _sqlController,
-                          );
-                        }
-                      : null,
-                  onBegin: _running ? null : () => _runTxCommand('START TRANSACTION;'),
-                  onCommit: _running ? null : () => _runTxCommand('COMMIT;'),
-                  onRollback: _running ? null : () => _runTxCommand('ROLLBACK;'),
+          child: material.Column(
+            crossAxisAlignment: material.CrossAxisAlignment.stretch,
+            children: [
+              SqlQueryTabBar(
+                sessions: _sessions,
+                selectedIndex: _activeSessionIndex,
+                onSelect: (index) => setState(() => _activeSessionIndex = index),
+                onAdd: _addNewTab,
+                onClose: _sessions.length > 1
+                    ? (index) => unawaited(_closeTab(index))
+                    : null,
+              ),
+              material.Expanded(
+                child: material.IndexedStack(
+                  index: _activeSessionIndex,
+                  children: [
+                    for (final session in _sessions)
+                      _buildSessionPane(context, session),
+                  ],
                 ),
-                const Divider(height: 1),
-                Expanded(
-                  child: QueryEditorTab(
-                    controller: _sqlController,
-                    fontSize: _editorFontSize,
-                  ),
-                ),
-              ],
-            ),
-            bottom: Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                material.Container(
-                  constraints: const material.BoxConstraints(minHeight: 44),
-                  padding: const material.EdgeInsets.symmetric(
-                    horizontal: 12,
-                  ),
-                  decoration: material.BoxDecoration(
-                    color: theme.colorScheme.muted.withValues(alpha: 0.6),
-                  ),
-                  alignment: material.Alignment.centerLeft,
-                  child: const Text('Data Output').semiBold().small(),
-                ),
-                const Divider(height: 1),
-                Expanded(
-                  child: ResultsTab(
-                    columns: _columns,
-                    rows: _rows,
-                    errorMessage: _error,
-                    isLoading: _running,
-                    affectedRows: _affectedRows,
-                    statusLine: _statusLine,
-                    stagingBuffer: _stagingBuffer,
-                    onApplyChanges: widget.isReadOnly ? null : _applyStagedChanges,
-                    isSaving: _savingChanges,
-                  ),
-                ),
-              ],
-            ),
+              ),
+            ],
           ),
         ),
+      ),
+    );
+  }
+
+  material.Widget _buildSessionPane(
+    material.BuildContext context,
+    SqlQueryTabSession session,
+  ) {
+    final theme = Theme.of(context);
+    return VerticalSplitPane(
+      fraction: session.topFraction,
+      maxFraction: 0.85,
+      top: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          _MysqlSqlToolbar(
+            onExecute: session.running ? null : () => _execute(session),
+            running: session.running,
+            queryTimeoutSeconds: _queryTimeoutSeconds,
+            onQueryTimeoutChanged: _onStmtTimeoutChanged,
+            onOpenPreferences: () => showPreferencesDialog(context),
+            onOpenHistory: widget.connectionRow.id != null && !session.running
+                ? () {
+                    showSqlQueryHistoryDialog(
+                      context: context,
+                      connectionId: widget.connectionRow.id!,
+                      databaseName: widget.connectionRow.databaseName,
+                      sqlController: session.controller,
+                    );
+                  }
+                : null,
+            onBegin: session.running ? null : () => _runTxCommand('START TRANSACTION;'),
+            onCommit: session.running ? null : () => _runTxCommand('COMMIT;'),
+            onRollback: session.running ? null : () => _runTxCommand('ROLLBACK;'),
+          ),
+          const Divider(height: 1),
+          Expanded(
+            child: QueryEditorTab(
+              controller: session.controller,
+              fontSize: _editorFontSize,
+            ),
+          ),
+        ],
+      ),
+      bottom: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          material.Container(
+            constraints: const material.BoxConstraints(minHeight: 44),
+            padding: const material.EdgeInsets.symmetric(
+              horizontal: 12,
+            ),
+            decoration: material.BoxDecoration(
+              color: theme.colorScheme.muted.withValues(alpha: 0.6),
+            ),
+            alignment: material.Alignment.centerLeft,
+            child: const Text('Data Output').semiBold().small(),
+          ),
+          const Divider(height: 1),
+          Expanded(
+            child: ResultsTab(
+              columns: session.columns,
+              rows: session.rows,
+              errorMessage: session.error,
+              isLoading: session.running,
+              affectedRows: session.affectedRows,
+              statusLine: session.statusLine,
+              stagingBuffer: session.stagingBuffer,
+              onApplyChanges:
+                  widget.isReadOnly ? null : () => _applyStagedChanges(session),
+              isSaving: session.savingChanges,
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/features/postgresql/postgres_sql_workspace.dart
+++ b/lib/features/postgresql/postgres_sql_workspace.dart
@@ -64,8 +64,11 @@ class PostgresSqlWorkspace extends material.StatefulWidget {
 }
 
 class _PostgresSqlWorkspaceState extends material.State<PostgresSqlWorkspace> {
-  final _sqlController = material.TextEditingController();
-  final ValueNotifier<double> _topFraction = ValueNotifier(0.65);
+  final List<SqlQueryTabSession> _sessions = [];
+  int _activeSessionIndex = 0;
+  int _nextSessionId = 1;
+
+  SqlQueryTabSession get _activeSession => _sessions[_activeSessionIndex];
 
   PgLease? _lease;
 
@@ -73,16 +76,6 @@ class _PostgresSqlWorkspaceState extends material.State<PostgresSqlWorkspace> {
   String? _interruptDatabase;
 
   int _lastAppliedSqlContextToken = -1;
-
-  bool _running = false;
-  String? _error;
-  List<String> _columns = [];
-  List<List<String>> _rows = [];
-  int? _affectedRows;
-  String? _statusLine;
-  DataGridStagingBuffer? _stagingBuffer;
-  String? _lastExecutedSql;
-  bool _savingChanges = false;
 
   /// PostgreSQL default: each statement is its own transaction unless you use
   /// `BEGIN` / `BEGIN`+implicit when autocommit is off.
@@ -103,6 +96,12 @@ class _PostgresSqlWorkspaceState extends material.State<PostgresSqlWorkspace> {
   @override
   void initState() {
     super.initState();
+    _sessions.add(
+      SqlQueryTabSession(
+        id: 'pg_tab_1',
+        title: 'Query 1',
+      ),
+    );
     _appSettingsListener = () {
       unawaited(_loadWorkspaceSettings());
     };
@@ -118,13 +117,70 @@ class _PostgresSqlWorkspaceState extends material.State<PostgresSqlWorkspace> {
     if (!mounted) return;
     SqlEditorCommandBridge.instance.register(
       connectionId: widget.connectionRow.id,
-      onNew: () => _sqlController.clear(),
+      onNew: _addNewTab,
       onOpen: () => unawaited(_openSqlFile()),
       onSave: () => unawaited(_saveSqlFile()),
       onExecute: () {
-        if (!_running) _execute();
+        if (!_activeSession.running) unawaited(_execute(_activeSession));
       },
+      onCloseTab: () {
+        if (_sessions.length > 1) unawaited(_closeTab(_activeSessionIndex));
+      },
+      onNextTab: _nextTab,
+      onPrevTab: _prevTab,
     );
+  }
+
+  void _addNewTab({String initialSql = '', String? title, String? filePath}) {
+    setState(() {
+      _nextSessionId++;
+      final session = SqlQueryTabSession(
+        id: 'pg_tab_${DateTime.now().millisecondsSinceEpoch}_$_nextSessionId',
+        title: title ?? 'Query $_nextSessionId',
+        initialSql: initialSql,
+        filePath: filePath,
+        initialFraction:
+            _sessions.isNotEmpty ? _activeSession.topFraction.value : 0.65,
+      );
+      _sessions.add(session);
+      _activeSessionIndex = _sessions.length - 1;
+    });
+  }
+
+  Future<void> _closeTab(int index) async {
+    if (index < 0 || index >= _sessions.length) return;
+    if (_sessions.length <= 1) return;
+    final session = _sessions[index];
+    if (session.stagingBuffer != null && session.stagingBuffer!.isDirty) {
+      final confirmed = await showUnsavedTabChangesDialog(
+        context: context,
+        tabTitle: session.title,
+      );
+      if (confirmed != true) return;
+    }
+    if (!mounted) return;
+    setState(() {
+      _sessions.removeAt(index);
+      session.dispose();
+      if (_activeSessionIndex >= _sessions.length) {
+        _activeSessionIndex = _sessions.length - 1;
+      }
+    });
+  }
+
+  void _nextTab() {
+    if (_sessions.length <= 1) return;
+    setState(() {
+      _activeSessionIndex = (_activeSessionIndex + 1) % _sessions.length;
+    });
+  }
+
+  void _prevTab() {
+    if (_sessions.length <= 1) return;
+    setState(() {
+      _activeSessionIndex =
+          (_activeSessionIndex - 1 + _sessions.length) % _sessions.length;
+    });
   }
 
   @override
@@ -165,10 +221,16 @@ class _PostgresSqlWorkspaceState extends material.State<PostgresSqlWorkspace> {
     _lastAppliedSqlContextToken = tok;
     _dropLease();
     final sql = postgresBrowseSelectSql(schema: ctx.schema, table: ctx.name);
-    _sqlController.value = material.TextEditingValue(
-      text: sql,
-      selection: material.TextSelection.collapsed(offset: sql.length),
-    );
+    if (_activeSession.controller.text.trim().isEmpty &&
+        _activeSession.rows.isEmpty) {
+      _activeSession.controller.value = material.TextEditingValue(
+        text: sql,
+        selection: material.TextSelection.collapsed(offset: sql.length),
+      );
+      _activeSession.title = ctx.name;
+    } else {
+      _addNewTab(initialSql: sql, title: ctx.name);
+    }
   }
 
   Future<void> _loadWorkspaceSettings() async {
@@ -228,9 +290,10 @@ class _PostgresSqlWorkspaceState extends material.State<PostgresSqlWorkspace> {
   }
 
   Future<void> _runTxCommand(String cmd) async {
+    final session = _activeSession;
     setState(() {
-      _running = true;
-      _error = null;
+      session.running = true;
+      session.error = null;
     });
     try {
       await _ensureLease();
@@ -238,8 +301,8 @@ class _PostgresSqlWorkspaceState extends material.State<PostgresSqlWorkspace> {
       if (conn == null || !conn.isConnected) {
         if (mounted) {
           setState(() {
-            _error = 'Could not connect to PostgreSQL.';
-            _running = false;
+            session.error = 'Could not connect to PostgreSQL.';
+            session.running = false;
           });
         }
         return;
@@ -248,32 +311,32 @@ class _PostgresSqlWorkspaceState extends material.State<PostgresSqlWorkspace> {
       await conn.execute(cmd, timeout: to);
       if (!mounted) return;
       setState(() {
-        _columns = [];
-        _rows = [];
-        _affectedRows = null;
-        _statusLine = 'OK: $cmd';
-        _running = false;
+        session.columns = [];
+        session.rows = [];
+        session.affectedRows = null;
+        session.statusLine = 'OK: $cmd';
+        session.running = false;
       });
     } on TimeoutException catch (e) {
       unawaited(_lease?.connection.forceClose());
       if (mounted) {
         setState(() {
-          _error = 'Query timed out: ${e.message ?? e}';
-          _running = false;
+          session.error = 'Query timed out: ${e.message ?? e}';
+          session.running = false;
         });
       }
     } on pg.ServerException catch (e) {
       if (mounted) {
         setState(() {
-          _error = e.message;
-          _running = false;
+          session.error = e.message;
+          session.running = false;
         });
       }
     } catch (e) {
       if (mounted) {
         setState(() {
-          _error = e.toString();
-          _running = false;
+          session.error = e.toString();
+          session.running = false;
         });
       }
     } finally {
@@ -287,8 +350,8 @@ class _PostgresSqlWorkspaceState extends material.State<PostgresSqlWorkspace> {
         .unregister(connectionId: widget.connectionRow.id);
     SqlWorkspaceSettingsRevision.listenable
         .removeListener(_appSettingsListener);
-    _topFraction.dispose();
-    if (_running) {
+    final anyRunning = _sessions.any((s) => s.running);
+    if (anyRunning) {
       PostgresService.instance.interrupt(
         widget.connectionRow,
         database: _interruptDatabase ?? _effectiveSessionDatabase(),
@@ -296,19 +359,20 @@ class _PostgresSqlWorkspaceState extends material.State<PostgresSqlWorkspace> {
       );
     }
     _dropLease();
-    _stagingBuffer?.dispose();
-    _stagingBuffer = null;
-    _sqlController.dispose();
+    for (final s in _sessions) {
+      s.dispose();
+    }
     super.dispose();
   }
 
-  Future<void> _execute() async {
-    final selection = _sqlController.selection;
+  Future<void> _execute([SqlQueryTabSession? targetSession]) async {
+    final session = targetSession ?? _activeSession;
+    final selection = session.controller.selection;
     String userSql;
     if (selection.isValid && !selection.isCollapsed) {
-      userSql = selection.textInside(_sqlController.text).trim();
+      userSql = selection.textInside(session.controller.text).trim();
     } else {
-      userSql = _sqlController.text.trim();
+      userSql = session.controller.text.trim();
     }
     if (userSql.isEmpty) return;
 
@@ -331,12 +395,12 @@ class _PostgresSqlWorkspaceState extends material.State<PostgresSqlWorkspace> {
     var sql = injectSqlLimit(userSql, _resultMaxRows);
 
     setState(() {
-      _running = true;
-      _error = null;
-      _columns = [];
-      _rows = [];
-      _affectedRows = null;
-      _statusLine = null;
+      session.running = true;
+      session.error = null;
+      session.columns = [];
+      session.rows = [];
+      session.affectedRows = null;
+      session.statusLine = null;
     });
 
     try {
@@ -345,8 +409,8 @@ class _PostgresSqlWorkspaceState extends material.State<PostgresSqlWorkspace> {
       if (conn == null || !conn.isConnected) {
         if (mounted) {
           setState(() {
-            _error = 'Could not connect to PostgreSQL.';
-            _running = false;
+            session.error = 'Could not connect to PostgreSQL.';
+            session.running = false;
           });
         }
         return;
@@ -386,24 +450,24 @@ class _PostgresSqlWorkspaceState extends material.State<PostgresSqlWorkspace> {
       final outRows = await convertResultRowsToStringsAdaptive(rawRows);
 
       setState(() {
-        _columns = cols;
-        _rows = outRows;
-        _affectedRows = result.affectedRows;
-        _lastExecutedSql = userSql;
-        _stagingBuffer?.dispose();
-        _stagingBuffer = cols.isNotEmpty
+        session.columns = cols;
+        session.rows = outRows;
+        session.affectedRows = result.affectedRows;
+        session.lastExecutedSql = userSql;
+        session.stagingBuffer?.dispose();
+        session.stagingBuffer = cols.isNotEmpty
             ? DataGridStagingBuffer(columns: cols, rows: outRows)
             : null;
         if (cols.isEmpty && outRows.isEmpty) {
-          _statusLine =
+          session.statusLine =
               'Command completed. Rows affected: ${result.affectedRows}.';
         } else {
           final truncated = result.length >= cap;
-          _statusLine = truncated
+          session.statusLine = truncated
               ? 'Showing first $cap row(s) (result capped).'
               : '${result.length} row(s).';
         }
-        _running = false;
+        session.running = false;
       });
       final cid = widget.connectionRow.id;
       if (cid != null) {
@@ -420,22 +484,22 @@ class _PostgresSqlWorkspaceState extends material.State<PostgresSqlWorkspace> {
       unawaited(_lease?.connection.forceClose());
       if (mounted) {
         setState(() {
-          _error = 'Query timed out: ${e.message ?? e}';
-          _running = false;
+          session.error = 'Query timed out: ${e.message ?? e}';
+          session.running = false;
         });
       }
     } on pg.ServerException catch (e) {
       if (mounted) {
         setState(() {
-          _error = e.message;
-          _running = false;
+          session.error = e.message;
+          session.running = false;
         });
       }
     } catch (e) {
       if (mounted) {
         setState(() {
-          _error = e.toString();
-          _running = false;
+          session.error = e.toString();
+          session.running = false;
         });
       }
     } finally {
@@ -443,21 +507,28 @@ class _PostgresSqlWorkspaceState extends material.State<PostgresSqlWorkspace> {
     }
   }
 
-  Future<void> _applyStagedChanges() async {
-    if (_stagingBuffer == null || !_stagingBuffer!.isDirty || _savingChanges) return;
-    final target = _lastExecutedSql != null ? SqlTableTargetExtractor.extract(_lastExecutedSql!) : null;
+  Future<void> _applyStagedChanges([SqlQueryTabSession? targetSession]) async {
+    final session = targetSession ?? _activeSession;
+    if (session.stagingBuffer == null ||
+        !session.stagingBuffer!.isDirty ||
+        session.savingChanges) {
+      return;
+    }
+    final target = session.lastExecutedSql != null
+        ? SqlTableTargetExtractor.extract(session.lastExecutedSql!)
+        : null;
     final tableName = target?.tableName ?? 'table';
     final schemaName = target?.schema;
 
-    setState(() => _savingChanges = true);
+    setState(() => session.savingChanges = true);
     try {
-      final plan = _stagingBuffer!.generateMutationPlan(
+      final plan = session.stagingBuffer!.generateMutationPlan(
         dialect: SqlDialect.postgres,
         tableName: tableName,
         schema: schemaName,
       );
       if (plan.isEmpty) {
-        setState(() => _savingChanges = false);
+        setState(() => session.savingChanges = false);
         return;
       }
 
@@ -466,7 +537,7 @@ class _PostgresSqlWorkspaceState extends material.State<PostgresSqlWorkspace> {
         plan: plan,
       );
       if (confirmed != true) {
-        setState(() => _savingChanges = false);
+        setState(() => session.savingChanges = false);
         return;
       }
 
@@ -481,17 +552,18 @@ class _PostgresSqlWorkspaceState extends material.State<PostgresSqlWorkspace> {
       await conn.execute(txSql, timeout: to);
 
       if (!mounted) return;
-      final newRows = _stagingBuffer!.effectiveRows;
-      _stagingBuffer?.dispose();
+      final newRows = session.stagingBuffer!.effectiveRows;
+      session.stagingBuffer?.dispose();
       setState(() {
-        _rows = newRows;
-        _stagingBuffer = DataGridStagingBuffer(columns: _columns, rows: _rows);
-        _savingChanges = false;
+        session.rows = newRows;
+        session.stagingBuffer =
+            DataGridStagingBuffer(columns: session.columns, rows: session.rows);
+        session.savingChanges = false;
       });
       await _refreshTxStatus();
     } catch (e) {
       if (mounted) {
-        setState(() => _savingChanges = false);
+        setState(() => session.savingChanges = false);
         await showAppDialog<void>(
           context: context,
           builder: (ctx) => material.AlertDialog(
@@ -522,10 +594,18 @@ class _PostgresSqlWorkspaceState extends material.State<PostgresSqlWorkspace> {
       if (file == null) return;
       final text = await file.readAsString();
       if (!mounted) return;
-      _sqlController.value = material.TextEditingValue(
-        text: text,
-        selection: material.TextSelection.collapsed(offset: text.length),
-      );
+      final session = _activeSession;
+      if (session.controller.text.trim().isEmpty && session.rows.isEmpty) {
+        session.controller.value = material.TextEditingValue(
+          text: text,
+          selection: material.TextSelection.collapsed(offset: text.length),
+        );
+        session.title = file.name;
+        session.filePath = file.path;
+        setState(() {});
+      } else {
+        _addNewTab(initialSql: text, title: file.name, filePath: file.path);
+      }
     } catch (e) {
       if (!mounted) return;
       showAppToast(
@@ -538,16 +618,41 @@ class _PostgresSqlWorkspaceState extends material.State<PostgresSqlWorkspace> {
 
   Future<void> _saveSqlFile() async {
     try {
-      final name = 'query_${DateTime.now().toIso8601String().replaceAll(':', '-')}.sql';
+      final session = _activeSession;
+      final existingPath = session.filePath;
+      if (existingPath != null && existingPath.isNotEmpty) {
+        await File(existingPath).writeAsString(session.controller.text);
+        if (!mounted) return;
+        showAppToast(
+          context: context,
+          message: 'Saved ${session.title}',
+          variant: AppToastVariant.success,
+        );
+        return;
+      }
+
+      final suggested = session.title.endsWith('.sql')
+          ? session.title
+          : '${session.title}.sql';
       final location = await getSaveLocation(
         acceptedTypeGroups: const [
           XTypeGroup(label: 'SQL', extensions: ['sql']),
         ],
-        suggestedName: name,
+        suggestedName: suggested,
       );
       final path = location?.path;
       if (path == null || path.isEmpty) return;
-      await File(path).writeAsString(_sqlController.text);
+      await File(path).writeAsString(session.controller.text);
+      if (!mounted) return;
+      setState(() {
+        session.filePath = path;
+        session.title = File(path).uri.pathSegments.last;
+      });
+      showAppToast(
+        context: context,
+        message: 'Saved to ${session.title}',
+        variant: AppToastVariant.success,
+      );
     } catch (e) {
       if (!mounted) return;
       showAppToast(
@@ -560,13 +665,31 @@ class _PostgresSqlWorkspaceState extends material.State<PostgresSqlWorkspace> {
 
   @override
   material.Widget build(material.BuildContext context) {
-    final theme = Theme.of(context);
-
     return Actions(
       actions: <Type, Action<Intent>>{
         NewSqlIntent: CallbackAction<NewSqlIntent>(
           onInvoke: (intent) {
-            _sqlController.clear();
+            _addNewTab();
+            return null;
+          },
+        ),
+        CloseSqlTabIntent: CallbackAction<CloseSqlTabIntent>(
+          onInvoke: (intent) {
+            if (_sessions.length > 1) {
+              unawaited(_closeTab(_activeSessionIndex));
+            }
+            return null;
+          },
+        ),
+        NextSqlTabIntent: CallbackAction<NextSqlTabIntent>(
+          onInvoke: (intent) {
+            _nextTab();
+            return null;
+          },
+        ),
+        PrevSqlTabIntent: CallbackAction<PrevSqlTabIntent>(
+          onInvoke: (intent) {
+            _prevTab();
             return null;
           },
         ),
@@ -585,120 +708,161 @@ class _PostgresSqlWorkspaceState extends material.State<PostgresSqlWorkspace> {
       },
       child: material.CallbackShortcuts(
         bindings: {
+          const material.SingleActivator(LogicalKeyboardKey.keyT, control: true): _addNewTab,
+          const material.SingleActivator(LogicalKeyboardKey.keyT, meta: true): _addNewTab,
+          const material.SingleActivator(LogicalKeyboardKey.keyW, control: true): () {
+            if (_sessions.length > 1) unawaited(_closeTab(_activeSessionIndex));
+          },
+          const material.SingleActivator(LogicalKeyboardKey.keyW, meta: true): () {
+            if (_sessions.length > 1) unawaited(_closeTab(_activeSessionIndex));
+          },
+          const material.SingleActivator(LogicalKeyboardKey.tab, control: true): _nextTab,
+          const material.SingleActivator(LogicalKeyboardKey.tab, control: true, shift: true): _prevTab,
           const material.SingleActivator(LogicalKeyboardKey.f5): () {
-            if (!_running) _execute();
+            if (!_activeSession.running) unawaited(_execute(_activeSession));
           },
           const material.SingleActivator(
             LogicalKeyboardKey.enter,
             control: true,
           ): () {
-            if (!_running) _execute();
+            if (!_activeSession.running) unawaited(_execute(_activeSession));
           },
           const material.SingleActivator(
             LogicalKeyboardKey.enter,
             meta: true,
           ): () {
-            if (!_running) _execute();
+            if (!_activeSession.running) unawaited(_execute(_activeSession));
           },
           const material.SingleActivator(
             LogicalKeyboardKey.numpadEnter,
             control: true,
           ): () {
-            if (!_running) _execute();
+            if (!_activeSession.running) unawaited(_execute(_activeSession));
           },
           const material.SingleActivator(
             LogicalKeyboardKey.numpadEnter,
             meta: true,
           ): () {
-            if (!_running) _execute();
+            if (!_activeSession.running) unawaited(_execute(_activeSession));
           },
           const material.SingleActivator(
             LogicalKeyboardKey.keyR,
             control: true,
           ): () {
-            if (!_running) _execute();
+            if (!_activeSession.running) unawaited(_execute(_activeSession));
           },
           const material.SingleActivator(
             LogicalKeyboardKey.keyR,
             meta: true,
           ): () {
-            if (!_running) _execute();
+            if (!_activeSession.running) unawaited(_execute(_activeSession));
           },
         },
         child: material.Focus(
           autofocus: true,
-          child: VerticalSplitPane(
-            fraction: _topFraction,
-            maxFraction: 0.85,
-            top: Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                _SqlToolbar(
-                  sessionDatabase: _effectiveSessionDatabase(),
-                  onExecute: _running ? null : _execute,
-                  running: _running,
-                  autocommit: _autocommit,
-                  onAutocommitChanged: (v) => setState(() => _autocommit = v),
-                  queryTimeoutSeconds: _queryTimeoutSeconds,
-                  onQueryTimeoutChanged: _onStmtTimeoutChanged,
-                  onOpenPreferences: () => showPreferencesDialog(context),
-                  onOpenHistory: widget.connectionRow.id != null && !_running
-                      ? () {
-                          showSqlQueryHistoryDialog(
-                            context: context,
-                            connectionId: widget.connectionRow.id!,
-                            databaseName: _effectiveSessionDatabase(),
-                            sqlController: _sqlController,
-                          );
-                        }
-                      : null,
-                  txOpen: _txOpen,
-                  onBegin: _running ? null : () => _runTxCommand('BEGIN'),
-                  onCommit: _running ? null : () => _runTxCommand('COMMIT'),
-                  onRollback:
-                      _running ? null : () => _runTxCommand('ROLLBACK'),
+          child: material.Column(
+            crossAxisAlignment: material.CrossAxisAlignment.stretch,
+            children: [
+              SqlQueryTabBar(
+                sessions: _sessions,
+                selectedIndex: _activeSessionIndex,
+                onSelect: (index) => setState(() => _activeSessionIndex = index),
+                onAdd: _addNewTab,
+                onClose: _sessions.length > 1
+                    ? (index) => unawaited(_closeTab(index))
+                    : null,
+              ),
+              material.Expanded(
+                child: material.IndexedStack(
+                  index: _activeSessionIndex,
+                  children: [
+                    for (final session in _sessions)
+                      _buildSessionPane(context, session),
+                  ],
                 ),
-                const Divider(height: 1),
-                Expanded(
-                  child: QueryEditorTab(
-                    controller: _sqlController,
-                    fontSize: _editorFontSize,
-                  ),
-                ),
-              ],
-            ),
-            bottom: Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                material.Container(
-                  constraints: const material.BoxConstraints(minHeight: 44),
-                  padding: const material.EdgeInsets.symmetric(
-                    horizontal: 12,
-                  ),
-                  decoration: material.BoxDecoration(
-                    color: theme.colorScheme.muted.withValues(alpha: 0.6),
-                  ),
-                  alignment: material.Alignment.centerLeft,
-                  child: const Text('Data Output').semiBold().small(),
-                ),
-                const Divider(height: 1),
-                Expanded(
-                  child: ResultsTab(
-                    columns: _columns,
-                    rows: _rows,
-                    errorMessage: _error,
-                    isLoading: _running,
-                    affectedRows: _affectedRows,
-                    statusLine: _statusLine,
-                    stagingBuffer: _stagingBuffer,
-                    onApplyChanges: widget.isReadOnly ? null : _applyStagedChanges,
-                    isSaving: _savingChanges,
-                  ),
-                ),
-              ],
-            ),
+              ),
+            ],
           ),
         ),
+      ),
+    );
+  }
+
+  material.Widget _buildSessionPane(
+    material.BuildContext context,
+    SqlQueryTabSession session,
+  ) {
+    final theme = Theme.of(context);
+    return VerticalSplitPane(
+      fraction: session.topFraction,
+      maxFraction: 0.85,
+      top: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          _SqlToolbar(
+            sessionDatabase: _effectiveSessionDatabase(),
+            onExecute: session.running ? null : () => _execute(session),
+            running: session.running,
+            autocommit: _autocommit,
+            onAutocommitChanged: (v) => setState(() => _autocommit = v),
+            queryTimeoutSeconds: _queryTimeoutSeconds,
+            onQueryTimeoutChanged: _onStmtTimeoutChanged,
+            onOpenPreferences: () => showPreferencesDialog(context),
+            onOpenHistory: widget.connectionRow.id != null && !session.running
+                ? () {
+                    showSqlQueryHistoryDialog(
+                      context: context,
+                      connectionId: widget.connectionRow.id!,
+                      databaseName: _effectiveSessionDatabase(),
+                      sqlController: session.controller,
+                    );
+                  }
+                : null,
+            txOpen: _txOpen,
+            onBegin: session.running ? null : () => _runTxCommand('BEGIN'),
+            onCommit: session.running ? null : () => _runTxCommand('COMMIT'),
+            onRollback:
+                session.running ? null : () => _runTxCommand('ROLLBACK'),
+          ),
+          const Divider(height: 1),
+          Expanded(
+            child: QueryEditorTab(
+              controller: session.controller,
+              fontSize: _editorFontSize,
+            ),
+          ),
+        ],
+      ),
+      bottom: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          material.Container(
+            constraints: const material.BoxConstraints(minHeight: 44),
+            padding: const material.EdgeInsets.symmetric(
+              horizontal: 12,
+            ),
+            decoration: material.BoxDecoration(
+              color: theme.colorScheme.muted.withValues(alpha: 0.6),
+            ),
+            alignment: material.Alignment.centerLeft,
+            child: const Text('Data Output').semiBold().small(),
+          ),
+          const Divider(height: 1),
+          Expanded(
+            child: ResultsTab(
+              columns: session.columns,
+              rows: session.rows,
+              errorMessage: session.error,
+              isLoading: session.running,
+              affectedRows: session.affectedRows,
+              statusLine: session.statusLine,
+              stagingBuffer: session.stagingBuffer,
+              onApplyChanges:
+                  widget.isReadOnly ? null : () => _applyStagedChanges(session),
+              isSaving: session.savingChanges,
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/features/sqlite/sqlite_sql_workspace.dart
+++ b/lib/features/sqlite/sqlite_sql_workspace.dart
@@ -34,20 +34,13 @@ class SqliteSqlWorkspace extends material.StatefulWidget {
 }
 
 class _SqliteSqlWorkspaceState extends material.State<SqliteSqlWorkspace> {
-  final _sqlController = material.TextEditingController();
-  final ValueNotifier<double> _topFraction = ValueNotifier(0.65);
+  final List<SqlQueryTabSession> _sessions = [];
+  int _activeSessionIndex = 0;
+  int _nextSessionId = 1;
+
+  SqlQueryTabSession get _activeSession => _sessions[_activeSessionIndex];
 
   SqliteLease? _lease;
-
-  bool _running = false;
-  String? _error;
-  List<String> _columns = [];
-  List<List<String>> _rows = [];
-  int? _affectedRows;
-  String? _statusLine;
-  DataGridStagingBuffer? _stagingBuffer;
-  String? _lastExecutedSql;
-  bool _savingChanges = false;
 
   int _resultMaxRows = kDefaultSqlResultMaxRows;
   int _historyMaxEntries = kDefaultSqlHistoryMaxEntries;
@@ -58,6 +51,12 @@ class _SqliteSqlWorkspaceState extends material.State<SqliteSqlWorkspace> {
   @override
   void initState() {
     super.initState();
+    _sessions.add(
+      SqlQueryTabSession(
+        id: 'sqlite_tab_1',
+        title: 'Query 1',
+      ),
+    );
     _appSettingsListener = () {
       unawaited(_loadWorkspaceSettings());
     };
@@ -72,13 +71,72 @@ class _SqliteSqlWorkspaceState extends material.State<SqliteSqlWorkspace> {
     if (!mounted) return;
     SqlEditorCommandBridge.instance.register(
       connectionId: widget.connectionRow.id,
-      onNew: () => _sqlController.clear(),
+      onNew: _addNewTab,
       onOpen: () => unawaited(_openSqlFile()),
       onSave: () => unawaited(_saveSqlFile()),
+      onCloseTab: () {
+        if (_sessions.length > 1) {
+          unawaited(_closeTab(_activeSessionIndex));
+        }
+      },
+      onNextTab: _nextTab,
+      onPrevTab: _prevTab,
       onExecute: () {
-        if (!_running) unawaited(_execute());
+        if (!_activeSession.running) unawaited(_execute(_activeSession));
       },
     );
+  }
+
+  void _addNewTab({String? initialSql, String? title, String? filePath}) {
+    setState(() {
+      _nextSessionId++;
+      final session = SqlQueryTabSession(
+        id: 'sqlite_tab_$_nextSessionId',
+        title: title ?? 'Query $_nextSessionId',
+        initialSql: initialSql,
+        filePath: filePath,
+        initialFraction:
+            _sessions.isNotEmpty ? _activeSession.topFraction.value : 0.65,
+      );
+      _sessions.add(session);
+      _activeSessionIndex = _sessions.length - 1;
+    });
+  }
+
+  Future<void> _closeTab(int index) async {
+    if (index < 0 || index >= _sessions.length) return;
+    if (_sessions.length <= 1) return;
+    final session = _sessions[index];
+    if (session.stagingBuffer != null && session.stagingBuffer!.isDirty) {
+      final confirmed = await showUnsavedTabChangesDialog(
+        context: context,
+        tabTitle: session.title,
+      );
+      if (confirmed != true) return;
+    }
+    if (!mounted) return;
+    setState(() {
+      _sessions.removeAt(index);
+      session.dispose();
+      if (_activeSessionIndex >= _sessions.length) {
+        _activeSessionIndex = _sessions.length - 1;
+      }
+    });
+  }
+
+  void _nextTab() {
+    if (_sessions.length <= 1) return;
+    setState(() {
+      _activeSessionIndex = (_activeSessionIndex + 1) % _sessions.length;
+    });
+  }
+
+  void _prevTab() {
+    if (_sessions.length <= 1) return;
+    setState(() {
+      _activeSessionIndex =
+          (_activeSessionIndex - 1 + _sessions.length) % _sessions.length;
+    });
   }
 
   @override
@@ -123,21 +181,22 @@ class _SqliteSqlWorkspaceState extends material.State<SqliteSqlWorkspace> {
         .unregister(connectionId: widget.connectionRow.id);
     SqlWorkspaceSettingsRevision.listenable
         .removeListener(_appSettingsListener);
-    _topFraction.dispose();
     _lease?.release();
-    _stagingBuffer?.dispose();
-    _stagingBuffer = null;
-    _sqlController.dispose();
+    for (final s in _sessions) {
+      s.dispose();
+    }
+    _sessions.clear();
     super.dispose();
   }
 
-  Future<void> _execute() async {
-    final selection = _sqlController.selection;
+  Future<void> _execute([SqlQueryTabSession? targetSession]) async {
+    final session = targetSession ?? _activeSession;
+    final selection = session.controller.selection;
     String userSql;
     if (selection.isValid && !selection.isCollapsed) {
-      userSql = selection.textInside(_sqlController.text).trim();
+      userSql = selection.textInside(session.controller.text).trim();
     } else {
-      userSql = _sqlController.text.trim();
+      userSql = session.controller.text.trim();
     }
     if (userSql.isEmpty) return;
 
@@ -158,12 +217,12 @@ class _SqliteSqlWorkspaceState extends material.State<SqliteSqlWorkspace> {
     }
 
     setState(() {
-      _running = true;
-      _error = null;
-      _columns = [];
-      _rows = [];
-      _affectedRows = null;
-      _statusLine = null;
+      session.running = true;
+      session.error = null;
+      session.columns = [];
+      session.rows = [];
+      session.affectedRows = null;
+      session.statusLine = null;
     });
 
     try {
@@ -172,8 +231,8 @@ class _SqliteSqlWorkspaceState extends material.State<SqliteSqlWorkspace> {
       if (conn == null || !conn.isConnected) {
         if (mounted) {
           setState(() {
-            _error = 'Could not connect to SQLite.';
-            _running = false;
+            session.error = 'Could not connect to SQLite.';
+            session.running = false;
           });
         }
         return;
@@ -204,22 +263,22 @@ class _SqliteSqlWorkspaceState extends material.State<SqliteSqlWorkspace> {
       final outRows = await convertResultRowsToStringsAdaptive(rawRows);
 
       setState(() {
-        _columns = cols;
-        _rows = outRows;
-        _affectedRows = null;
-        _lastExecutedSql = userSql;
-        _stagingBuffer?.dispose();
-        _stagingBuffer = cols.isNotEmpty
+        session.columns = cols;
+        session.rows = outRows;
+        session.affectedRows = null;
+        session.lastExecutedSql = userSql;
+        session.stagingBuffer?.dispose();
+        session.stagingBuffer = cols.isNotEmpty
             ? DataGridStagingBuffer(columns: cols, rows: outRows)
             : null;
         if (cols.isEmpty && outRows.isEmpty) {
-          _statusLine = 'Command completed.';
+          session.statusLine = 'Command completed.';
         } else if (truncated || (injectedLimit && results.length >= cap)) {
-          _statusLine = 'Showing first $cap row(s) (result capped).';
+          session.statusLine = 'Showing first $cap row(s) (result capped).';
         } else {
-          _statusLine = '${results.length} row(s).';
+          session.statusLine = '${results.length} row(s).';
         }
-        _running = false;
+        session.running = false;
       });
 
       final cid = widget.connectionRow.id;
@@ -237,34 +296,41 @@ class _SqliteSqlWorkspaceState extends material.State<SqliteSqlWorkspace> {
       unawaited(_lease?.connection.forceClose());
       if (mounted) {
         setState(() {
-          _error = 'Query timed out: ${e.message ?? e}';
-          _running = false;
+          session.error = 'Query timed out: ${e.message ?? e}';
+          session.running = false;
         });
       }
     } catch (e) {
       if (mounted) {
         setState(() {
-          _error = e.toString();
-          _running = false;
+          session.error = e.toString();
+          session.running = false;
         });
       }
     }
   }
 
-  Future<void> _applyStagedChanges() async {
-    if (_stagingBuffer == null || !_stagingBuffer!.isDirty || _savingChanges) return;
-    final target = _lastExecutedSql != null ? SqlTableTargetExtractor.extract(_lastExecutedSql!) : null;
+  Future<void> _applyStagedChanges([SqlQueryTabSession? targetSession]) async {
+    final session = targetSession ?? _activeSession;
+    if (session.stagingBuffer == null ||
+        !session.stagingBuffer!.isDirty ||
+        session.savingChanges) {
+      return;
+    }
+    final target = session.lastExecutedSql != null
+        ? SqlTableTargetExtractor.extract(session.lastExecutedSql!)
+        : null;
     final tableName = target?.tableName ?? 'table';
 
-    setState(() => _savingChanges = true);
+    setState(() => session.savingChanges = true);
     try {
-      final plan = _stagingBuffer!.generateMutationPlan(
+      final plan = session.stagingBuffer!.generateMutationPlan(
         dialect: SqlDialect.sqlite,
         tableName: tableName,
         schema: target?.schema,
       );
       if (plan.isEmpty) {
-        setState(() => _savingChanges = false);
+        setState(() => session.savingChanges = false);
         return;
       }
 
@@ -273,7 +339,7 @@ class _SqliteSqlWorkspaceState extends material.State<SqliteSqlWorkspace> {
         plan: plan,
       );
       if (confirmed != true) {
-        setState(() => _savingChanges = false);
+        setState(() => session.savingChanges = false);
         return;
       }
 
@@ -288,16 +354,17 @@ class _SqliteSqlWorkspaceState extends material.State<SqliteSqlWorkspace> {
       }
 
       if (!mounted) return;
-      final newRows = _stagingBuffer!.effectiveRows;
-      _stagingBuffer?.dispose();
+      final newRows = session.stagingBuffer!.effectiveRows;
+      session.stagingBuffer?.dispose();
       setState(() {
-        _rows = newRows;
-        _stagingBuffer = DataGridStagingBuffer(columns: _columns, rows: _rows);
-        _savingChanges = false;
+        session.rows = newRows;
+        session.stagingBuffer =
+            DataGridStagingBuffer(columns: session.columns, rows: session.rows);
+        session.savingChanges = false;
       });
     } catch (e) {
       if (mounted) {
-        setState(() => _savingChanges = false);
+        setState(() => session.savingChanges = false);
         await showAppDialog<void>(
           context: context,
           builder: (ctx) => material.AlertDialog(
@@ -328,10 +395,18 @@ class _SqliteSqlWorkspaceState extends material.State<SqliteSqlWorkspace> {
       if (file == null) return;
       final text = await file.readAsString();
       if (!mounted) return;
-      _sqlController.value = material.TextEditingValue(
-        text: text,
-        selection: material.TextSelection.collapsed(offset: text.length),
-      );
+      final session = _activeSession;
+      if (session.controller.text.trim().isEmpty && session.rows.isEmpty) {
+        session.controller.value = material.TextEditingValue(
+          text: text,
+          selection: material.TextSelection.collapsed(offset: text.length),
+        );
+        session.title = file.name;
+        session.filePath = file.path;
+        setState(() {});
+      } else {
+        _addNewTab(initialSql: text, title: file.name, filePath: file.path);
+      }
     } catch (e) {
       if (!mounted) return;
       showAppToast(
@@ -344,16 +419,41 @@ class _SqliteSqlWorkspaceState extends material.State<SqliteSqlWorkspace> {
 
   Future<void> _saveSqlFile() async {
     try {
-      final name = 'query_${DateTime.now().toIso8601String().replaceAll(':', '-')}.sql';
+      final session = _activeSession;
+      final existingPath = session.filePath;
+      if (existingPath != null && existingPath.isNotEmpty) {
+        await File(existingPath).writeAsString(session.controller.text);
+        if (!mounted) return;
+        showAppToast(
+          context: context,
+          message: 'Saved ${session.title}',
+          variant: AppToastVariant.success,
+        );
+        return;
+      }
+
+      final suggested = session.title.endsWith('.sql')
+          ? session.title
+          : '${session.title}.sql';
       final location = await getSaveLocation(
         acceptedTypeGroups: const [
           XTypeGroup(label: 'SQL', extensions: ['sql']),
         ],
-        suggestedName: name,
+        suggestedName: suggested,
       );
       final path = location?.path;
       if (path == null || path.isEmpty) return;
-      await File(path).writeAsString(_sqlController.text);
+      await File(path).writeAsString(session.controller.text);
+      if (!mounted) return;
+      setState(() {
+        session.filePath = path;
+        session.title = File(path).uri.pathSegments.last;
+      });
+      showAppToast(
+        context: context,
+        message: 'Saved to ${session.title}',
+        variant: AppToastVariant.success,
+      );
     } catch (e) {
       if (!mounted) return;
       showAppToast(
@@ -366,13 +466,31 @@ class _SqliteSqlWorkspaceState extends material.State<SqliteSqlWorkspace> {
 
   @override
   material.Widget build(material.BuildContext context) {
-    final theme = Theme.of(context);
-
     return Actions(
       actions: <Type, Action<Intent>>{
         NewSqlIntent: CallbackAction<NewSqlIntent>(
           onInvoke: (intent) {
-            _sqlController.clear();
+            _addNewTab();
+            return null;
+          },
+        ),
+        CloseSqlTabIntent: CallbackAction<CloseSqlTabIntent>(
+          onInvoke: (intent) {
+            if (_sessions.length > 1) {
+              unawaited(_closeTab(_activeSessionIndex));
+            }
+            return null;
+          },
+        ),
+        NextSqlTabIntent: CallbackAction<NextSqlTabIntent>(
+          onInvoke: (intent) {
+            _nextTab();
+            return null;
+          },
+        ),
+        PrevSqlTabIntent: CallbackAction<PrevSqlTabIntent>(
+          onInvoke: (intent) {
+            _prevTab();
             return null;
           },
         ),
@@ -391,110 +509,150 @@ class _SqliteSqlWorkspaceState extends material.State<SqliteSqlWorkspace> {
       },
       child: material.CallbackShortcuts(
         bindings: {
+          const material.SingleActivator(LogicalKeyboardKey.keyT, control: true): _addNewTab,
+          const material.SingleActivator(LogicalKeyboardKey.keyT, meta: true): _addNewTab,
+          const material.SingleActivator(LogicalKeyboardKey.keyW, control: true): () {
+            if (_sessions.length > 1) unawaited(_closeTab(_activeSessionIndex));
+          },
+          const material.SingleActivator(LogicalKeyboardKey.keyW, meta: true): () {
+            if (_sessions.length > 1) unawaited(_closeTab(_activeSessionIndex));
+          },
+          const material.SingleActivator(LogicalKeyboardKey.tab, control: true): _nextTab,
+          const material.SingleActivator(LogicalKeyboardKey.tab, control: true, shift: true): _prevTab,
           const material.SingleActivator(LogicalKeyboardKey.f5): () {
-            if (!_running) unawaited(_execute());
+            if (!_activeSession.running) unawaited(_execute(_activeSession));
           },
           const material.SingleActivator(
             LogicalKeyboardKey.enter,
             control: true,
           ): () {
-            if (!_running) unawaited(_execute());
+            if (!_activeSession.running) unawaited(_execute(_activeSession));
           },
           const material.SingleActivator(
             LogicalKeyboardKey.enter,
             meta: true,
           ): () {
-            if (!_running) unawaited(_execute());
+            if (!_activeSession.running) unawaited(_execute(_activeSession));
           },
           const material.SingleActivator(
             LogicalKeyboardKey.numpadEnter,
             control: true,
           ): () {
-            if (!_running) unawaited(_execute());
+            if (!_activeSession.running) unawaited(_execute(_activeSession));
           },
           const material.SingleActivator(
             LogicalKeyboardKey.numpadEnter,
             meta: true,
           ): () {
-            if (!_running) unawaited(_execute());
+            if (!_activeSession.running) unawaited(_execute(_activeSession));
           },
           const material.SingleActivator(
             LogicalKeyboardKey.keyR,
             control: true,
           ): () {
-            if (!_running) unawaited(_execute());
+            if (!_activeSession.running) unawaited(_execute(_activeSession));
           },
           const material.SingleActivator(
             LogicalKeyboardKey.keyR,
             meta: true,
           ): () {
-            if (!_running) unawaited(_execute());
+            if (!_activeSession.running) unawaited(_execute(_activeSession));
           },
         },
         child: material.Focus(
           autofocus: true,
-          child: VerticalSplitPane(
-            fraction: _topFraction,
-            maxFraction: 0.85,
-            top: material.Column(
-              crossAxisAlignment: material.CrossAxisAlignment.stretch,
-              children: [
-                _SqliteSqlToolbar(
-                  onExecute: _running ? null : _execute,
-                  running: _running,
-                  onOpenPreferences: () => showPreferencesDialog(context),
-                  onOpenHistory: widget.connectionRow.id != null && !_running
-                      ? () {
-                          showSqlQueryHistoryDialog(
-                            context: context,
-                            connectionId: widget.connectionRow.id!,
-                            databaseName: widget.connectionRow.databaseName,
-                            sqlController: _sqlController,
-                          );
-                        }
-                      : null,
+          child: material.Column(
+            crossAxisAlignment: material.CrossAxisAlignment.stretch,
+            children: [
+              SqlQueryTabBar(
+                sessions: _sessions,
+                selectedIndex: _activeSessionIndex,
+                onSelect: (index) => setState(() => _activeSessionIndex = index),
+                onAdd: _addNewTab,
+                onClose: _sessions.length > 1
+                    ? (index) => unawaited(_closeTab(index))
+                    : null,
+              ),
+              material.Expanded(
+                child: material.IndexedStack(
+                  index: _activeSessionIndex,
+                  children: [
+                    for (final session in _sessions)
+                      _buildSessionPane(context, session),
+                  ],
                 ),
-                const Divider(height: 1),
-                material.Expanded(
-                  child: QueryEditorTab(
-                    controller: _sqlController,
-                    fontSize: _editorFontSize,
-                  ),
-                ),
-              ],
-            ),
-            bottom: material.Column(
-              crossAxisAlignment: material.CrossAxisAlignment.stretch,
-              children: [
-                material.Container(
-                  constraints: const material.BoxConstraints(minHeight: 44),
-                  padding: const material.EdgeInsets.symmetric(
-                    horizontal: 12,
-                  ),
-                  decoration: material.BoxDecoration(
-                    color: theme.colorScheme.muted.withValues(alpha: 0.6),
-                  ),
-                  alignment: material.Alignment.centerLeft,
-                  child: const Text('Data Output').semiBold().small(),
-                ),
-                const Divider(height: 1),
-                material.Expanded(
-                  child: ResultsTab(
-                    columns: _columns,
-                    rows: _rows,
-                    errorMessage: _error,
-                    isLoading: _running,
-                    affectedRows: _affectedRows,
-                    statusLine: _statusLine,
-                    stagingBuffer: _stagingBuffer,
-                    onApplyChanges: widget.isReadOnly ? null : _applyStagedChanges,
-                    isSaving: _savingChanges,
-                  ),
-                ),
-              ],
-            ),
+              ),
+            ],
           ),
         ),
+      ),
+    );
+  }
+
+  material.Widget _buildSessionPane(
+    material.BuildContext context,
+    SqlQueryTabSession session,
+  ) {
+    final theme = Theme.of(context);
+    return VerticalSplitPane(
+      fraction: session.topFraction,
+      maxFraction: 0.85,
+      top: material.Column(
+        crossAxisAlignment: material.CrossAxisAlignment.stretch,
+        children: [
+          _SqliteSqlToolbar(
+            onExecute: session.running ? null : () => _execute(session),
+            running: session.running,
+            onOpenPreferences: () => showPreferencesDialog(context),
+            onOpenHistory: widget.connectionRow.id != null && !session.running
+                ? () {
+                    showSqlQueryHistoryDialog(
+                      context: context,
+                      connectionId: widget.connectionRow.id!,
+                      databaseName: widget.connectionRow.databaseName,
+                      sqlController: session.controller,
+                    );
+                  }
+                : null,
+          ),
+          const Divider(height: 1),
+          material.Expanded(
+            child: QueryEditorTab(
+              controller: session.controller,
+              fontSize: _editorFontSize,
+            ),
+          ),
+        ],
+      ),
+      bottom: material.Column(
+        crossAxisAlignment: material.CrossAxisAlignment.stretch,
+        children: [
+          material.Container(
+            constraints: const material.BoxConstraints(minHeight: 44),
+            padding: const material.EdgeInsets.symmetric(
+              horizontal: 12,
+            ),
+            decoration: material.BoxDecoration(
+              color: theme.colorScheme.muted.withValues(alpha: 0.6),
+            ),
+            alignment: material.Alignment.centerLeft,
+            child: const Text('Data Output').semiBold().small(),
+          ),
+          const Divider(height: 1),
+          material.Expanded(
+            child: ResultsTab(
+              columns: session.columns,
+              rows: session.rows,
+              errorMessage: session.error,
+              isLoading: session.running,
+              affectedRows: session.affectedRows,
+              statusLine: session.statusLine,
+              stagingBuffer: session.stagingBuffer,
+              onApplyChanges: widget.isReadOnly ? null : () => _applyStagedChanges(session),
+              isSaving: session.savingChanges,
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/features/workspace/sql_query_tab_bar.dart
+++ b/lib/features/workspace/sql_query_tab_bar.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart' as material;
+import 'package:querya_desktop/features/workspace/sql_query_tab_session.dart';
+import 'package:querya_desktop/shared/widgets/app_dialog.dart';
+import 'package:querya_desktop/shared/widgets/querya_tab_strip.dart';
+import 'package:shadcn_flutter/shadcn_flutter.dart';
+
+/// Lightweight query tab strip rendered above the SQL editor workspace.
+class SqlQueryTabBar extends material.StatelessWidget {
+  const SqlQueryTabBar({
+    super.key,
+    required this.sessions,
+    required this.selectedIndex,
+    required this.onSelect,
+    required this.onAdd,
+    this.onClose,
+  });
+
+  final List<SqlQueryTabSession> sessions;
+  final int selectedIndex;
+  final material.ValueChanged<int> onSelect;
+  final material.VoidCallback onAdd;
+  final material.ValueChanged<int>? onClose;
+
+  @override
+  material.Widget build(material.BuildContext context) {
+    final theme = Theme.of(context);
+    final cs = theme.colorScheme;
+
+    return material.Container(
+      height: 40,
+      padding: const material.EdgeInsets.symmetric(horizontal: 8),
+      decoration: material.BoxDecoration(
+        color: cs.card,
+        border: material.Border(
+          bottom: material.BorderSide(color: cs.border),
+        ),
+      ),
+      child: material.Row(
+        children: [
+          material.Expanded(
+            child: material.SingleChildScrollView(
+              scrollDirection: material.Axis.horizontal,
+              child: QueryaTabStrip(
+                labels: sessions.map((s) => s.title).toList(),
+                selectedIndex: selectedIndex,
+                onSelected: onSelect,
+                onClose: onClose,
+                onAdd: onAdd,
+                canClose: sessions.length > 1 ? (_) => true : (_) => false,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Prompts confirmation when attempting to close a query tab that has uncommitted
+/// staged database modifications.
+Future<bool?> showUnsavedTabChangesDialog({
+  required material.BuildContext context,
+  required String tabTitle,
+}) {
+  return showAppDialog<bool>(
+    context: context,
+    builder: (ctx) {
+      final theme = Theme.of(ctx);
+      final cs = theme.colorScheme;
+
+      return material.Dialog(
+        backgroundColor: cs.card,
+        shape: material.RoundedRectangleBorder(
+          borderRadius: material.BorderRadius.circular(8),
+          side: material.BorderSide(color: cs.border, width: 1),
+        ),
+        child: material.ConstrainedBox(
+          constraints: const material.BoxConstraints(maxWidth: 420),
+          child: material.Padding(
+            padding: const material.EdgeInsets.all(20),
+            child: material.Column(
+              mainAxisSize: material.MainAxisSize.min,
+              crossAxisAlignment: material.CrossAxisAlignment.start,
+              children: [
+                Text('Unsaved Changes in "$tabTitle"').semiBold().large(),
+                const Gap(8),
+                const Text(
+                  'This query tab contains staged database changes that have not been applied yet. Closing the tab will discard these changes.',
+                ).muted().small(),
+                const Gap(20),
+                material.Align(
+                  alignment: material.Alignment.centerRight,
+                  child: material.Wrap(
+                    alignment: material.WrapAlignment.end,
+                    spacing: 8,
+                    runSpacing: 8,
+                    children: [
+                      OutlineButton(
+                        onPressed: () => material.Navigator.of(ctx).pop(false),
+                        child: const Text('Cancel'),
+                      ),
+                      DestructiveButton(
+                        onPressed: () => material.Navigator.of(ctx).pop(true),
+                        child: const Text('Discard & Close'),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+    },
+  );
+}

--- a/lib/features/workspace/sql_query_tab_session.dart
+++ b/lib/features/workspace/sql_query_tab_session.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart' as material;
+import 'package:querya_desktop/features/workspace/data_grid_staging_buffer.dart';
+
+/// A stateful query session inside an SQL workspace.
+///
+/// Each tab preserves its own query text buffer, execution results, status,
+/// error state, and DML staging buffer independently.
+class SqlQueryTabSession {
+  SqlQueryTabSession({
+    required this.id,
+    required this.title,
+    String? initialSql,
+    this.filePath,
+    double initialFraction = 0.65,
+  })  : controller = material.TextEditingController(text: initialSql ?? ''),
+        topFraction = material.ValueNotifier<double>(initialFraction);
+
+  final String id;
+  String title;
+  String? filePath;
+  final material.TextEditingController controller;
+  final material.ValueNotifier<double> topFraction;
+
+  bool running = false;
+  String? error;
+  List<String> columns = const [];
+  List<List<String>> rows = const [];
+  int? affectedRows;
+  String? statusLine;
+  DataGridStagingBuffer? stagingBuffer;
+  String? lastExecutedSql;
+  bool savingChanges = false;
+  bool isModified = false;
+
+  void dispose() {
+    controller.dispose();
+    topFraction.dispose();
+  }
+}

--- a/lib/features/workspace/workspace.dart
+++ b/lib/features/workspace/workspace.dart
@@ -17,4 +17,6 @@ export 'result_grid_view.dart';
 export 'results_tab.dart';
 export 'sql_editor_chrome.dart';
 export 'sql_query_history_dialog.dart';
+export 'sql_query_tab_bar.dart';
+export 'sql_query_tab_session.dart';
 export 'xml_html_formatter.dart';

--- a/lib/shared/widgets/querya_tab_strip.dart
+++ b/lib/shared/widgets/querya_tab_strip.dart
@@ -20,11 +20,17 @@ class QueryaTabStrip extends material.StatefulWidget {
     required this.labels,
     required this.selectedIndex,
     required this.onSelected,
+    this.onClose,
+    this.onAdd,
+    this.canClose,
   }) : assert(labels.length > 0);
 
   final List<String> labels;
   final int selectedIndex;
   final material.ValueChanged<int> onSelected;
+  final material.ValueChanged<int>? onClose;
+  final material.VoidCallback? onAdd;
+  final bool Function(int index)? canClose;
 
   @override
   material.State<QueryaTabStrip> createState() => _QueryaTabStripState();
@@ -175,61 +181,116 @@ class _QueryaTabStripState extends material.State<QueryaTabStrip>
 
     final tabs = material.Row(
       mainAxisSize: material.MainAxisSize.min,
-      children: List.generate(widget.labels.length, (index) {
-        final selected = widget.selectedIndex == index;
-        final focused = _focused[index];
-        final label = widget.labels[index];
-        return material.Padding(
-          padding: material.EdgeInsets.only(left: index == 0 ? 0 : 6),
-          child: material.KeyedSubtree(
-            key: _tabKeys[index],
-            child: material.Focus(
-              focusNode: _focusNodes[index],
-              onFocusChange: (value) =>
-                  setState(() => _focused[index] = value),
-              onKeyEvent: (_, event) => _onKeyEvent(index, event),
-              child: material.Semantics(
-                button: true,
-                selected: selected,
-                label: label,
-                onTap: () => _selectAndFocus(index),
-                child: material.ExcludeSemantics(
-                  child: material.MouseRegion(
-                    cursor: material.SystemMouseCursors.click,
-                    child: material.GestureDetector(
-                      excludeFromSemantics: true,
-                      behavior: material.HitTestBehavior.opaque,
-                      onTap: () => _selectAndFocus(index),
-                      child: material.AnimatedContainer(
-                        key: material.ValueKey('querya_tab_$label'),
-                        duration: context.motionDuration(QueryaMotion.fast),
-                        curve: context.motionCurve(QueryaMotion.enter),
-                        padding: const material.EdgeInsets.symmetric(
-                          horizontal: 12,
-                          vertical: 8,
-                        ),
-                        decoration: material.BoxDecoration(
-                          color: material.Colors.transparent,
-                          borderRadius: material.BorderRadius.circular(6),
-                          border: material.Border.all(
-                            color: focused
-                                ? colors.ring
-                                : material.Colors.transparent,
-                            width: 2,
+      children: [
+        ...List.generate(widget.labels.length, (index) {
+          final selected = widget.selectedIndex == index;
+          final focused = _focused[index];
+          final label = widget.labels[index];
+          final showClose = widget.onClose != null &&
+              (widget.canClose == null || widget.canClose!(index));
+          return material.Padding(
+            padding: material.EdgeInsets.only(left: index == 0 ? 0 : 6),
+            child: material.KeyedSubtree(
+              key: _tabKeys[index],
+              child: material.Focus(
+                focusNode: _focusNodes[index],
+                onFocusChange: (value) =>
+                    setState(() => _focused[index] = value),
+                onKeyEvent: (_, event) => _onKeyEvent(index, event),
+                child: material.Semantics(
+                  button: true,
+                  selected: selected,
+                  label: label,
+                  onTap: () => _selectAndFocus(index),
+                  child: material.ExcludeSemantics(
+                    child: material.MouseRegion(
+                      cursor: material.SystemMouseCursors.click,
+                      child: material.GestureDetector(
+                        excludeFromSemantics: true,
+                        behavior: material.HitTestBehavior.opaque,
+                        onTap: () => _selectAndFocus(index),
+                        child: material.AnimatedContainer(
+                          key: material.ValueKey('querya_tab_$label'),
+                          duration: context.motionDuration(QueryaMotion.fast),
+                          curve: context.motionCurve(QueryaMotion.enter),
+                          padding: material.EdgeInsets.symmetric(
+                            horizontal: showClose ? 10 : 12,
+                            vertical: 8,
+                          ),
+                          decoration: material.BoxDecoration(
+                            color: material.Colors.transparent,
+                            borderRadius: material.BorderRadius.circular(6),
+                            border: material.Border.all(
+                              color: focused
+                                  ? colors.ring
+                                  : material.Colors.transparent,
+                              width: 2,
+                            ),
+                          ),
+                          child: material.Row(
+                            mainAxisSize: material.MainAxisSize.min,
+                            children: [
+                              selected
+                                  ? Text(label).small().semiBold()
+                                  : Text(label).small().muted(),
+                              if (showClose) ...[
+                                const Gap(6),
+                                material.MouseRegion(
+                                  cursor: material.SystemMouseCursors.click,
+                                  child: material.GestureDetector(
+                                    behavior: material.HitTestBehavior.opaque,
+                                    onTap: () => widget.onClose!(index),
+                                    child: material.Container(
+                                      padding: const material.EdgeInsets.all(1),
+                                      decoration: material.BoxDecoration(
+                                        borderRadius:
+                                            material.BorderRadius.circular(4),
+                                      ),
+                                      child: material.Icon(
+                                        material.Icons.close_rounded,
+                                        size: 13,
+                                        color: selected
+                                            ? colors.foreground
+                                            : colors.mutedForeground,
+                                      ),
+                                    ),
+                                  ),
+                                ),
+                              ],
+                            ],
                           ),
                         ),
-                        child: selected
-                            ? Text(label).small().semiBold()
-                            : Text(label).small().muted(),
                       ),
                     ),
                   ),
                 ),
               ),
             ),
+          );
+        }),
+        if (widget.onAdd != null) ...[
+          const Gap(4),
+          material.MouseRegion(
+            cursor: material.SystemMouseCursors.click,
+            child: material.GestureDetector(
+              behavior: material.HitTestBehavior.opaque,
+              onTap: widget.onAdd,
+              child: material.Container(
+                key: const material.ValueKey('querya_tab_add_button'),
+                padding: const material.EdgeInsets.all(6),
+                decoration: material.BoxDecoration(
+                  borderRadius: material.BorderRadius.circular(6),
+                ),
+                child: material.Icon(
+                  material.Icons.add_rounded,
+                  size: 16,
+                  color: colors.mutedForeground,
+                ),
+              ),
+            ),
           ),
-        );
-      }),
+        ],
+      ],
     );
 
     return material.KeyedSubtree(

--- a/test/features/workspace/multi_tab_sql_workspace_test.dart
+++ b/test/features/workspace/multi_tab_sql_workspace_test.dart
@@ -1,0 +1,183 @@
+import 'package:flutter/material.dart' as material;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:querya_desktop/core/actions/sql_editor_command_bridge.dart';
+import 'package:querya_desktop/features/workspace/data_grid_staging_buffer.dart';
+import 'package:querya_desktop/features/workspace/sql_query_tab_bar.dart';
+import 'package:querya_desktop/features/workspace/sql_query_tab_session.dart';
+
+import '../../support/querya_theme_test_shell.dart';
+
+void main() {
+  group('SqlQueryTabSession', () {
+    test('initializes with default and custom values', () {
+      final session = SqlQueryTabSession(
+        id: 'tab_1',
+        title: 'Query 1',
+        initialSql: 'SELECT 1;',
+      );
+
+      expect(session.id, 'tab_1');
+      expect(session.title, 'Query 1');
+      expect(session.controller.text, 'SELECT 1;');
+      expect(session.running, isFalse);
+      expect(session.columns, isEmpty);
+      expect(session.rows, isEmpty);
+      expect(session.stagingBuffer, isNull);
+
+      session.dispose();
+    });
+
+    test('state is isolated across multiple sessions', () {
+      final tab1 = SqlQueryTabSession(id: '1', title: 'Tab 1', initialSql: 'SELECT A;');
+      final tab2 = SqlQueryTabSession(id: '2', title: 'Tab 2', initialSql: 'SELECT B;');
+
+      tab1.columns = ['a'];
+      tab1.rows = [['val_a']];
+      tab1.statusLine = '1 row.';
+
+      tab2.columns = ['b', 'c'];
+      tab2.rows = [['val_b', 'val_c']];
+      tab2.statusLine = '2 rows.';
+
+      expect(tab1.controller.text, 'SELECT A;');
+      expect(tab2.controller.text, 'SELECT B;');
+      expect(tab1.columns, ['a']);
+      expect(tab2.columns, ['b', 'c']);
+      expect(tab1.statusLine, '1 row.');
+      expect(tab2.statusLine, '2 rows.');
+
+      tab1.dispose();
+      tab2.dispose();
+    });
+  });
+
+  group('SqlQueryTabBar widget', () {
+    testWidgets('renders all tab titles and handles tab selection', (tester) async {
+      final tab1 = SqlQueryTabSession(id: '1', title: 'Orders');
+      final tab2 = SqlQueryTabSession(id: '2', title: 'Users');
+      int selected = 0;
+      bool addCalled = false;
+      int? closedIndex;
+
+      await tester.pumpWidget(
+        queryaThemeTestShell(
+          child: material.StatefulBuilder(
+            builder: (context, setState) {
+              return material.Scaffold(
+                body: SqlQueryTabBar(
+                  sessions: [tab1, tab2],
+                  selectedIndex: selected,
+                  onSelect: (i) => setState(() => selected = i),
+                  onAdd: () => addCalled = true,
+                  onClose: (i) => closedIndex = i,
+                ),
+              );
+            },
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Orders'), findsOneWidget);
+      expect(find.text('Users'), findsOneWidget);
+
+      // Select second tab
+      await tester.tap(find.text('Users'));
+      await tester.pumpAndSettle();
+      expect(selected, 1);
+
+      // Add tab button
+      final addBtn = find.byIcon(material.Icons.add_rounded);
+      expect(addBtn, findsOneWidget);
+      await tester.tap(addBtn);
+      await tester.pumpAndSettle();
+      expect(addCalled, isTrue);
+
+      // Close tab button
+      final closeIcons = find.byIcon(material.Icons.close_rounded);
+      expect(closeIcons, findsNWidgets(2));
+      await tester.tap(closeIcons.last);
+      await tester.pumpAndSettle();
+      expect(closedIndex, 1);
+
+      tab1.dispose();
+      tab2.dispose();
+    });
+
+    testWidgets('shows unsaved tab changes dialog when closing dirty tab', (tester) async {
+      final buffer = DataGridStagingBuffer(
+        columns: ['id', 'name'],
+        rows: [['1', 'Alice']],
+      );
+      buffer.setCell(0, 1, 'Bob');
+      expect(buffer.isDirty, isTrue);
+
+      bool? dialogResult;
+
+      await tester.pumpWidget(
+        queryaThemeTestShell(
+          child: material.Builder(
+            builder: (context) {
+              return material.TextButton(
+                onPressed: () async {
+                  dialogResult = await showUnsavedTabChangesDialog(
+                    context: context,
+                    tabTitle: 'Dirty Tab',
+                  );
+                },
+                child: const material.Text('Open Dialog'),
+              );
+            },
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Open Dialog'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Unsaved Changes in "Dirty Tab"'), findsOneWidget);
+      expect(find.text('Discard & Close'), findsOneWidget);
+
+      // Tap Discard & Close
+      await tester.tap(find.text('Discard & Close'));
+      await tester.pumpAndSettle();
+
+      expect(dialogResult, isTrue);
+      buffer.dispose();
+    });
+  });
+
+  group('SqlEditorCommandBridge tab delegation', () {
+    test('routes onCloseTab, onNextTab, onPrevTab correctly', () {
+      final bridge = SqlEditorCommandBridge.instance;
+      bridge.resetForTest();
+
+      bool closed = false;
+      bool next = false;
+      bool prev = false;
+
+      bridge.register(
+        connectionId: 10,
+        onNew: () {},
+        onOpen: () {},
+        onSave: () {},
+        onCloseTab: () => closed = true,
+        onNextTab: () => next = true,
+        onPrevTab: () => prev = true,
+      );
+
+      expect(bridge.canCloseTab, isTrue);
+      bridge.invokeCloseTab();
+      expect(closed, isTrue);
+
+      bridge.invokeNextTab();
+      expect(next, isTrue);
+
+      bridge.invokePrevTab();
+      expect(prev, isTrue);
+
+      bridge.unregister(connectionId: 10);
+      expect(bridge.canCloseTab, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
Closes #679

### Summary of Changes
- **Multi-Tab Sessions Architecture**:
  - Added `SqlQueryTabSession` encapsulating query text (`TextEditingController`), top/bottom split fraction (`ValueNotifier<double>`), columns, rows, execution status, and in-memory `DataGridStagingBuffer`.
  - Added `SqlQueryTabBar` powered by `QueryaTabStrip` with dynamic close buttons on individual tabs and a `+` add tab button.
  - Implemented `showUnsavedTabChangesDialog` to guard against losing uncommitted staging changes when closing dirty query tabs.
  - Preserved tab state across switching via `material.IndexedStack`.
- **Workspaces Converted**:
  - `PostgresSqlWorkspace`
  - `MysqlSqlWorkspace`
  - `SqliteSqlWorkspace`
  - `ExtensionSqlWorkspace`
- **Keyboard Shortcuts & Bridge**:
  - Added intents and shortcuts for `Ctrl+T` / `Cmd+T` (new tab), `Ctrl+W` / `Cmd+W` (close tab), `Ctrl+Tab` (next tab), and `Ctrl+Shift+Tab` (previous tab), including Russian keyboard layout support.
  - Integrated with `SqlEditorCommandBridge`.
- **Automated Verification**:
  - Added unit and widget tests in `test/features/workspace/multi_tab_sql_workspace_test.dart` (100% passing).
  - Clean `dart analyze` with 0 issues.