### PR TITLE
feat(settings): extract theme editor into focused modal and clean up appearance actions

### DIFF
--- a/lib/features/settings/preferences_appearance_section.dart
+++ b/lib/features/settings/preferences_appearance_section.dart
@@ -270,123 +270,144 @@ class _PreferencesAppearanceSectionState
           const PreferencesHint(
             'Full enables all animations. Reduced cuts durations in half. Off disables all transitions.',
           ),
-          const material.SizedBox(height: 12),
-          material.Wrap(
-            spacing: 8,
-            runSpacing: 8,
-            children: [
-              OutlineButton(
-                onPressed: (_importing || _installingFromUrl)
-                    ? null
-                    : () => unawaited(_pickAndImportTheme()),
-                child: material.Row(
-                  mainAxisSize: material.MainAxisSize.min,
+          const material.SizedBox(height: 16),
+          material.Container(
+            padding: const material.EdgeInsets.all(14),
+            decoration: material.BoxDecoration(
+              color: Theme.of(context).colorScheme.muted.withValues(alpha: 0.14),
+              borderRadius: material.BorderRadius.circular(8),
+              border: material.Border.all(
+                color: Theme.of(context).colorScheme.border.withValues(alpha: 0.25),
+              ),
+            ),
+            child: material.Column(
+              crossAxisAlignment: material.CrossAxisAlignment.start,
+              children: [
+                const Text('Theme Actions').semiBold().small().foreground(),
+                const material.SizedBox(height: 4),
+                const PreferencesHint(
+                  'Import themes from disk, install from verified HTTPS endpoints, or explore your local folder.',
+                ),
+                const material.SizedBox(height: 10),
+                material.Wrap(
+                  spacing: 8,
+                  runSpacing: 8,
                   children: [
-                    const material.Icon(
-                      material.Icons.file_open_outlined,
-                      size: 14,
+                    OutlineButton(
+                      onPressed: (_importing || _installingFromUrl)
+                          ? null
+                          : () => unawaited(_pickAndImportTheme()),
+                      child: material.Row(
+                        mainAxisSize: material.MainAxisSize.min,
+                        children: [
+                          const material.Icon(
+                            material.Icons.file_open_outlined,
+                            size: 14,
+                          ),
+                          const material.SizedBox(width: 6),
+                          material.Text(
+                            _importing ? 'Importing…' : 'Import theme…',
+                          ),
+                        ],
+                      ),
                     ),
-                    const material.SizedBox(width: 6),
-                    material.Text(
-                      _importing ? 'Importing…' : 'Import theme…',
+                    OutlineButton(
+                      onPressed: (_importing || _installingFromUrl || refreshingThemes)
+                          ? null
+                          : () => unawaited(_installThemeFromUrl()),
+                      child: material.Row(
+                        mainAxisSize: material.MainAxisSize.min,
+                        children: [
+                          const material.Icon(
+                            material.Icons.download_rounded,
+                            size: 14,
+                          ),
+                          const material.SizedBox(width: 6),
+                          material.Text(
+                            _installingFromUrl ? 'Installing…' : 'Install from URL…',
+                          ),
+                        ],
+                      ),
+                    ),
+                    OutlineButton(
+                      onPressed: (_importing || _installingFromUrl || refreshingThemes)
+                          ? null
+                          : () => unawaited(_refreshThemes()),
+                      child: material.Row(
+                        mainAxisSize: material.MainAxisSize.min,
+                        children: [
+                          const material.Icon(
+                            material.Icons.refresh_rounded,
+                            size: 14,
+                          ),
+                          const material.SizedBox(width: 6),
+                          material.Text(
+                            refreshingThemes ? 'Refreshing…' : 'Refresh themes',
+                          ),
+                        ],
+                      ),
+                    ),
+                    OutlineButton(
+                      onPressed:
+                          (_importing || _installingFromUrl || _openingThemesFolder)
+                              ? null
+                              : () => unawaited(_openThemesFolder()),
+                      child: material.Row(
+                        mainAxisSize: material.MainAxisSize.min,
+                        children: [
+                          const material.Icon(
+                            material.Icons.folder_open_outlined,
+                            size: 14,
+                          ),
+                          const material.SizedBox(width: 6),
+                          material.Text(
+                            _openingThemesFolder
+                                ? 'Opening…'
+                                : 'Open themes folder',
+                          ),
+                        ],
+                      ),
+                    ),
+                    OutlineButton(
+                      onPressed: () => unawaited(_resetAppearance()),
+                      child: const material.Row(
+                        mainAxisSize: material.MainAxisSize.min,
+                        children: [
+                          material.Icon(
+                            material.Icons.restart_alt_rounded,
+                            size: 14,
+                          ),
+                          material.SizedBox(width: 6),
+                          Text('Reset appearance'),
+                        ],
+                      ),
                     ),
                   ],
                 ),
-              ),
-              OutlineButton(
-                onPressed: (_importing || _installingFromUrl || refreshingThemes)
-                    ? null
-                    : () => unawaited(_installThemeFromUrl()),
-                child: material.Row(
-                  mainAxisSize: material.MainAxisSize.min,
-                  children: [
-                    const material.Icon(
-                      material.Icons.download_rounded,
-                      size: 14,
+                if (_importError != null) ...[
+                  const material.SizedBox(height: 8),
+                  material.Text(
+                    _importError!,
+                    style: material.TextStyle(
+                      fontSize: 12,
+                      color: Theme.of(context).colorScheme.destructive,
                     ),
-                    const material.SizedBox(width: 6),
-                    material.Text(
-                      _installingFromUrl ? 'Installing…' : 'Install from URL…',
+                  ),
+                ],
+                if (_folderOpenError != null) ...[
+                  const material.SizedBox(height: 8),
+                  material.Text(
+                    _folderOpenError!,
+                    style: material.TextStyle(
+                      fontSize: 12,
+                      color: Theme.of(context).colorScheme.destructive,
                     ),
-                  ],
-                ),
-              ),
-              OutlineButton(
-                onPressed: (_importing || _installingFromUrl || refreshingThemes)
-                    ? null
-                    : () => unawaited(_refreshThemes()),
-                child: material.Row(
-                  mainAxisSize: material.MainAxisSize.min,
-                  children: [
-                    const material.Icon(
-                      material.Icons.refresh_rounded,
-                      size: 14,
-                    ),
-                    const material.SizedBox(width: 6),
-                    material.Text(
-                      refreshingThemes ? 'Refreshing…' : 'Refresh themes',
-                    ),
-                  ],
-                ),
-              ),
-              OutlineButton(
-                onPressed:
-                    (_importing || _installingFromUrl || _openingThemesFolder)
-                        ? null
-                        : () => unawaited(_openThemesFolder()),
-                child: material.Row(
-                  mainAxisSize: material.MainAxisSize.min,
-                  children: [
-                    const material.Icon(
-                      material.Icons.folder_open_outlined,
-                      size: 14,
-                    ),
-                    const material.SizedBox(width: 6),
-                    material.Text(
-                      _openingThemesFolder
-                          ? 'Opening…'
-                          : 'Open themes folder',
-                    ),
-                  ],
-                ),
-              ),
-              OutlineButton(
-                onPressed: () => unawaited(_resetAppearance()),
-                child: const material.Row(
-                  mainAxisSize: material.MainAxisSize.min,
-                  children: [
-                    material.Icon(
-                      material.Icons.restart_alt_rounded,
-                      size: 14,
-                    ),
-                    material.SizedBox(width: 6),
-                    Text('Reset appearance'),
-                  ],
-                ),
-              ),
-            ],
+                  ),
+                ],
+              ],
+            ),
           ),
-          if (_importError != null) ...[
-            const material.SizedBox(height: 8),
-            material.Text(
-              _importError!,
-              style: material.TextStyle(
-                fontSize: 12,
-                color: Theme.of(context).colorScheme.destructive,
-              ),
-            ),
-          ],
-          if (_folderOpenError != null) ...[
-            const material.SizedBox(height: 8),
-            material.Text(
-              _folderOpenError!,
-              style: material.TextStyle(
-                fontSize: 12,
-                color: Theme.of(context).colorScheme.destructive,
-              ),
-            ),
-          ],
-          const material.SizedBox(height: 4),
+          const material.SizedBox(height: 6),
           const PreferencesHint(
             'Import copies a theme into the themes folder. '
             'Install from URL requires HTTPS and optional SHA-256 verification. '

--- a/lib/features/settings/theme_editor_dialog.dart
+++ b/lib/features/settings/theme_editor_dialog.dart
@@ -1,0 +1,385 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:file_selector/file_selector.dart';
+import 'package:flutter/material.dart' as material;
+import 'package:querya_desktop/core/theme/parser/color_parser.dart';
+import 'package:querya_desktop/core/theme/parser/querya_theme_manifest.dart';
+import 'package:querya_desktop/core/theme/querya_typography.dart';
+import 'package:querya_desktop/core/theme/theme_controller.dart';
+import 'package:querya_desktop/core/theme/theme_editor_draft.dart';
+import 'package:querya_desktop/core/theme/theme_editor_loader.dart';
+import 'package:querya_desktop/features/settings/theme_color_picker_dialog.dart';
+import 'package:querya_desktop/shared/widgets/widgets.dart';
+
+/// Shows the focused Theme Studio modal dialog with live token editing and real-time preview.
+Future<void> showThemeEditorDialog(material.BuildContext context) {
+  return showAppDialog<void>(
+    context: context,
+    builder: (dialogContext) => const ThemeEditorDialog(),
+  );
+}
+
+/// Focused Theme Studio modal for editing palette tokens and exporting custom themes.
+class ThemeEditorDialog extends material.StatefulWidget {
+  const ThemeEditorDialog({super.key});
+
+  @override
+  material.State<ThemeEditorDialog> createState() => _ThemeEditorDialogState();
+}
+
+class _ThemeEditorDialogState extends material.State<ThemeEditorDialog> {
+  final _controller = ThemeController.instance;
+  ThemeEditorDraft? _draft;
+  bool _loading = true;
+  bool _exporting = false;
+  String? _error;
+  Timer? _previewDebounce;
+
+  @override
+  void initState() {
+    super.initState();
+    unawaited(_loadDraft());
+  }
+
+  @override
+  void dispose() {
+    _previewDebounce?.cancel();
+    unawaited(_controller.endEditorPreview());
+    super.dispose();
+  }
+
+  Future<void> _loadDraft() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      final draft = await ThemeEditorLoader.fromController(_controller);
+      if (!mounted) return;
+      setState(() {
+        _draft = draft;
+        _loading = false;
+      });
+      unawaited(_controller.previewEditorManifest(draft.toManifest()));
+    } on Object catch (error) {
+      if (!mounted) return;
+      setState(() {
+        _loading = false;
+        _error = error.toString();
+      });
+    }
+  }
+
+  void _schedulePreview() {
+    final draft = _draft;
+    if (draft == null) return;
+
+    _previewDebounce?.cancel();
+    _previewDebounce = Timer(const Duration(milliseconds: 150), () {
+      if (!mounted || _draft == null) return;
+      unawaited(_controller.previewEditorManifest(_draft!.toManifest()));
+    });
+  }
+
+  Future<void> _pickColor(ThemeEditorColorField field) async {
+    final draft = _draft;
+    if (draft == null) return;
+
+    final currentHex = draft.colorHex(field);
+    Color initial;
+    try {
+      initial = currentHex != null
+          ? parseQueryaThemeColor(currentHex)
+          : Theme.of(context).colorScheme.primary;
+    } on FormatException {
+      initial = Theme.of(context).colorScheme.primary;
+    }
+
+    final picked = await showThemeColorPickerDialog(
+      context: context,
+      initial: initial,
+    );
+    if (picked == null || !mounted) return;
+
+    setState(() {
+      draft.setColor(field, picked);
+    });
+    _schedulePreview();
+  }
+
+  Future<void> _exportDraft() async {
+    final draft = _draft;
+    if (draft == null) return;
+
+    setState(() {
+      _exporting = true;
+      _error = null;
+    });
+
+    try {
+      final exportDraft = draft.forExport();
+      final location = await getSaveLocation(
+        suggestedName: '${exportDraft.id}.json',
+        acceptedTypeGroups: const [
+          XTypeGroup(
+            label: 'Querya theme',
+            extensions: ['json'],
+          ),
+        ],
+      );
+      if (location == null) return;
+
+      await File(location.path).writeAsString(exportDraft.toExportJsonString());
+      QueryaThemeManifest.fromJsonString(exportDraft.toExportJsonString());
+    } on Object catch (error) {
+      if (!mounted) return;
+      setState(() => _error = error.toString());
+    } finally {
+      if (mounted) {
+        setState(() => _exporting = false);
+      }
+    }
+  }
+
+  @override
+  material.Widget build(material.BuildContext context) {
+    final theme = Theme.of(context);
+    final cs = theme.colorScheme;
+
+    return material.AlertDialog(
+      backgroundColor: cs.popover,
+      shape: material.RoundedRectangleBorder(
+        borderRadius: material.BorderRadius.circular(12),
+        side: material.BorderSide(color: cs.border.withValues(alpha: 0.35)),
+      ),
+      titlePadding: const material.EdgeInsets.fromLTRB(20, 16, 16, 12),
+      contentPadding: const material.EdgeInsets.symmetric(horizontal: 20),
+      actionsPadding: const material.EdgeInsets.fromLTRB(20, 12, 20, 16),
+      title: material.Row(
+        children: [
+          material.Icon(
+            material.Icons.palette_outlined,
+            size: 20,
+            color: cs.primary,
+          ),
+          const material.SizedBox(width: 10),
+          material.Expanded(
+            child: material.Column(
+              crossAxisAlignment: material.CrossAxisAlignment.start,
+              children: [
+                const Text('Theme Studio')
+                    .semiBold()
+                    .medium()
+                    .foreground(),
+                const material.SizedBox(height: 2),
+                const Text(
+                  'Customize color tokens with real-time UI preview',
+                ).muted().xSmall(),
+              ],
+            ),
+          ),
+          IconButton.ghost(
+            icon: const material.Icon(material.Icons.close, size: 16),
+            onPressed: () => material.Navigator.of(context).pop(),
+            density: ButtonDensity.compact,
+          ),
+        ],
+      ),
+      content: material.SizedBox(
+        width: 540,
+        height: 480,
+        child: _loading
+            ? const material.Center(
+                child: material.CircularProgressIndicator(),
+              )
+            : material.SingleChildScrollView(
+                child: material.Column(
+                  crossAxisAlignment: material.CrossAxisAlignment.start,
+                  children: [
+                    if (_draft != null) ...[
+                      // Info Pill
+                      material.Container(
+                        padding: const material.EdgeInsets.symmetric(
+                          horizontal: 12,
+                          vertical: 8,
+                        ),
+                        decoration: material.BoxDecoration(
+                          color: cs.muted.withValues(alpha: 0.25),
+                          borderRadius: material.BorderRadius.circular(6),
+                          border: material.Border.all(
+                            color: cs.border.withValues(alpha: 0.2),
+                          ),
+                        ),
+                        child: material.Row(
+                          children: [
+                            material.Icon(
+                              material.Icons.info_outline,
+                              size: 14,
+                              color: cs.mutedForeground,
+                            ),
+                            const material.SizedBox(width: 8),
+                            material.Expanded(
+                              child: material.Text(
+                                _draft!.readOnlySource
+                                    ? 'Editing copy of built-in theme "${_draft!.name}". Export to save.'
+                                    : 'Editing theme "${_draft!.name}". Changes preview live.',
+                                style: material.TextStyle(
+                                  fontSize: 12,
+                                  color: cs.mutedForeground,
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                      const material.SizedBox(height: 14),
+                    ],
+
+                    if (_error != null) ...[
+                      material.Padding(
+                        padding: const material.EdgeInsets.only(bottom: 12),
+                        child: material.Text(
+                          _error!,
+                          style: material.TextStyle(
+                            fontSize: 12,
+                            color: cs.destructive,
+                          ),
+                        ),
+                      ),
+                    ],
+
+                    if (_draft != null) ...[
+                      material.Container(
+                        decoration: material.BoxDecoration(
+                          color: cs.muted.withValues(alpha: 0.1),
+                          borderRadius: material.BorderRadius.circular(8),
+                          border: material.Border.all(
+                            color: cs.border.withValues(alpha: 0.2),
+                          ),
+                        ),
+                        child: material.Column(
+                          children: [
+                            for (var i = 0;
+                                i < themeEditorMvpColorFields.length;
+                                i++) ...[
+                              if (i > 0)
+                                Divider(
+                                  height: 1,
+                                  color: cs.border.withValues(alpha: 0.18),
+                                ),
+                              _ThemeEditorColorRow(
+                                field: themeEditorMvpColorFields[i],
+                                hex: _draft!.colorHex(
+                                  themeEditorMvpColorFields[i],
+                                ),
+                                onPick: () => unawaited(
+                                  _pickColor(themeEditorMvpColorFields[i]),
+                                ),
+                              ),
+                            ],
+                          ],
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+      ),
+      actions: [
+        OutlineButton(
+          onPressed: _loading ? null : () => unawaited(_loadDraft()),
+          child: const material.Text('Reset from current'),
+        ),
+        if (_draft != null)
+          OutlineButton(
+            onPressed: _exporting ? null : () => unawaited(_exportDraft()),
+            child: material.Text(
+              _exporting ? 'Exporting…' : 'Export theme…',
+            ),
+          ),
+        PrimaryButton(
+          onPressed: () => material.Navigator.of(context).pop(),
+          child: const material.Text('Done'),
+        ),
+      ],
+    );
+  }
+}
+
+class _ThemeEditorColorRow extends material.StatelessWidget {
+  const _ThemeEditorColorRow({
+    required this.field,
+    required this.hex,
+    required this.onPick,
+  });
+
+  final ThemeEditorColorField field;
+  final String? hex;
+  final material.VoidCallback onPick;
+
+  @override
+  material.Widget build(material.BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    Color? swatchColor;
+    if (hex != null) {
+      try {
+        swatchColor = parseQueryaThemeColor(hex!);
+      } on FormatException {
+        swatchColor = null;
+      }
+    }
+
+    return material.Padding(
+      padding: const material.EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+      child: material.Row(
+        children: [
+          material.Expanded(
+            child: material.Text(
+              field.label,
+              style: material.TextStyle(
+                fontSize: 13,
+                color: cs.foreground,
+              ),
+            ),
+          ),
+          const material.SizedBox(width: 12),
+          material.InkWell(
+            onTap: onPick,
+            borderRadius: material.BorderRadius.circular(6),
+            child: material.Container(
+              width: 28,
+              height: 28,
+              decoration: material.BoxDecoration(
+                color: swatchColor ?? cs.muted,
+                borderRadius: material.BorderRadius.circular(6),
+                border: material.Border.all(
+                  color: cs.border.withValues(alpha: 0.5),
+                ),
+                boxShadow: [
+                  material.BoxShadow(
+                    color: material.Colors.black.withValues(alpha: 0.06),
+                    offset: const material.Offset(0, 1),
+                    blurRadius: 1,
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const material.SizedBox(width: 10),
+          material.SizedBox(
+            width: 80,
+            child: material.Text(
+              hex ?? '—',
+              style: material.TextStyle(
+                fontSize: 12,
+                color: cs.mutedForeground,
+                fontFamily: QueryaTypography.mono,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/settings/theme_editor_section.dart
+++ b/lib/features/settings/theme_editor_section.dart
@@ -1,278 +1,72 @@
 import 'dart:async';
-import 'dart:io';
 
-import 'package:file_selector/file_selector.dart';
 import 'package:flutter/material.dart' as material;
-import 'package:querya_desktop/core/theme/parser/color_parser.dart';
-import 'package:querya_desktop/core/theme/parser/querya_theme_manifest.dart';
-import 'package:querya_desktop/core/theme/theme_controller.dart';
-import 'package:querya_desktop/core/theme/theme_editor_draft.dart';
-import 'package:querya_desktop/core/theme/theme_editor_loader.dart';
-import 'package:querya_desktop/features/settings/preferences_controls.dart';
-import 'package:querya_desktop/features/settings/theme_color_picker_dialog.dart';
-import 'package:querya_desktop/core/layout/ui_scale.dart';
+import 'package:querya_desktop/features/settings/theme_editor_dialog.dart';
 import 'package:querya_desktop/shared/widgets/widgets.dart';
 
-/// MVP visual theme editor in Preferences → Appearance.
-class ThemeEditorSection extends material.StatefulWidget {
+export 'package:querya_desktop/features/settings/theme_editor_dialog.dart'
+    show showThemeEditorDialog, ThemeEditorDialog;
+
+/// Launcher card in Preferences → Appearance for opening the focused Theme Studio modal.
+class ThemeEditorSection extends material.StatelessWidget {
   const ThemeEditorSection({super.key});
 
   @override
-  material.State<ThemeEditorSection> createState() =>
-      _ThemeEditorSectionState();
-}
-
-class _ThemeEditorSectionState extends material.State<ThemeEditorSection> {
-  final _controller = ThemeController.instance;
-  ThemeEditorDraft? _draft;
-  bool _expanded = false;
-  bool _loading = false;
-  bool _exporting = false;
-  String? _error;
-  Timer? _previewDebounce;
-
-  @override
-  void dispose() {
-    _previewDebounce?.cancel();
-    unawaited(_controller.endEditorPreview());
-    super.dispose();
-  }
-
-  Future<void> _loadDraft() async {
-    setState(() {
-      _loading = true;
-      _error = null;
-    });
-    try {
-      final draft = await ThemeEditorLoader.fromController(_controller);
-      if (!mounted) return;
-      setState(() {
-        _draft = draft;
-        _loading = false;
-      });
-      if (_expanded) {
-        unawaited(_controller.previewEditorManifest(draft.toManifest()));
-      }
-    } on Object catch (error) {
-      if (!mounted) return;
-      setState(() {
-        _loading = false;
-        _error = error.toString();
-      });
-    }
-  }
-
-  Future<void> _toggleExpanded() async {
-    final next = !_expanded;
-    setState(() => _expanded = next);
-
-    if (next) {
-      if (_draft == null) {
-        await _loadDraft();
-      } else {
-        unawaited(_controller.previewEditorManifest(_draft!.toManifest()));
-      }
-      return;
-    }
-
-    await _controller.endEditorPreview();
-  }
-
-  void _schedulePreview() {
-    final draft = _draft;
-    if (draft == null) return;
-
-    _previewDebounce?.cancel();
-    _previewDebounce = Timer(const Duration(milliseconds: 150), () {
-      if (!mounted || _draft == null) return;
-      unawaited(_controller.previewEditorManifest(_draft!.toManifest()));
-    });
-  }
-
-  Future<void> _pickColor(ThemeEditorColorField field) async {
-    final draft = _draft;
-    if (draft == null) return;
-
-    final currentHex = draft.colorHex(field);
-    Color initial;
-    try {
-      initial = currentHex != null
-          ? parseQueryaThemeColor(currentHex)
-          : Theme.of(context).colorScheme.primary;
-    } on FormatException {
-      initial = Theme.of(context).colorScheme.primary;
-    }
-
-    final picked = await showThemeColorPickerDialog(
-      context: context,
-      initial: initial,
-    );
-    if (picked == null || !mounted) return;
-
-    setState(() {
-      draft.setColor(field, picked);
-    });
-    _schedulePreview();
-  }
-
-  Future<void> _exportDraft() async {
-    final draft = _draft;
-    if (draft == null) return;
-
-    setState(() {
-      _exporting = true;
-      _error = null;
-    });
-
-    try {
-      final exportDraft = draft.forExport();
-      final location = await getSaveLocation(
-        suggestedName: '${exportDraft.id}.json',
-        acceptedTypeGroups: const [
-          XTypeGroup(
-            label: 'Querya theme',
-            extensions: ['json'],
-          ),
-        ],
-      );
-      if (location == null) return;
-
-      await File(location.path).writeAsString(exportDraft.toExportJsonString());
-      QueryaThemeManifest.fromJsonString(exportDraft.toExportJsonString());
-    } on Object catch (error) {
-      if (!mounted) return;
-      setState(() => _error = error.toString());
-    } finally {
-      if (mounted) {
-        setState(() => _exporting = false);
-      }
-    }
-  }
-
-  @override
   material.Widget build(material.BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
+    final theme = Theme.of(context);
+    final cs = theme.colorScheme;
 
-    return material.Column(
-      crossAxisAlignment: material.CrossAxisAlignment.start,
-      children: [
-        const material.SizedBox(height: 12),
-        material.Wrap(
-          spacing: 8,
-          runSpacing: 8,
-          children: [
-            OutlineButton(
-              onPressed: _loading ? null : () => unawaited(_toggleExpanded()),
-              child: material.Text(
-                _loading
-                    ? 'Loading editor…'
-                    : _expanded
-                        ? 'Hide theme editor'
-                        : 'Edit theme colors…',
-              ),
-            ),
-            if (_expanded && _draft != null)
-              OutlineButton(
-                onPressed: _exporting ? null : () => unawaited(_exportDraft()),
-                child: material.Text(
-                  _exporting ? 'Exporting…' : 'Export theme…',
-                ),
-              ),
-            if (_expanded)
-              OutlineButton(
-                onPressed: _loading ? null : () => unawaited(_loadDraft()),
-                child: const material.Text('Reset from current'),
-              ),
-          ],
+    return material.Container(
+      margin: const material.EdgeInsets.only(top: 12),
+      padding: const material.EdgeInsets.all(14),
+      decoration: material.BoxDecoration(
+        color: cs.muted.withValues(alpha: 0.18),
+        borderRadius: material.BorderRadius.circular(8),
+        border: material.Border.all(
+          color: cs.border.withValues(alpha: 0.28),
         ),
-        if (_expanded && _draft?.readOnlySource == true) ...[
-          const material.SizedBox(height: 8),
-          const PreferencesHint(
-            'Built-in themes are not modified in place. Export saves a copy '
-            'with a new id that you can import into the themes folder.',
-          ),
-        ],
-        if (_error != null) ...[
-          const material.SizedBox(height: 8),
-          material.Text(
-            _error!,
-            style: material.TextStyle(fontSize: 12, color: cs.destructive),
-          ),
-        ],
-        if (_expanded && _draft != null) ...[
-          const material.SizedBox(height: 12),
-          for (final field in themeEditorMvpColorFields)
-            _ThemeEditorColorRow(
-              field: field,
-              hex: _draft!.colorHex(field),
-              onPick: () => unawaited(_pickColor(field)),
-            ),
-        ],
-      ],
-    );
-  }
-}
-
-class _ThemeEditorColorRow extends material.StatelessWidget {
-  const _ThemeEditorColorRow({
-    required this.field,
-    required this.hex,
-    required this.onPick,
-  });
-
-  final ThemeEditorColorField field;
-  final String? hex;
-  final material.VoidCallback onPick;
-
-  @override
-  material.Widget build(material.BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
-    Color? swatchColor;
-    if (hex != null) {
-      try {
-        swatchColor = parseQueryaThemeColor(hex!);
-      } on FormatException {
-        swatchColor = null;
-      }
-    }
-
-    return material.Padding(
-      padding: const material.EdgeInsets.only(bottom: 8),
+      ),
       child: material.Row(
         children: [
-          material.SizedBox(
-            width: context.scaled(kPreferencesLabelWidth),
-            child: material.Text(
-              field.label,
-              style: material.TextStyle(
-                fontSize: 13,
-                color: cs.popoverForeground,
-              ),
+          material.Container(
+            padding: const material.EdgeInsets.all(8),
+            decoration: material.BoxDecoration(
+              color: cs.primary.withValues(alpha: 0.12),
+              borderRadius: material.BorderRadius.circular(6),
+            ),
+            child: material.Icon(
+              material.Icons.palette_outlined,
+              size: 20,
+              color: cs.primary,
             ),
           ),
           const material.SizedBox(width: 12),
-          material.InkWell(
-            onTap: onPick,
-            borderRadius: material.BorderRadius.circular(6),
-            child: material.Container(
-              width: 28,
-              height: 28,
-              decoration: material.BoxDecoration(
-                color: swatchColor ?? cs.muted,
-                borderRadius: material.BorderRadius.circular(6),
-                border: material.Border.all(color: cs.border),
-              ),
+          material.Expanded(
+            child: material.Column(
+              crossAxisAlignment: material.CrossAxisAlignment.start,
+              mainAxisSize: material.MainAxisSize.min,
+              children: [
+                const Text('Theme Studio').semiBold().small().foreground(),
+                const material.SizedBox(height: 2),
+                const Text(
+                  'Fine-tune workbench and syntax highlight colors with live preview.',
+                ).muted().xSmall(),
+              ],
             ),
           ),
-          const material.SizedBox(width: 10),
-          material.Expanded(
-            child: material.Text(
-              hex ?? '—',
-              style: material.TextStyle(
-                fontSize: 12,
-                color: cs.mutedForeground,
-                fontFamily: 'monospace',
-              ),
+          const material.SizedBox(width: 12),
+          OutlineButton(
+            onPressed: () => unawaited(showThemeEditorDialog(context)),
+            child: const material.Row(
+              mainAxisSize: material.MainAxisSize.min,
+              children: [
+                material.Icon(
+                  material.Icons.tune_rounded,
+                  size: 14,
+                ),
+                material.SizedBox(width: 6),
+                material.Text('Edit theme colors…'),
+              ],
             ),
           ),
         ],

--- a/test/features/settings/theme_editor_dialog_test.dart
+++ b/test/features/settings/theme_editor_dialog_test.dart
@@ -1,0 +1,112 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart' as material;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:querya_desktop/core/storage/app_settings.dart';
+import 'package:querya_desktop/core/storage/local_db.dart';
+import 'package:querya_desktop/core/theme/theme_controller.dart';
+import 'package:querya_desktop/core/theme/theme_editor_draft.dart';
+import 'package:querya_desktop/core/theme/theme_registry_service.dart';
+import 'package:querya_desktop/features/settings/theme_editor_dialog.dart';
+
+import '../../support/querya_theme_test_shell.dart';
+
+Future<String> _fixtureAssetLoader(String assetPath) async {
+  final fileName = p.basename(assetPath);
+  return File(p.join('test/fixtures/themes', fileName)).readAsString();
+}
+
+class _FakePathProvider extends PathProviderPlatform {
+  _FakePathProvider(this._root);
+  final String _root;
+
+  @override
+  Future<String?> getApplicationSupportPath() async => _root;
+  @override
+  Future<String?> getTemporaryPath() async => _root;
+  @override
+  Future<String?> getApplicationDocumentsPath() async => _root;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempDir;
+  late Directory themesDir;
+  late Directory importedDir;
+
+  setUpAll(() async {
+    tempDir = await Directory.systemTemp.createTemp('querya_theme_editor_test_');
+    PathProviderPlatform.instance = _FakePathProvider(tempDir.path);
+    await LocalDb.initFfi();
+  });
+
+  setUp(() async {
+    themesDir = Directory(p.join(tempDir.path, 'themes'));
+    importedDir = Directory(p.join(themesDir.path, 'imported'));
+    await importedDir.create(recursive: true);
+
+    final registry = ThemeRegistryService(
+      userThemesDirectory: () async => themesDir,
+      importedThemesDirectory: () async => importedDir,
+      assetLoader: _fixtureAssetLoader,
+    );
+    ThemeController.instance.setRegistryServiceForTest(registry);
+    await ThemeController.instance.load();
+  });
+
+  tearDownAll(() async {
+    await LocalDb.instance.close();
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  tearDown(() async {
+    await AppSettings.instance.clearThemeSettings();
+    if (await themesDir.exists()) {
+      await themesDir.delete(recursive: true);
+    }
+  });
+
+  group('ThemeEditorDialog', () {
+    testWidgets('renders dialog header, fields, and action buttons', (tester) async {
+      await tester.binding.setSurfaceSize(const material.Size(1280, 900));
+      await tester.pumpWidget(
+        queryaThemeTestShell(
+          child: material.Scaffold(
+            body: material.Builder(
+              builder: (context) => material.ElevatedButton(
+                onPressed: () => showThemeEditorDialog(context),
+                child: const material.Text('Open'),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Open modal dialog
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      // Verify header and elements
+      expect(find.text('Theme Studio'), findsOneWidget);
+      expect(find.text('Reset from current'), findsOneWidget);
+      expect(find.text('Done'), findsOneWidget);
+
+      // Verify token color field labels
+      for (final field in themeEditorMvpColorFields) {
+        expect(find.text(field.label), findsWidgets);
+      }
+
+      // Close modal
+      await tester.tap(find.text('Done'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Theme Studio'), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
Closes #689

### Summary of Changes
- Extracted theme token editing into a dedicated, focused modal dialog (`showThemeEditorDialog` / `ThemeEditorDialog`) with real-time UI preview, theme information pill, palette pickers, and export functionality.
- Replaced the inline expanding palette accordion in `ThemeEditorSection` with a compact Theme Studio launcher card featuring clean typography and actions.
- Reorganized appearance actions (Import theme…, Install from URL…, Refresh themes, Open themes folder, Reset appearance) into an integrated `Theme Actions` card with clear descriptions and icons.
- Added comprehensive widget test suite for `ThemeEditorDialog` in `test/features/settings/theme_editor_dialog_test.dart`.