### PR TITLE
feat(settings): master-detail categorized preferences dialog with sidebar and search (close #686)

### DIFF
--- a/lib/core/layout/window_layout.dart
+++ b/lib/core/layout/window_layout.dart
@@ -16,8 +16,8 @@ abstract class WindowLayout {
   static const double connectionFormMongoMaxHeight = 820;
 
   /// Preferences / settings dialog.
-  static const double preferencesDialogMaxWidth = 600;
-  static const double preferencesDialogMinWidth = 420;
+  static const double preferencesDialogMaxWidth = 760;
+  static const double preferencesDialogMinWidth = 480;
   static const double preferencesDialogMaxHeight = 760;
 
   /// Horizontal inset for modal dialogs (clamped by screen).

--- a/lib/features/settings/preferences_about_section.dart
+++ b/lib/features/settings/preferences_about_section.dart
@@ -1,0 +1,170 @@
+import 'package:flutter/material.dart' as material;
+import 'package:querya_desktop/core/extensions/extension_paths.dart';
+import 'package:querya_desktop/core/platform/open_directory.dart';
+import 'package:querya_desktop/core/storage/app_data_root.dart';
+import 'package:querya_desktop/core/theme/theme_paths.dart';
+import 'package:querya_desktop/core/ui/querya_icons.dart';
+import 'package:querya_desktop/shared/widgets/widgets.dart';
+import 'package:url_launcher/url_launcher_string.dart';
+
+class PreferencesAboutSection extends StatelessWidget {
+  const PreferencesAboutSection({super.key});
+
+  static const String appVersion = '0.4.15';
+  static const String githubRepoUrl = 'https://github.com/QueryaHub/Querya-Desktop';
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return material.Column(
+      crossAxisAlignment: material.CrossAxisAlignment.start,
+      children: [
+        // App Header Card
+        material.Container(
+          padding: const material.EdgeInsets.all(16),
+          decoration: material.BoxDecoration(
+            color: theme.colorScheme.muted.withValues(alpha: 0.18),
+            borderRadius: material.BorderRadius.circular(8),
+            border: material.Border.all(
+              color: theme.colorScheme.border.withValues(alpha: 0.25),
+            ),
+          ),
+          child: material.Row(
+            children: [
+              material.Container(
+                width: 48,
+                height: 48,
+                decoration: material.BoxDecoration(
+                  color: theme.colorScheme.primary.withValues(alpha: 0.12),
+                  borderRadius: material.BorderRadius.circular(8),
+                  border: material.Border.all(
+                    color: theme.colorScheme.primary.withValues(alpha: 0.3),
+                  ),
+                ),
+                child: material.Center(
+                  child: material.Icon(
+                    QueryaIcons.database,
+                    size: 24,
+                    color: theme.colorScheme.primary,
+                  ),
+                ),
+              ),
+              const material.SizedBox(width: 16),
+              material.Expanded(
+                child: material.Column(
+                  crossAxisAlignment: material.CrossAxisAlignment.start,
+                  children: [
+                    const Text('Querya Desktop').semiBold().large().foreground(),
+                    const material.SizedBox(height: 2),
+                    const Text('Version $appVersion (Desktop Build)').muted().small(),
+                    const material.SizedBox(height: 4),
+                    const Text('Fast, native multi-database management studio.')
+                        .muted()
+                        .xSmall(),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+
+        const material.SizedBox(height: 20),
+        const Text('Storage & Directories').semiBold().small().foreground(),
+        const material.SizedBox(height: 6),
+        const Text(
+          'Querya stores connection credentials securely and configuration in local SQLite.',
+        ).muted().xSmall(),
+        const material.SizedBox(height: 12),
+
+        material.Wrap(
+          spacing: 8,
+          runSpacing: 8,
+          children: [
+            OutlineButton(
+              onPressed: () async {
+                final dir = await AppDataRoot.applicationSupportDirectory();
+                await openDirectoryInFileManager(dir.path);
+              },
+              child: const material.Row(
+                mainAxisSize: material.MainAxisSize.min,
+                children: [
+                  material.Icon(material.Icons.folder_outlined, size: 14),
+                  material.SizedBox(width: 6),
+                  material.Text('Open App Data Folder'),
+                ],
+              ),
+            ),
+            OutlineButton(
+              onPressed: () async {
+                final dir = await ThemePaths.ensureUserThemesDirectory();
+                await openDirectoryInFileManager(dir.path);
+              },
+              child: const material.Row(
+                mainAxisSize: material.MainAxisSize.min,
+                children: [
+                  material.Icon(material.Icons.palette_outlined, size: 14),
+                  material.SizedBox(width: 6),
+                  material.Text('Open Themes Folder'),
+                ],
+              ),
+            ),
+            OutlineButton(
+              onPressed: () async {
+                final dir = await ExtensionPaths.ensureExtensionsDirectory();
+                await openDirectoryInFileManager(dir.path);
+              },
+              child: const material.Row(
+                mainAxisSize: material.MainAxisSize.min,
+                children: [
+                  material.Icon(material.Icons.extension_outlined, size: 14),
+                  material.SizedBox(width: 6),
+                  material.Text('Open Extensions Folder'),
+                ],
+              ),
+            ),
+          ],
+        ),
+
+        const material.SizedBox(height: 24),
+        const Text('Community & Support').semiBold().small().foreground(),
+        const material.SizedBox(height: 12),
+
+        material.Wrap(
+          spacing: 8,
+          runSpacing: 8,
+          children: [
+            OutlineButton(
+              onPressed: () => launchUrlString(
+                githubRepoUrl,
+                mode: LaunchMode.externalApplication,
+              ),
+              child: const material.Row(
+                mainAxisSize: material.MainAxisSize.min,
+                children: [
+                  material.Icon(material.Icons.code_rounded, size: 14),
+                  material.SizedBox(width: 6),
+                  material.Text('GitHub Repository'),
+                ],
+              ),
+            ),
+            OutlineButton(
+              onPressed: () => launchUrlString(
+                '$githubRepoUrl/issues',
+                mode: LaunchMode.externalApplication,
+              ),
+              child: const material.Row(
+                mainAxisSize: material.MainAxisSize.min,
+                children: [
+                  material.Icon(material.Icons.bug_report_outlined, size: 14),
+                  material.SizedBox(width: 6),
+                  material.Text('Report an Issue'),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/settings/preferences_category.dart
+++ b/lib/features/settings/preferences_category.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart' as material;
+
+/// Categorized sections of the [PreferencesDialog].
+enum PreferencesCategory {
+  general(
+    id: 'general',
+    label: 'General',
+    description: 'Startup, updates, release channel',
+    icon: material.Icons.tune_rounded,
+  ),
+  appearance(
+    id: 'appearance',
+    label: 'Appearance',
+    description: 'Themes, dark mode, scaling, animations',
+    icon: material.Icons.palette_outlined,
+  ),
+  sql(
+    id: 'sql',
+    label: 'SQL & Editor',
+    description: 'Editor font, statement timeouts, query history',
+    icon: material.Icons.terminal_rounded,
+  ),
+  dataGrid(
+    id: 'dataGrid',
+    label: 'Data Grid',
+    description: 'Result rows limit, column sizing, safety',
+    icon: material.Icons.table_chart_outlined,
+  ),
+  extensions(
+    id: 'extensions',
+    label: 'Extensions',
+    description: 'Sideloading .qext/.zip packages, extension folder',
+    icon: material.Icons.extension_outlined,
+  ),
+  shortcuts(
+    id: 'shortcuts',
+    label: 'Shortcuts',
+    description: 'Keyboard shortcuts reference and keymap',
+    icon: material.Icons.keyboard_outlined,
+  ),
+  about(
+    id: 'about',
+    label: 'About & Storage',
+    description: 'App version, local SQLite storage, paths',
+    icon: material.Icons.info_outline_rounded,
+  );
+
+  const PreferencesCategory({
+    required this.id,
+    required this.label,
+    required this.description,
+    required this.icon,
+  });
+
+  final String id;
+  final String label;
+  final String description;
+  final material.IconData icon;
+}

--- a/lib/features/settings/preferences_controls.dart
+++ b/lib/features/settings/preferences_controls.dart
@@ -101,6 +101,63 @@ class PreferencesCheckboxRow extends StatelessWidget {
   }
 }
 
+/// Leading title/subtitle with a trailing [material.Switch] for Preferences.
+class PreferencesSwitchRow extends StatelessWidget {
+  const PreferencesSwitchRow({
+    super.key,
+    required this.value,
+    required this.onChanged,
+    required this.title,
+    this.subtitle,
+    this.enabled = true,
+  });
+
+  final bool value;
+  final material.ValueChanged<bool>? onChanged;
+  final material.Widget title;
+  final material.Widget? subtitle;
+  final bool enabled;
+
+  @override
+  material.Widget build(material.BuildContext context) {
+    final isInteractive = enabled && onChanged != null;
+
+    return material.Material(
+      type: material.MaterialType.transparency,
+      child: material.InkWell(
+        onTap: isInteractive ? () => onChanged!(!value) : null,
+        borderRadius: material.BorderRadius.circular(6),
+        child: material.Padding(
+          padding: const material.EdgeInsets.symmetric(vertical: 6, horizontal: 4),
+          child: material.Row(
+            crossAxisAlignment: material.CrossAxisAlignment.center,
+            children: [
+              material.Expanded(
+                child: material.Column(
+                  crossAxisAlignment: material.CrossAxisAlignment.start,
+                  mainAxisSize: material.MainAxisSize.min,
+                  children: [
+                    title,
+                    if (subtitle != null) ...[
+                      const material.SizedBox(height: 2),
+                      subtitle!,
+                    ],
+                  ],
+                ),
+              ),
+              const material.SizedBox(width: 16),
+              material.Switch(
+                value: value,
+                onChanged: isInteractive ? onChanged : null,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 /// Label + full-width control row for Preferences (uniform dropdown width).
 class PreferencesFieldRow extends StatelessWidget {
   const PreferencesFieldRow({

--- a/lib/features/settings/preferences_dialog.dart
+++ b/lib/features/settings/preferences_dialog.dart
@@ -1,37 +1,59 @@
 import 'dart:async' show unawaited;
 
 import 'package:flutter/material.dart' as material;
+import 'package:flutter/services.dart' show LogicalKeyboardKey;
 import 'package:querya_desktop/core/layout/window_layout.dart';
 import 'package:querya_desktop/core/storage/app_settings.dart';
+import 'package:querya_desktop/core/updater/update_manifest.dart';
+import 'package:querya_desktop/features/settings/preferences_about_section.dart';
 import 'package:querya_desktop/features/settings/preferences_appearance_section.dart';
+import 'package:querya_desktop/features/settings/preferences_category.dart';
 import 'package:querya_desktop/features/settings/preferences_controls.dart';
 import 'package:querya_desktop/features/settings/preferences_extensions_section.dart';
+import 'package:querya_desktop/features/settings/preferences_shortcuts_section.dart';
 import 'package:querya_desktop/features/settings/sql_statement_timeout_dropdown.dart';
 import 'package:querya_desktop/shared/widgets/widgets.dart';
 
-void showPreferencesDialog(BuildContext context) {
+export 'preferences_category.dart';
+
+/// Opens application preferences in a master-detail dialog.
+void showPreferencesDialog(
+  BuildContext context, {
+  PreferencesCategory? initialCategory,
+}) {
   showAppDialog<void>(
     context: context,
     builder: (ctx) => material.Dialog(
       backgroundColor: material.Colors.transparent,
       insetPadding: WindowLayout.dialogSymmetricInsets(ctx),
-      child: const _PreferencesDialogContent(),
+      child: _PreferencesDialogContent(
+        initialCategory: initialCategory ?? PreferencesCategory.general,
+      ),
     ),
   );
 }
 
 class _PreferencesDialogContent extends material.StatefulWidget {
-  const _PreferencesDialogContent();
+  const _PreferencesDialogContent({
+    this.initialCategory = PreferencesCategory.general,
+  });
+
+  final PreferencesCategory initialCategory;
 
   @override
   material.State<_PreferencesDialogContent> createState() =>
-      _PreferencesDialogContentState();
+      PreferencesDialogContentState();
 }
 
-class _PreferencesDialogContentState
+class PreferencesDialogContentState
     extends material.State<_PreferencesDialogContent> {
-  bool _loading = true;
+  late PreferencesCategory _selectedCategory;
+  final _searchController = material.TextEditingController();
+  final _searchFocusNode = material.FocusNode();
+  String _searchQuery = '';
+
   bool _checkUpdatesOnStartup = true;
+  UpdateChannel _updateChannel = UpdateChannel.stable;
   bool _confirmDestructive = true;
   int? _pgTimeout;
   int? _mysqlTimeout;
@@ -39,37 +61,65 @@ class _PreferencesDialogContentState
   int _historyMax = kDefaultSqlHistoryMaxEntries;
   double _fontSize = kDefaultSqlEditorFontSize;
 
+  PreferencesCategory get selectedCategory => _selectedCategory;
+  String get searchQuery => _searchQuery;
+
   @override
   void initState() {
     super.initState();
+    _selectedCategory = widget.initialCategory;
     _load();
   }
 
+  @override
+  void dispose() {
+    _searchController.dispose();
+    _searchFocusNode.dispose();
+    super.dispose();
+  }
+
+  void selectCategory(PreferencesCategory category) {
+    setState(() => _selectedCategory = category);
+  }
+
+  void setSearchQueryForTest(String query) {
+    _searchController.text = query;
+    setState(() => _searchQuery = query.trim());
+  }
+
   Future<void> _load() async {
-    final startup = await AppSettings.instance.getCheckForUpdatesOnStartup();
-    final destructive =
-        await AppSettings.instance.getConfirmDestructiveOperations();
-    final pg = await AppSettings.instance.getPostgresSqlStmtTimeoutSeconds();
-    final my = await AppSettings.instance.getMysqlSqlStmtTimeoutSeconds();
-    final rows = await AppSettings.instance.getSqlResultMaxRows();
-    final hist = await AppSettings.instance.getSqlHistoryMaxEntries();
-    final font = await AppSettings.instance.getSqlEditorFontSize();
-    if (!mounted) return;
-    setState(() {
-      _checkUpdatesOnStartup = startup;
-      _confirmDestructive = destructive;
-      _pgTimeout = pg;
-      _mysqlTimeout = my;
-      _maxRows = rows;
-      _historyMax = hist;
-      _fontSize = font;
-      _loading = false;
-    });
+    try {
+      final startup = await AppSettings.instance.getCheckForUpdatesOnStartup();
+      final channel = await AppSettings.instance.getUpdateChannel();
+      final destructive =
+          await AppSettings.instance.getConfirmDestructiveOperations();
+      final pg = await AppSettings.instance.getPostgresSqlStmtTimeoutSeconds();
+      final my = await AppSettings.instance.getMysqlSqlStmtTimeoutSeconds();
+      final rows = await AppSettings.instance.getSqlResultMaxRows();
+      final hist = await AppSettings.instance.getSqlHistoryMaxEntries();
+      final font = await AppSettings.instance.getSqlEditorFontSize();
+      if (!mounted) return;
+      setState(() {
+        _checkUpdatesOnStartup = startup;
+        _updateChannel = channel;
+        _confirmDestructive = destructive;
+        _pgTimeout = pg;
+        _mysqlTimeout = my;
+        _maxRows = rows;
+        _historyMax = hist;
+        _fontSize = font;
+      });
+    } catch (_) {}
   }
 
   Future<void> _setCheckUpdatesOnStartup(bool enabled) async {
     setState(() => _checkUpdatesOnStartup = enabled);
     await AppSettings.instance.setCheckForUpdatesOnStartup(enabled);
+  }
+
+  Future<void> _setUpdateChannel(UpdateChannel channel) async {
+    setState(() => _updateChannel = channel);
+    await AppSettings.instance.setUpdateChannel(channel);
   }
 
   Future<void> _setConfirmDestructive(bool enabled) async {
@@ -102,224 +152,546 @@ class _PreferencesDialogContentState
     await AppSettings.instance.setSqlHistoryMaxEntries(v);
   }
 
+  int _matchCountForCategory(PreferencesCategory cat) {
+    if (_searchQuery.isEmpty) return 0;
+    final q = _searchQuery.toLowerCase();
+    int count = 0;
+    if (cat.label.toLowerCase().contains(q)) count++;
+    if (cat.description.toLowerCase().contains(q)) count++;
+
+    switch (cat) {
+      case PreferencesCategory.general:
+        if ('updates startup automatic release channel stable beta'
+            .contains(q)) {
+          count++;
+        }
+      case PreferencesCategory.appearance:
+        if ('theme dark light system scaling motion animation interface color'
+            .contains(q)) {
+          count++;
+        }
+      case PreferencesCategory.sql:
+        if ('font size postgresql mysql statement timeout history destructive drop truncate delete'
+            .contains(q)) {
+          count++;
+        }
+      case PreferencesCategory.dataGrid:
+        if ('max rows results grid column size formatting safety limits'
+            .contains(q)) {
+          count++;
+        }
+      case PreferencesCategory.extensions:
+        if ('extensions qext zip package install sideload folder directory'
+            .contains(q)) {
+          count++;
+        }
+      case PreferencesCategory.shortcuts:
+        final matching = PreferencesShortcutsSection.allShortcuts.where(
+          (s) =>
+              s.action.toLowerCase().contains(q) ||
+              s.keys.any((k) => k.toLowerCase().contains(q)),
+        );
+        count += matching.length;
+      case PreferencesCategory.about:
+        if ('about version storage directory cache logs sqlite'
+            .contains(q)) {
+          count++;
+        }
+    }
+    return count;
+  }
+
   @override
   material.Widget build(material.BuildContext context) {
     final theme = Theme.of(context).colorScheme;
     final onPopover = theme.popoverForeground;
-    return material.DefaultTextStyle(
-      style: material.TextStyle(color: onPopover),
-      child: material.IconTheme(
-        data: material.IconThemeData(color: onPopover),
-        child: QueryaDialogCard(
-          constraints: WindowLayout.dialogConstraints(
-            context,
-            maxWidth: WindowLayout.preferencesDialogMaxWidth,
-            minWidth: WindowLayout.preferencesDialogMinWidth,
-            maxHeight: WindowLayout.preferencesDialogMaxHeight,
-          ),
-          borderColor: theme.border,
-          child: material.Column(
-            crossAxisAlignment: material.CrossAxisAlignment.stretch,
-            children: [
-              material.Padding(
-                padding: const material.EdgeInsets.fromLTRB(24, 24, 24, 8),
-                child: material.Column(
-                  crossAxisAlignment: material.CrossAxisAlignment.start,
-                  children: [
-                    const Text('Preferences').large().semiBold().foreground(),
-                    const material.SizedBox(height: 6),
-                    const PreferencesHint(
-                      'Changes apply immediately. SQL timeouts are global for all connections of that type.',
+
+    return material.CallbackShortcuts(
+      bindings: {
+        const material.SingleActivator(LogicalKeyboardKey.keyF, control: true):
+            () => _searchFocusNode.requestFocus(),
+        const material.SingleActivator(LogicalKeyboardKey.keyF, meta: true):
+            () => _searchFocusNode.requestFocus(),
+      },
+      child: material.DefaultTextStyle(
+        style: material.TextStyle(color: onPopover),
+        child: material.IconTheme(
+          data: material.IconThemeData(color: onPopover),
+          child: QueryaDialogCard(
+            constraints: WindowLayout.dialogConstraints(
+              context,
+              maxWidth: WindowLayout.preferencesDialogMaxWidth,
+              minWidth: WindowLayout.preferencesDialogMinWidth,
+              maxHeight: WindowLayout.preferencesDialogMaxHeight,
+            ),
+            borderColor: theme.border,
+            child: material.Column(
+              crossAxisAlignment: material.CrossAxisAlignment.stretch,
+              children: [
+                // Dialog Header with Title and Search Input
+                material.Container(
+                  padding: const material.EdgeInsets.fromLTRB(20, 16, 16, 12),
+                  decoration: material.BoxDecoration(
+                    border: material.Border(
+                      bottom: material.BorderSide(
+                        color: theme.border.withValues(alpha: 0.28),
+                      ),
                     ),
-                  ],
-                ),
-              ),
-              material.Expanded(
-                child: material.SingleChildScrollView(
-                  padding: const material.EdgeInsets.symmetric(
-                      horizontal: 24, vertical: 8),
-                  child: _loading
-                      ? const material.Center(
-                          child: material.Padding(
-                            padding: material.EdgeInsets.all(24),
-                            child: material.CircularProgressIndicator(),
+                  ),
+                  child: material.Row(
+                    children: [
+                      material.Icon(
+                        material.Icons.tune_rounded,
+                        size: 20,
+                        color: theme.primary,
+                      ),
+                      const Gap(10),
+                      const Text('Preferences').large().semiBold().foreground(),
+                      const Gap(20),
+                      material.Expanded(
+                        child: material.Container(
+                          height: 32,
+                          padding: const material.EdgeInsets.symmetric(
+                              horizontal: 10),
+                          decoration: material.BoxDecoration(
+                            color: theme.muted.withValues(alpha: 0.25),
+                            borderRadius: material.BorderRadius.circular(6),
+                            border: material.Border.all(
+                              color: _searchQuery.isNotEmpty
+                                  ? theme.primary.withValues(alpha: 0.5)
+                                  : theme.border.withValues(alpha: 0.25),
+                            ),
                           ),
-                        )
-                      : material.Column(
-                          crossAxisAlignment: material.CrossAxisAlignment.start,
-                          children: [
-                            const Text('General')
-                                .semiBold()
-                                .small()
-                                .foreground(),
-                            const material.SizedBox(height: 8),
-                            PreferencesCheckboxRow(
-                              value: _checkUpdatesOnStartup,
-                              title: const Text(
-                                'Automatically check for updates on startup',
-                              ).small(),
-                              subtitle: const Text(
-                                'Queries GitHub Releases silently when Querya starts.',
-                              ).muted().xSmall(),
-                              onChanged: (v) {
-                                unawaited(_setCheckUpdatesOnStartup(v));
-                              },
-                            ),
-                            const material.SizedBox(height: 24),
-                            const PreferencesAppearanceSection(),
-                            const material.SizedBox(height: 24),
-                            const PreferencesExtensionsSection(),
-                            const material.SizedBox(height: 24),
-                            const Text('SQL — PostgreSQL')
-                                .semiBold()
-                                .small()
-                                .foreground(),
-                            const material.SizedBox(height: 8),
-                            PreferencesFieldRow(
-                              label: 'Statement timeout',
-                              control: SqlStatementTimeoutDropdown(
-                                value: _pgTimeout,
-                                expandToParent: true,
-                                onChanged: (v) => unawaited(_setPg(v)),
+                          child: material.Row(
+                            children: [
+                              material.Icon(
+                                material.Icons.search_rounded,
+                                size: 15,
+                                color: _searchQuery.isNotEmpty
+                                    ? theme.primary
+                                    : theme.mutedForeground,
                               ),
-                            ),
-                            const material.SizedBox(height: 24),
-                            const Text('SQL — MySQL / MariaDB')
-                                .semiBold()
-                                .small()
-                                .foreground(),
-                            const material.SizedBox(height: 8),
-                            PreferencesFieldRow(
-                              label: 'Statement timeout',
-                              control: SqlStatementTimeoutDropdown(
-                                value: _mysqlTimeout,
-                                expandToParent: true,
-                                onChanged: (v) => unawaited(_setMysql(v)),
-                              ),
-                            ),
-                            const material.SizedBox(height: 24),
-                            const Text('SQL editor')
-                                .semiBold()
-                                .small()
-                                .foreground(),
-                            const material.SizedBox(height: 8),
-                            PreferencesFieldRow(
-                              label: 'Max rows in results',
-                              control: PreferencesDropdownMenu<int>(
-                                value: _maxRows,
-                                onSelected: (v) {
-                                  if (v != null) unawaited(_setMaxRows(v));
-                                },
-                                entries: [
-                                  for (final n in kSqlResultMaxRowsPresets)
-                                    material.DropdownMenuEntry(
-                                      value: n,
-                                      label: '$n',
+                              const Gap(8),
+                              material.Expanded(
+                                child: material.TextField(
+                                  controller: _searchController,
+                                  focusNode: _searchFocusNode,
+                                  onChanged: (val) {
+                                    final q = val.trim();
+                                    setState(() {
+                                      _searchQuery = q;
+                                      if (q.isNotEmpty &&
+                                          _matchCountForCategory(
+                                                  _selectedCategory) ==
+                                              0) {
+                                        for (final cat
+                                            in PreferencesCategory.values) {
+                                          if (_matchCountForCategory(cat) > 0) {
+                                            _selectedCategory = cat;
+                                            break;
+                                          }
+                                        }
+                                      }
+                                    });
+                                  },
+                                  style: material.TextStyle(
+                                    fontSize: 12,
+                                    color: theme.foreground,
+                                  ),
+                                  decoration: material.InputDecoration(
+                                    hintText: 'Filter preferences... (Ctrl+F)',
+                                    hintStyle: material.TextStyle(
+                                      fontSize: 12,
+                                      color: theme.mutedForeground
+                                          .withValues(alpha: 0.6),
                                     ),
-                                ],
+                                    border: material.InputBorder.none,
+                                    isDense: true,
+                                    contentPadding: material.EdgeInsets.zero,
+                                  ),
+                                ),
+                              ),
+                              if (_searchQuery.isNotEmpty)
+                                material.GestureDetector(
+                                  behavior: material.HitTestBehavior.opaque,
+                                  onTap: () {
+                                    _searchController.clear();
+                                    setState(() => _searchQuery = '');
+                                  },
+                                  child: material.Icon(
+                                    material.Icons.close_rounded,
+                                    size: 14,
+                                    color: theme.mutedForeground,
+                                  ),
+                                ),
+                            ],
+                          ),
+                        ),
+                      ),
+                      const Gap(8),
+                      material.IconButton(
+                        icon: const material.Icon(material.Icons.close_rounded,
+                            size: 18),
+                        padding: material.EdgeInsets.zero,
+                        constraints: const material.BoxConstraints(
+                          minWidth: 28,
+                          minHeight: 28,
+                        ),
+                        splashRadius: 16,
+                        tooltip: 'Close',
+                        onPressed: () => material.Navigator.of(context).pop(),
+                      ),
+                    ],
+                  ),
+                ),
+
+                // Master-Detail Body
+                material.Expanded(
+                  child: material.Row(
+                    crossAxisAlignment: material.CrossAxisAlignment.stretch,
+                    children: [
+                            // Left Category Rail
+                            material.Container(
+                              width: 184,
+                              decoration: material.BoxDecoration(
+                                border: material.Border(
+                                  right: material.BorderSide(
+                                    color: theme.border.withValues(alpha: 0.28),
+                                  ),
+                                ),
+                              ),
+                              child: material.SingleChildScrollView(
+                                padding: const material.EdgeInsets.symmetric(
+                                  horizontal: 8,
+                                  vertical: 10,
+                                ),
+                                child: material.Column(
+                                  crossAxisAlignment:
+                                      material.CrossAxisAlignment.stretch,
+                                  children: [
+                                    for (final cat
+                                        in PreferencesCategory.values)
+                                      _buildCategoryRailTile(cat, theme),
+                                  ],
+                                ),
                               ),
                             ),
-                            const material.SizedBox(height: 12),
-                            PreferencesFieldRow(
-                              label: 'Query history limit',
-                              hint:
-                                  'Per connection and database; oldest queries are dropped.',
-                              control: PreferencesDropdownMenu<int>(
-                                value: _historyMax,
-                                onSelected: (v) {
-                                  if (v != null) {
-                                    unawaited(_setHistoryMax(v));
-                                  }
-                                },
-                                entries: [
-                                  for (final n in kSqlHistoryMaxEntriesPresets)
-                                    material.DropdownMenuEntry(
-                                      value: n,
-                                      label: '$n entries',
-                                    ),
-                                ],
+
+                            // Right Detail Content Area
+                            material.Expanded(
+                              child: material.SingleChildScrollView(
+                                padding: const material.EdgeInsets.symmetric(
+                                  horizontal: 24,
+                                  vertical: 16,
+                                ),
+                                child: _buildSelectedCategoryPane(theme),
                               ),
-                            ),
-                            const material.SizedBox(height: 12),
-                            PreferencesFieldRow(
-                              label: 'Font size',
-                              control: PreferencesDropdownMenu<double>(
-                                value: _fontSize,
-                                onSelected: (v) {
-                                  if (v != null) unawaited(_setFont(v));
-                                },
-                                entries: const [
-                                  material.DropdownMenuEntry(
-                                    value: 11.0,
-                                    label: '11 pt',
-                                  ),
-                                  material.DropdownMenuEntry(
-                                    value: 12.0,
-                                    label: '12 pt',
-                                  ),
-                                  material.DropdownMenuEntry(
-                                    value: 13.0,
-                                    label: '13 pt',
-                                  ),
-                                  material.DropdownMenuEntry(
-                                    value: 14.0,
-                                    label: '14 pt',
-                                  ),
-                                  material.DropdownMenuEntry(
-                                    value: 16.0,
-                                    label: '16 pt',
-                                  ),
-                                  material.DropdownMenuEntry(
-                                    value: 18.0,
-                                    label: '18 pt',
-                                  ),
-                                ],
-                              ),
-                            ),
-                            const material.SizedBox(height: 12),
-                            PreferencesCheckboxRow(
-                              value: _confirmDestructive,
-                              title: const Text(
-                                'Confirm destructive SQL operations',
-                              ).small(),
-                              subtitle: const Text(
-                                'Prompts before executing DROP, TRUNCATE, or unconditional DELETE queries.',
-                              ).muted().xSmall(),
-                              onChanged: (v) {
-                                unawaited(_setConfirmDestructive(v));
-                              },
-                            ),
-                            const material.SizedBox(height: 16),
-                            const PreferencesHint(
-                              'Preferences are stored locally in SQLite (non-secret keys only).',
                             ),
                           ],
                         ),
                 ),
-              ),
-              material.Container(
-                padding: const material.EdgeInsets.symmetric(
-                    horizontal: 24, vertical: 16),
-                decoration: material.BoxDecoration(
-                  border: material.Border(
-                    top: material.BorderSide(
-                        color: theme.border.withValues(alpha: 0.3)),
+
+                // Footer Actions
+                material.Container(
+                  padding: const material.EdgeInsets.symmetric(
+                    horizontal: 20,
+                    vertical: 12,
+                  ),
+                  decoration: material.BoxDecoration(
+                    border: material.Border(
+                      top: material.BorderSide(
+                        color: theme.border.withValues(alpha: 0.28),
+                      ),
+                    ),
+                  ),
+                  child: material.Row(
+                    children: [
+                      const material.Expanded(
+                        child: PreferencesHint(
+                          'Changes apply immediately and persist locally.',
+                        ),
+                      ),
+                      PrimaryButton(
+                        onPressed: () => material.Navigator.of(context).pop(),
+                        child: const Text('Close'),
+                      ),
+                    ],
                   ),
                 ),
-                child: material.Row(
-                  mainAxisAlignment: material.MainAxisAlignment.end,
-                  children: [
-                    PrimaryButton(
-                      onPressed: () => material.Navigator.of(context).pop(),
-                      child: const Text('Close'),
-                    ),
-                  ],
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  material.Widget _buildCategoryRailTile(
+    PreferencesCategory cat,
+    ColorScheme theme,
+  ) {
+    final isSelected = _selectedCategory == cat;
+    final matches = _matchCountForCategory(cat);
+    final hasSearch = _searchQuery.isNotEmpty;
+
+    return material.Padding(
+      padding: const material.EdgeInsets.only(bottom: 2),
+      child: material.Material(
+        type: material.MaterialType.transparency,
+        child: material.InkWell(
+          onTap: () => setState(() => _selectedCategory = cat),
+          borderRadius: material.BorderRadius.circular(6),
+          child: material.Container(
+            padding: const material.EdgeInsets.symmetric(
+              horizontal: 10,
+              vertical: 8,
+            ),
+            decoration: material.BoxDecoration(
+              color: isSelected
+                  ? theme.primary.withValues(alpha: 0.12)
+                  : material.Colors.transparent,
+              borderRadius: material.BorderRadius.circular(6),
+            ),
+            child: material.Row(
+              children: [
+                material.Icon(
+                  cat.icon,
+                  size: 16,
+                  color: isSelected ? theme.primary : theme.mutedForeground,
                 ),
+                const Gap(10),
+                material.Expanded(
+                  child: material.Text(
+                    cat.label,
+                    style: material.TextStyle(
+                      fontSize: 12,
+                      fontWeight: isSelected
+                          ? material.FontWeight.w600
+                          : material.FontWeight.w400,
+                      color: isSelected ? theme.primary : theme.foreground,
+                    ),
+                  ),
+                ),
+                if (hasSearch && matches > 0)
+                  material.Container(
+                    padding: const material.EdgeInsets.symmetric(
+                      horizontal: 5,
+                      vertical: 1,
+                    ),
+                    decoration: material.BoxDecoration(
+                      color: isSelected
+                          ? theme.primary
+                          : theme.muted.withValues(alpha: 0.5),
+                      borderRadius: material.BorderRadius.circular(10),
+                    ),
+                    child: material.Text(
+                      '$matches',
+                      style: material.TextStyle(
+                        fontSize: 10,
+                        fontWeight: material.FontWeight.w600,
+                        color: isSelected
+                            ? theme.primaryForeground
+                            : theme.foreground,
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  material.Widget _buildSelectedCategoryPane(ColorScheme theme) {
+    switch (_selectedCategory) {
+      case PreferencesCategory.general:
+        return _buildGeneralSection(theme);
+      case PreferencesCategory.appearance:
+        return const PreferencesAppearanceSection();
+      case PreferencesCategory.sql:
+        return _buildSqlSection(theme);
+      case PreferencesCategory.dataGrid:
+        return _buildDataGridSection(theme);
+      case PreferencesCategory.extensions:
+        return const PreferencesExtensionsSection();
+      case PreferencesCategory.shortcuts:
+        return PreferencesShortcutsSection(searchQuery: _searchQuery);
+      case PreferencesCategory.about:
+        return const PreferencesAboutSection();
+    }
+  }
+
+  material.Widget _buildGeneralSection(ColorScheme theme) {
+    return material.Column(
+      crossAxisAlignment: material.CrossAxisAlignment.start,
+      children: [
+        const Text('General Settings').semiBold().small().foreground(),
+        const material.SizedBox(height: 6),
+        const PreferencesHint(
+          'Application startup behavior and update release channels.',
+        ),
+        const material.SizedBox(height: 14),
+
+        PreferencesSwitchRow(
+          value: _checkUpdatesOnStartup,
+          title: const Text('Check for updates automatically on startup').small(),
+          subtitle: const Text(
+            'Silently checks GitHub Releases when Querya starts to notify you of new features.',
+          ).muted().xSmall(),
+          onChanged: (v) => unawaited(_setCheckUpdatesOnStartup(v)),
+        ),
+
+        const material.SizedBox(height: 16),
+        PreferencesFieldRow(
+          label: 'Release channel',
+          hint:
+              'Stable receives thoroughly tested monthly updates. Beta receives early releases with experimental features.',
+          control: PreferencesDropdownMenu<UpdateChannel>(
+            value: _updateChannel,
+            onSelected: (v) {
+              if (v != null) unawaited(_setUpdateChannel(v));
+            },
+            entries: const [
+              material.DropdownMenuEntry(
+                value: UpdateChannel.stable,
+                label: 'Stable (Recommended)',
+              ),
+              material.DropdownMenuEntry(
+                value: UpdateChannel.dev,
+                label: 'Beta / Early Access',
               ),
             ],
           ),
         ),
-      ),
+      ],
+    );
+  }
+
+  material.Widget _buildSqlSection(ColorScheme theme) {
+    return material.Column(
+      crossAxisAlignment: material.CrossAxisAlignment.start,
+      children: [
+        const Text('SQL & Query Execution').semiBold().small().foreground(),
+        const material.SizedBox(height: 6),
+        const PreferencesHint(
+          'Global statement timeouts, editor formatting, and query history.',
+        ),
+        const material.SizedBox(height: 16),
+
+        PreferencesFieldRow(
+          label: 'Editor font size',
+          control: PreferencesDropdownMenu<double>(
+            value: _fontSize,
+            onSelected: (v) {
+              if (v != null) unawaited(_setFont(v));
+            },
+            entries: const [
+              material.DropdownMenuEntry(value: 11.0, label: '11 pt'),
+              material.DropdownMenuEntry(value: 12.0, label: '12 pt'),
+              material.DropdownMenuEntry(value: 13.0, label: '13 pt (Default)'),
+              material.DropdownMenuEntry(value: 14.0, label: '14 pt'),
+              material.DropdownMenuEntry(value: 16.0, label: '16 pt'),
+              material.DropdownMenuEntry(value: 18.0, label: '18 pt'),
+            ],
+          ),
+        ),
+
+        const material.SizedBox(height: 16),
+        PreferencesFieldRow(
+          label: 'PostgreSQL timeout',
+          hint: 'Statement timeout applied to queries on PostgreSQL connections.',
+          control: SqlStatementTimeoutDropdown(
+            value: _pgTimeout,
+            expandToParent: true,
+            onChanged: (v) => unawaited(_setPg(v)),
+          ),
+        ),
+
+        const material.SizedBox(height: 16),
+        PreferencesFieldRow(
+          label: 'MySQL timeout',
+          hint:
+              'Max execution time applied to queries on MySQL and MariaDB servers.',
+          control: SqlStatementTimeoutDropdown(
+            value: _mysqlTimeout,
+            expandToParent: true,
+            onChanged: (v) => unawaited(_setMysql(v)),
+          ),
+        ),
+
+        const material.SizedBox(height: 16),
+        PreferencesFieldRow(
+          label: 'Query history limit',
+          hint: 'Per connection and database. Older queries are trimmed automatically.',
+          control: PreferencesDropdownMenu<int>(
+            value: _historyMax,
+            onSelected: (v) {
+              if (v != null) unawaited(_setHistoryMax(v));
+            },
+            entries: [
+              for (final n in kSqlHistoryMaxEntriesPresets)
+                material.DropdownMenuEntry(
+                  value: n,
+                  label: '$n entries',
+                ),
+            ],
+          ),
+        ),
+
+        const material.SizedBox(height: 16),
+        PreferencesSwitchRow(
+          value: _confirmDestructive,
+          title: const Text('Confirm destructive SQL queries').small(),
+          subtitle: const Text(
+            'Displays confirmation modal before running DROP, TRUNCATE, or unconditional DELETE queries.',
+          ).muted().xSmall(),
+          onChanged: (v) => unawaited(_setConfirmDestructive(v)),
+        ),
+      ],
+    );
+  }
+
+  material.Widget _buildDataGridSection(ColorScheme theme) {
+    return material.Column(
+      crossAxisAlignment: material.CrossAxisAlignment.start,
+      children: [
+        const Text('Data Grid & Results').semiBold().small().foreground(),
+        const material.SizedBox(height: 6),
+        const PreferencesHint(
+          'Configure virtualization limits, column sizing, and result viewing.',
+        ),
+        const material.SizedBox(height: 16),
+
+        PreferencesFieldRow(
+          label: 'Max rows in results',
+          hint:
+              'Limits row count rendered in the virtualized grid to prevent out-of-memory errors on large queries.',
+          control: PreferencesDropdownMenu<int>(
+            value: _maxRows,
+            onSelected: (v) {
+              if (v != null) unawaited(_setMaxRows(v));
+            },
+            entries: [
+              for (final n in kSqlResultMaxRowsPresets)
+                material.DropdownMenuEntry(
+                  value: n,
+                  label: '$n rows',
+                ),
+            ],
+          ),
+        ),
+
+        const material.SizedBox(height: 16),
+        PreferencesSwitchRow(
+          value: _confirmDestructive,
+          title: const Text('Confirm DML staging applications').small(),
+          subtitle: const Text(
+            'Requests confirmation before applying staged row inserts, deletes, or cell updates.',
+          ).muted().xSmall(),
+          onChanged: (v) => unawaited(_setConfirmDestructive(v)),
+        ),
+      ],
     );
   }
 }

--- a/lib/features/settings/preferences_shortcuts_section.dart
+++ b/lib/features/settings/preferences_shortcuts_section.dart
@@ -1,0 +1,275 @@
+import 'dart:io' show Platform;
+import 'package:flutter/material.dart' as material;
+import 'package:querya_desktop/core/theme/querya_typography.dart';
+import 'package:querya_desktop/shared/widgets/widgets.dart';
+
+class ShortcutItem {
+  const ShortcutItem({
+    required this.category,
+    required this.action,
+    required this.keys,
+    this.description,
+  });
+
+  final String category;
+  final String action;
+  final List<String> keys;
+  final String? description;
+}
+
+class PreferencesShortcutsSection extends StatelessWidget {
+  const PreferencesShortcutsSection({super.key, this.searchQuery = ''});
+
+  final String searchQuery;
+
+  static bool get _isMac => Platform.isMacOS;
+  static String get _modKey => _isMac ? '⌘' : 'Ctrl';
+
+  static List<ShortcutItem> get allShortcuts => [
+        // SQL Editor
+        ShortcutItem(
+          category: 'SQL Editor',
+          action: 'Execute query / selection',
+          keys: [_modKey, 'Enter'],
+          description: 'Runs statement under cursor or selected text',
+        ),
+        ShortcutItem(
+          category: 'SQL Editor',
+          action: 'Execute all statements',
+          keys: [_modKey, 'Shift', 'Enter'],
+          description: 'Runs entire query script sequentially',
+        ),
+        ShortcutItem(
+          category: 'SQL Editor',
+          action: 'New query tab',
+          keys: [_modKey, 'T'],
+          description: 'Opens a new independent SQL tab session',
+        ),
+        ShortcutItem(
+          category: 'SQL Editor',
+          action: 'Close current tab',
+          keys: [_modKey, 'W'],
+          description: 'Prompts to save if uncommitted changes exist',
+        ),
+        const ShortcutItem(
+          category: 'SQL Editor',
+          action: 'Next query tab',
+          keys: ['Ctrl', 'Tab'],
+          description: 'Switches to the next open SQL tab',
+        ),
+        const ShortcutItem(
+          category: 'SQL Editor',
+          action: 'Previous query tab',
+          keys: ['Ctrl', 'Shift', 'Tab'],
+          description: 'Switches to the previous open SQL tab',
+        ),
+        ShortcutItem(
+          category: 'SQL Editor',
+          action: 'Query history',
+          keys: [_modKey, 'H'],
+          description: 'Browse previous queries for this connection',
+        ),
+
+        // Data Grid
+        ShortcutItem(
+          category: 'Data Grid',
+          action: 'Copy cell value',
+          keys: [_modKey, 'C'],
+          description: 'Copies selected cell value to clipboard',
+        ),
+        ShortcutItem(
+          category: 'Data Grid',
+          action: 'Copy with headers',
+          keys: [_modKey, 'Shift', 'C'],
+          description: 'Copies selection formatted with column names (TSV)',
+        ),
+        ShortcutItem(
+          category: 'Data Grid',
+          action: 'Inspect / Edit cell',
+          keys: [_modKey, 'I'],
+          description: 'Opens popover inspector for JSON, XML, or Text',
+        ),
+        const ShortcutItem(
+          category: 'Data Grid',
+          action: 'Set cell to NULL',
+          keys: ['Alt', 'N'],
+          description: 'Stages NULL value for selected cell(s)',
+        ),
+        ShortcutItem(
+          category: 'Data Grid',
+          action: 'Duplicate row',
+          keys: [_modKey, 'D'],
+          description: 'Duplicates selected row into DML staging buffer',
+        ),
+        const ShortcutItem(
+          category: 'Data Grid',
+          action: 'Auto-fit column width',
+          keys: ['Double Click Divider'],
+          description: 'Sizes column width to fit sampled content',
+        ),
+
+        // Navigation & App
+        ShortcutItem(
+          category: 'Navigation & App',
+          action: 'Find in Connections / Editor',
+          keys: [_modKey, 'F'],
+          description: 'Focuses quick search in sidebar tree or editor',
+        ),
+        ShortcutItem(
+          category: 'Navigation & App',
+          action: 'Toggle sidebar',
+          keys: [_modKey, 'B'],
+          description: 'Expands or hides the servers/connections panel',
+        ),
+        ShortcutItem(
+          category: 'Navigation & App',
+          action: 'Preferences',
+          keys: [_modKey, ','],
+          description: 'Opens application settings dialog',
+        ),
+        const ShortcutItem(
+          category: 'Navigation & App',
+          action: 'Refresh schema / connection',
+          keys: ['F5'],
+          description: 'Refreshes databases and table tree',
+        ),
+      ];
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final q = searchQuery.trim().toLowerCase();
+
+    final filtered = q.isEmpty
+        ? allShortcuts
+        : allShortcuts.where((item) {
+            final matchAction = item.action.toLowerCase().contains(q);
+            final matchCategory = item.category.toLowerCase().contains(q);
+            final matchDesc =
+                item.description?.toLowerCase().contains(q) ?? false;
+            final matchKeys = item.keys.any((k) => k.toLowerCase().contains(q));
+            return matchAction || matchCategory || matchDesc || matchKeys;
+          }).toList();
+
+    if (filtered.isEmpty) {
+      return material.Padding(
+        padding: const material.EdgeInsets.symmetric(vertical: 32),
+        child: material.Center(
+          child: Text('No shortcuts match "$searchQuery"')
+              .muted()
+              .small(),
+        ),
+      );
+    }
+
+    final categories = <String, List<ShortcutItem>>{};
+    for (final item in filtered) {
+      categories.putIfAbsent(item.category, () => []).add(item);
+    }
+
+    return material.Column(
+      crossAxisAlignment: material.CrossAxisAlignment.start,
+      children: [
+        for (final entry in categories.entries) ...[
+          material.Padding(
+            padding: const material.EdgeInsets.only(top: 8, bottom: 8),
+            child: Text(entry.key).semiBold().small().foreground(),
+          ),
+          material.Container(
+            decoration: material.BoxDecoration(
+              color: theme.colorScheme.muted.withValues(alpha: 0.16),
+              borderRadius: material.BorderRadius.circular(8),
+              border: material.Border.all(
+                color: theme.colorScheme.border.withValues(alpha: 0.25),
+              ),
+            ),
+            child: material.Column(
+              children: [
+                for (var i = 0; i < entry.value.length; i++) ...[
+                  if (i > 0)
+                    Divider(
+                      height: 1,
+                      color: theme.colorScheme.border.withValues(alpha: 0.18),
+                    ),
+                  _buildShortcutRow(context, entry.value[i], theme),
+                ],
+              ],
+            ),
+          ),
+          const material.SizedBox(height: 16),
+        ],
+      ],
+    );
+  }
+
+  material.Widget _buildShortcutRow(
+    BuildContext context,
+    ShortcutItem item,
+    ThemeData theme,
+  ) {
+    return material.Padding(
+      padding: const material.EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+      child: material.Row(
+        children: [
+          material.Expanded(
+            child: material.Column(
+              crossAxisAlignment: material.CrossAxisAlignment.start,
+              mainAxisSize: material.MainAxisSize.min,
+              children: [
+                Text(item.action).small().foreground(),
+                if (item.description != null) ...[
+                  const material.SizedBox(height: 2),
+                  Text(item.description!).muted().xSmall(),
+                ],
+              ],
+            ),
+          ),
+          const material.SizedBox(width: 12),
+          material.Row(
+            mainAxisSize: material.MainAxisSize.min,
+            children: [
+              for (var j = 0; j < item.keys.length; j++) ...[
+                if (j > 0)
+                  material.Padding(
+                    padding: const material.EdgeInsets.symmetric(horizontal: 3),
+                    child: const Text('+')
+                        .muted()
+                        .xSmall(),
+                  ),
+                material.Container(
+                  padding: const material.EdgeInsets.symmetric(
+                    horizontal: 7,
+                    vertical: 3,
+                  ),
+                  decoration: material.BoxDecoration(
+                    color: theme.colorScheme.background,
+                    borderRadius: material.BorderRadius.circular(4),
+                    border: material.Border.all(
+                      color: theme.colorScheme.border.withValues(alpha: 0.4),
+                    ),
+                    boxShadow: [
+                      material.BoxShadow(
+                        color: material.Colors.black.withValues(alpha: 0.08),
+                        offset: const material.Offset(0, 1),
+                        blurRadius: 1,
+                      ),
+                    ],
+                  ),
+                  child: material.Text(
+                    item.keys[j],
+                    style: material.TextStyle(
+                      fontFamily: QueryaTypography.mono,
+                      fontSize: 11,
+                      fontWeight: material.FontWeight.w600,
+                      color: theme.colorScheme.foreground,
+                    ),
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/test/features/settings/preferences_master_detail_test.dart
+++ b/test/features/settings/preferences_master_detail_test.dart
@@ -1,0 +1,183 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart' as material;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:querya_desktop/core/storage/app_settings.dart';
+import 'package:querya_desktop/core/storage/local_db.dart';
+import 'package:querya_desktop/core/theme/app_theme.dart';
+import 'package:querya_desktop/features/settings/preferences_controls.dart';
+import 'package:querya_desktop/features/settings/preferences_dialog.dart';
+import 'package:shadcn_flutter/shadcn_flutter.dart';
+
+class _FakePathProvider extends PathProviderPlatform {
+  _FakePathProvider(this._root);
+  final String _root;
+
+  @override
+  Future<String?> getApplicationSupportPath() async => _root;
+
+  @override
+  Future<String?> getTemporaryPath() async => _root;
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async => _root;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempDir;
+
+  setUpAll(() async {
+    tempDir = await Directory.systemTemp
+        .createTemp('querya_preferences_master_detail_test_');
+    PathProviderPlatform.instance = _FakePathProvider(tempDir.path);
+    await LocalDb.initFfi();
+    await AppSettings.instance.getCheckForUpdatesOnStartup();
+  });
+
+  tearDownAll(() async {
+    await LocalDb.instance.close();
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  Widget buildTestApp({
+    PreferencesCategory? initialCategory,
+  }) {
+    return ShadcnApp(
+      theme: AppTheme.dark,
+      darkTheme: AppTheme.dark,
+      themeMode: ThemeMode.dark,
+      home: material.Scaffold(
+        body: material.Builder(
+          builder: (context) {
+            return material.ElevatedButton(
+              onPressed: () => showPreferencesDialog(
+                context,
+                initialCategory: initialCategory,
+              ),
+              child: const material.Text('Open Preferences'),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  Future<void> openDialog(WidgetTester tester) async {
+    await tester.tap(find.text('Open Preferences'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+  }
+
+  group('Preferences Master-Detail Dialog', () {
+    testWidgets('renders categories in master rail and defaults to General',
+        (tester) async {
+      await tester.pumpWidget(buildTestApp());
+      await openDialog(tester);
+
+      expect(find.text('Preferences'), findsOneWidget);
+      expect(find.text('General'), findsAtLeastNWidgets(1));
+      expect(find.text('Appearance'), findsOneWidget);
+      expect(find.text('SQL & Editor'), findsOneWidget);
+      expect(find.text('Data Grid'), findsOneWidget);
+      expect(find.text('Extensions'), findsOneWidget);
+      expect(find.text('Shortcuts'), findsOneWidget);
+      expect(find.text('About & Storage'), findsOneWidget);
+
+      // Default category is General
+      expect(find.text('General Settings'), findsOneWidget);
+    });
+
+    testWidgets('switching category switches active pane', (tester) async {
+      await tester.pumpWidget(buildTestApp());
+      await openDialog(tester);
+
+      // Tap on Shortcuts category in the rail
+      await tester.tap(find.text('Shortcuts'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 200));
+
+      expect(find.text('Execute query / selection'), findsOneWidget);
+      expect(find.text('Auto-fit column width'), findsOneWidget);
+
+      // Tap on About category
+      await tester.tap(find.text('About & Storage'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 200));
+
+      expect(find.text('Querya Desktop'), findsOneWidget);
+      expect(find.text('Fast, native multi-database management studio.'),
+          findsOneWidget);
+    });
+
+    testWidgets('deep links directly to specified initialCategory',
+        (tester) async {
+      await tester.pumpWidget(
+        buildTestApp(initialCategory: PreferencesCategory.sql),
+      );
+      await openDialog(tester);
+
+      // Should be directly in SQL Editor pane
+      expect(find.text('SQL & Query Execution'), findsOneWidget);
+      expect(find.text('PostgreSQL timeout'), findsOneWidget);
+    });
+
+    testWidgets('search bar filters preferences and updates matches',
+        (tester) async {
+      await tester.pumpWidget(buildTestApp());
+      await openDialog(tester);
+
+      final searchInput = find.byType(material.TextField);
+      expect(searchInput, findsOneWidget);
+
+      await tester.enterText(searchInput, 'timeout');
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 200));
+
+      // Match badge should appear on SQL Editor and pane is active
+      expect(find.text('SQL & Query Execution'), findsOneWidget);
+      expect(find.text('PostgreSQL timeout'), findsOneWidget);
+    });
+
+    testWidgets('PreferencesSwitchRow toggles on tap and exposes state',
+        (tester) async {
+      var currentValue = false;
+
+      await tester.pumpWidget(
+        ShadcnApp(
+          theme: AppTheme.dark,
+          home: material.Scaffold(
+            body: StatefulBuilder(
+              builder: (context, setState) {
+                return PreferencesSwitchRow(
+                  title: const material.Text('Auto Commit'),
+                  subtitle:
+                      const material.Text('Automatically commit transactions'),
+                  value: currentValue,
+                  onChanged: (val) {
+                    setState(() {
+                      currentValue = val;
+                    });
+                  },
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Auto Commit'), findsOneWidget);
+      expect(find.text('Automatically commit transactions'), findsOneWidget);
+      expect(find.byType(material.Switch), findsOneWidget);
+
+      await tester.tap(find.text('Auto Commit'));
+      await tester.pump();
+
+      expect(currentValue, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
### Summary
Re-architects the monolithic Preferences modal into a modern Master-Detail categorized dialog with sidebar navigation and interactive filter search, closing #686.

### Key Changes
1. **Master-Detail Layout & Categorization**:
   - Added `PreferencesCategory` enum (`general`, `appearance`, `sql`, `dataGrid`, `extensions`, `shortcuts`, `about`).
   - Clean left navigation rail with icons, active highlight, and dynamic search match count badges.
   - Deep-linking support via `showPreferencesDialog(context, {PreferencesCategory? initialCategory})`.
2. **Interactive Search & Keymap Filtering**:
   - Filter input at the dialog header with `Ctrl+F` shortcut binding and quick clear button.
   - Searches across category titles, descriptions, and shortcut action keymaps.
3. **PreferencesSwitchRow & About Pane**:
   - Added `PreferencesSwitchRow` for consistent switch toggling across settings.
   - Added `PreferencesAboutSection` displaying build version, SQLite local storage paths, and app shortcuts.
   - Added `PreferencesShortcutsSection` OS-aware keyboard map reference.
4. **Testing & QA**:
   - Added `test/features/settings/preferences_master_detail_test.dart` covering category navigation, deep-linking, search filtering, and switch interactions.
   - Verified 100% test pass rate across all 48 settings/preferences tests and zero analyzer warnings.