### PR TITLE
feat(settings): interactive keyboard shortcuts reference section in preferences

### DIFF
--- a/lib/features/settings/preferences_shortcuts_section.dart
+++ b/lib/features/settings/preferences_shortcuts_section.dart
@@ -17,7 +17,8 @@ class ShortcutItem {
   final String? description;
 }
 
-class PreferencesShortcutsSection extends StatelessWidget {
+/// Interactive shortcuts reference table grouped by category with OS-aware keycaps.
+class PreferencesShortcutsSection extends material.StatefulWidget {
   const PreferencesShortcutsSection({super.key, this.searchQuery = ''});
 
   final String searchQuery;
@@ -69,6 +70,18 @@ class PreferencesShortcutsSection extends StatelessWidget {
           keys: [_modKey, 'H'],
           description: 'Browse previous queries for this connection',
         ),
+        const ShortcutItem(
+          category: 'SQL Editor',
+          action: 'Format SQL statement',
+          keys: ['Shift', 'Alt', 'F'],
+          description: 'Formats keywords and statement indentation',
+        ),
+        const ShortcutItem(
+          category: 'SQL Editor',
+          action: 'Toggle full-screen editor',
+          keys: ['F11'],
+          description: 'Maximizes the SQL query workspace area',
+        ),
 
         // Data Grid
         ShortcutItem(
@@ -107,6 +120,18 @@ class PreferencesShortcutsSection extends StatelessWidget {
           keys: ['Double Click Divider'],
           description: 'Sizes column width to fit sampled content',
         ),
+        const ShortcutItem(
+          category: 'Data Grid',
+          action: 'Revert staged cell changes',
+          keys: ['Escape'],
+          description: 'Discards uncommitted cell edit or inspector',
+        ),
+        const ShortcutItem(
+          category: 'Data Grid',
+          action: 'Filter by cell value',
+          keys: ['Right Click', 'Filter'],
+          description: 'Filters grid by value matching selected cell',
+        ),
 
         // Navigation & App
         ShortcutItem(
@@ -133,37 +158,142 @@ class PreferencesShortcutsSection extends StatelessWidget {
           keys: ['F5'],
           description: 'Refreshes databases and table tree',
         ),
+        ShortcutItem(
+          category: 'Navigation & App',
+          action: 'New connection',
+          keys: [_modKey, 'N'],
+          description: 'Opens connection creation dialog',
+        ),
+        const ShortcutItem(
+          category: 'Navigation & App',
+          action: 'Close modal dialog',
+          keys: ['Escape'],
+          description: 'Dismisses open dialog or popover overlay',
+        ),
       ];
+
+  @override
+  material.State<PreferencesShortcutsSection> createState() =>
+      _PreferencesShortcutsSectionState();
+}
+
+class _PreferencesShortcutsSectionState
+    extends material.State<PreferencesShortcutsSection> {
+  String _selectedCategory = 'All';
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final q = searchQuery.trim().toLowerCase();
+    final q = widget.searchQuery.trim().toLowerCase();
 
-    final filtered = q.isEmpty
-        ? allShortcuts
-        : allShortcuts.where((item) {
-            final matchAction = item.action.toLowerCase().contains(q);
-            final matchCategory = item.category.toLowerCase().contains(q);
-            final matchDesc =
-                item.description?.toLowerCase().contains(q) ?? false;
-            final matchKeys = item.keys.any((k) => k.toLowerCase().contains(q));
-            return matchAction || matchCategory || matchDesc || matchKeys;
-          }).toList();
+    final all = PreferencesShortcutsSection.allShortcuts;
+    final categoriesList = ['All', 'SQL Editor', 'Data Grid', 'Navigation & App'];
 
-    if (filtered.isEmpty) {
-      return material.Padding(
-        padding: const material.EdgeInsets.symmetric(vertical: 32),
-        child: material.Center(
-          child: Text('No shortcuts match "$searchQuery"')
-              .muted()
-              .small(),
+    final filtered = all.where((item) {
+      if (_selectedCategory != 'All' && item.category != _selectedCategory) {
+        return false;
+      }
+      if (q.isEmpty) return true;
+      final matchAction = item.action.toLowerCase().contains(q);
+      final matchCategory = item.category.toLowerCase().contains(q);
+      final matchDesc = item.description?.toLowerCase().contains(q) ?? false;
+      final matchKeys = item.keys.any((k) => k.toLowerCase().contains(q));
+      return matchAction || matchCategory || matchDesc || matchKeys;
+    }).toList();
+
+    return material.Column(
+      crossAxisAlignment: material.CrossAxisAlignment.start,
+      children: [
+        // Category Filter Chips
+        material.SingleChildScrollView(
+          scrollDirection: material.Axis.horizontal,
+          child: material.Row(
+            children: [
+              for (final cat in categoriesList) ...[
+                material.Padding(
+                  padding: const material.EdgeInsets.only(right: 6, bottom: 10),
+                  child: material.Material(
+                    type: material.MaterialType.transparency,
+                    child: material.InkWell(
+                      onTap: () => setState(() => _selectedCategory = cat),
+                      borderRadius: material.BorderRadius.circular(16),
+                      child: material.Container(
+                        padding: const material.EdgeInsets.symmetric(
+                          horizontal: 10,
+                          vertical: 4,
+                        ),
+                        decoration: material.BoxDecoration(
+                          color: _selectedCategory == cat
+                              ? theme.colorScheme.primary.withValues(alpha: 0.16)
+                              : theme.colorScheme.muted.withValues(alpha: 0.3),
+                          borderRadius: material.BorderRadius.circular(16),
+                          border: material.Border.all(
+                            color: _selectedCategory == cat
+                                ? theme.colorScheme.primary.withValues(alpha: 0.5)
+                                : theme.colorScheme.border.withValues(alpha: 0.25),
+                          ),
+                        ),
+                        child: material.Row(
+                          mainAxisSize: material.MainAxisSize.min,
+                          children: [
+                            material.Text(
+                              cat,
+                              style: material.TextStyle(
+                                fontSize: 11,
+                                fontWeight: _selectedCategory == cat
+                                    ? material.FontWeight.w600
+                                    : material.FontWeight.w400,
+                                color: _selectedCategory == cat
+                                    ? theme.colorScheme.primary
+                                    : theme.colorScheme.foreground,
+                              ),
+                            ),
+                            const material.SizedBox(width: 4),
+                            material.Text(
+                              '(${cat == 'All' ? all.length : all.where((s) => s.category == cat).length})',
+                              style: material.TextStyle(
+                                fontSize: 10,
+                                color: _selectedCategory == cat
+                                    ? theme.colorScheme.primary.withValues(alpha: 0.8)
+                                    : theme.colorScheme.mutedForeground,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ],
+          ),
         ),
-      );
-    }
 
+        if (filtered.isEmpty)
+          material.Padding(
+            padding: const material.EdgeInsets.symmetric(vertical: 32),
+            child: material.Center(
+              child: Text(widget.searchQuery.isNotEmpty
+                      ? 'No shortcuts match "${widget.searchQuery}"'
+                      : 'No shortcuts in $_selectedCategory')
+                  .muted()
+                  .small(),
+            ),
+          )
+        else ...[
+          _buildShortcutTable(context, filtered, theme),
+        ],
+      ],
+    );
+  }
+
+  material.Widget _buildShortcutTable(
+    BuildContext context,
+    List<ShortcutItem> items,
+    ThemeData theme,
+  ) {
     final categories = <String, List<ShortcutItem>>{};
-    for (final item in filtered) {
+    for (final item in items) {
       categories.putIfAbsent(item.category, () => []).add(item);
     }
 

--- a/test/features/settings/preferences_shortcuts_section_test.dart
+++ b/test/features/settings/preferences_shortcuts_section_test.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/material.dart' as material;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:querya_desktop/features/settings/preferences_shortcuts_section.dart';
+import 'package:querya_desktop/shared/widgets/widgets.dart';
+
+void main() {
+  Widget buildTestWidget({String searchQuery = ''}) {
+    return ShadcnApp(
+      home: material.Scaffold(
+        body: material.SingleChildScrollView(
+          child: material.Padding(
+            padding: const material.EdgeInsets.all(16),
+            child: PreferencesShortcutsSection(searchQuery: searchQuery),
+          ),
+        ),
+      ),
+    );
+  }
+
+  group('PreferencesShortcutsSection', () {
+    testWidgets('renders all category sections and shortcuts by default', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      // Check category headers exist
+      expect(find.text('SQL Editor'), findsWidgets);
+      expect(find.text('Data Grid'), findsWidgets);
+      expect(find.text('Navigation & App'), findsWidgets);
+
+      // Check specific shortcut actions exist
+      expect(find.text('Execute query / selection'), findsOneWidget);
+      expect(find.text('Format SQL statement'), findsOneWidget);
+      expect(find.text('Toggle full-screen editor'), findsOneWidget);
+      expect(find.text('Auto-fit column width'), findsOneWidget);
+      expect(find.text('Revert staged cell changes'), findsOneWidget);
+      expect(find.text('Filter by cell value'), findsOneWidget);
+      expect(find.text('Preferences'), findsOneWidget);
+    });
+
+    testWidgets('filters list by tapping category filter chips', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      // Initially both SQL and Data Grid actions are visible
+      expect(find.text('Execute query / selection'), findsOneWidget);
+      expect(find.text('Inspect / Edit cell'), findsOneWidget);
+
+      // Tap 'Data Grid' filter pill
+      final dataGridChip = find.text('Data Grid').first;
+      await tester.tap(dataGridChip);
+      await tester.pumpAndSettle();
+
+      // Data Grid actions are visible, SQL Editor actions are hidden
+      expect(find.text('Inspect / Edit cell'), findsOneWidget);
+      expect(find.text('Auto-fit column width'), findsOneWidget);
+      expect(find.text('Execute query / selection'), findsNothing);
+      expect(find.text('Format SQL statement'), findsNothing);
+
+      // Tap 'SQL Editor' filter pill
+      final sqlChip = find.text('SQL Editor').first;
+      await tester.tap(sqlChip);
+      await tester.pumpAndSettle();
+
+      // SQL Editor visible, Data Grid hidden
+      expect(find.text('Execute query / selection'), findsOneWidget);
+      expect(find.text('Format SQL statement'), findsOneWidget);
+      expect(find.text('Inspect / Edit cell'), findsNothing);
+
+      // Tap 'All' filter pill
+      final allChip = find.text('All').first;
+      await tester.tap(allChip);
+      await tester.pumpAndSettle();
+
+      // Both restored
+      expect(find.text('Execute query / selection'), findsOneWidget);
+      expect(find.text('Inspect / Edit cell'), findsOneWidget);
+    });
+
+    testWidgets('filters shortcuts dynamically by search query', (tester) async {
+      await tester.pumpWidget(buildTestWidget(searchQuery: 'format'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Format SQL statement'), findsOneWidget);
+      expect(find.text('Execute query / selection'), findsNothing);
+      expect(find.text('Inspect / Edit cell'), findsNothing);
+    });
+
+    testWidgets('filters shortcuts by keycap search query', (tester) async {
+      await tester.pumpWidget(buildTestWidget(searchQuery: 'F11'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Toggle full-screen editor'), findsOneWidget);
+      expect(find.text('Execute query / selection'), findsNothing);
+    });
+
+    testWidgets('shows empty state when no shortcuts match search', (tester) async {
+      await tester.pumpWidget(buildTestWidget(searchQuery: 'xyzunknown'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('No shortcuts match "xyzunknown"'), findsOneWidget);
+      expect(find.text('Execute query / selection'), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
Closes #688

### Summary of Changes
- Converted `PreferencesShortcutsSection` into an interactive reference table with dynamic category filter pills (`All`, `SQL Editor`, `Data Grid`, `Navigation & App`) showing badge counts.
- Added comprehensive shortcuts including Format SQL (`Shift+Alt+F`), Fullscreen Editor (`F11`), Revert staged cell (`Escape`), Filter by cell value (`Right Click > Filter`), and New connection (`Ctrl+N` / `Cmd+N`).
- Maintained OS-aware hardware keycap badge styling with monospace typography.
- Added unit & widget test suite in `test/features/settings/preferences_shortcuts_section_test.dart` covering all filters, search queries, and empty states.