### PR TITLE
polish(workspace): UI/UX refinements for data grid, filter bar, staging toolbar, and export labels

### DIFF
--- a/lib/features/extensions/extension_table_toolbar.dart
+++ b/lib/features/extensions/extension_table_toolbar.dart
@@ -158,8 +158,8 @@ class ExtensionTableToolbar extends material.StatelessWidget {
                         if (onSaveFormat != null) ...[
                           const Gap(4),
                           ExportMenuButton(
-                            label: 'Save ▾',
-                            icon: material.Icons.save_alt_rounded,
+                            label: 'Export ▾',
+                            icon: material.Icons.file_download_outlined,
                             isSave: true,
                             onSelected: onSaveFormat!,
                           ),

--- a/lib/features/workspace/data_grid_filter_bar.dart
+++ b/lib/features/workspace/data_grid_filter_bar.dart
@@ -1,5 +1,6 @@
 import 'dart:async' show Timer;
 import 'package:flutter/material.dart' as material;
+import 'package:flutter/services.dart' show KeyDownEvent, LogicalKeyboardKey;
 import 'package:shadcn_flutter/shadcn_flutter.dart';
 
 /// Kind of filter autocomplete suggestion.
@@ -120,6 +121,7 @@ class DataGridFilterBar extends material.StatefulWidget {
     required this.filteredRowCount,
     this.columns = const [],
     this.debounceDuration = const Duration(milliseconds: 150),
+    this.onClose,
   });
 
   final String filterText;
@@ -128,6 +130,7 @@ class DataGridFilterBar extends material.StatefulWidget {
   final int filteredRowCount;
   final List<String> columns;
   final Duration debounceDuration;
+  final material.VoidCallback? onClose;
 
   @override
   material.State<DataGridFilterBar> createState() => _DataGridFilterBarState();
@@ -135,6 +138,7 @@ class DataGridFilterBar extends material.StatefulWidget {
 
 class _DataGridFilterBarState extends material.State<DataGridFilterBar> {
   late final material.TextEditingController _controller;
+  late final material.FocusNode _focusNode;
   final _layerLink = material.LayerLink();
   material.OverlayEntry? _overlayEntry;
   List<FilterSuggestion> _suggestions = [];
@@ -145,6 +149,7 @@ class _DataGridFilterBarState extends material.State<DataGridFilterBar> {
   void initState() {
     super.initState();
     _controller = material.TextEditingController(text: widget.filterText);
+    _focusNode = material.FocusNode();
   }
 
   @override
@@ -161,6 +166,7 @@ class _DataGridFilterBarState extends material.State<DataGridFilterBar> {
     _debounceTimer?.cancel();
     _hideSuggestions();
     _controller.dispose();
+    _focusNode.dispose();
     super.dispose();
   }
 
@@ -207,7 +213,6 @@ class _DataGridFilterBarState extends material.State<DataGridFilterBar> {
     _overlayEntry = material.OverlayEntry(
       builder: (context) {
         final cs = Theme.of(context).colorScheme;
-        final isDark = Theme.of(context).brightness == Brightness.dark;
 
         return material.Positioned(
           width: 320,
@@ -218,14 +223,12 @@ class _DataGridFilterBarState extends material.State<DataGridFilterBar> {
             child: material.Material(
               elevation: 4,
               borderRadius: material.BorderRadius.circular(6),
-              color: isDark
-                  ? const material.Color(0xFF1E1E22)
-                  : const material.Color(0xFFFFFFFF),
+              color: cs.popover,
               child: material.Container(
                 decoration: material.BoxDecoration(
                   borderRadius: material.BorderRadius.circular(6),
                   border: material.Border.all(
-                    color: cs.border.withValues(alpha: 0.6),
+                    color: cs.border,
                   ),
                 ),
                 constraints: const material.BoxConstraints(maxHeight: 200),
@@ -250,10 +253,10 @@ class _DataGridFilterBarState extends material.State<DataGridFilterBar> {
                           children: [
                             _buildSuggestionIcon(s.kind, cs),
                             const Gap(8),
-                            Text(s.text).semiBold().small(),
+                            Text(s.text, style: TextStyle(color: cs.popoverForeground)).semiBold().small(),
                             const Spacer(),
                             if (s.description.isNotEmpty)
-                              Text(s.description).muted().xSmall(),
+                              Text(s.description, style: TextStyle(color: cs.mutedForeground)).xSmall(),
                           ],
                         ),
                       ),
@@ -350,23 +353,49 @@ class _DataGridFilterBarState extends material.State<DataGridFilterBar> {
             ),
             const Gap(6),
             material.Expanded(
-              child: material.TextField(
-                controller: _controller,
-                onChanged: _onChanged,
-                onSubmitted: _onSubmitted,
-                style: TextStyle(
-                  fontSize: 12,
-                  color: cs.foreground,
-                ),
-                decoration: material.InputDecoration(
-                  hintText: 'Filter results... (e.g. "active", "status = ACTIVE", "amount > 100")',
-                  hintStyle: TextStyle(
+              child: material.Focus(
+                onKeyEvent: (node, event) {
+                  if (event is KeyDownEvent &&
+                      event.logicalKey == LogicalKeyboardKey.escape) {
+                    if (_overlayEntry != null) {
+                      _hideSuggestions();
+                      return material.KeyEventResult.handled;
+                    }
+                    if (widget.onClose != null) {
+                      _debounceTimer?.cancel();
+                      _hideSuggestions();
+                      widget.onClose?.call();
+                      return material.KeyEventResult.handled;
+                    } else if (_controller.text.isNotEmpty) {
+                      _debounceTimer?.cancel();
+                      _controller.clear();
+                      _hideSuggestions();
+                      widget.onFilterChanged('');
+                      return material.KeyEventResult.handled;
+                    }
+                  }
+                  return material.KeyEventResult.ignored;
+                },
+                child: material.TextField(
+                  controller: _controller,
+                  focusNode: _focusNode,
+                  autofocus: true,
+                  onChanged: _onChanged,
+                  onSubmitted: _onSubmitted,
+                  style: TextStyle(
                     fontSize: 12,
-                    color: cs.mutedForeground.withValues(alpha: 0.7),
+                    color: cs.foreground,
                   ),
-                  border: material.InputBorder.none,
-                  isDense: true,
-                  contentPadding: material.EdgeInsets.zero,
+                  decoration: material.InputDecoration(
+                    hintText: 'Filter results... (e.g. "active", "status = ACTIVE", "amount > 100")',
+                    hintStyle: TextStyle(
+                      fontSize: 12,
+                      color: cs.mutedForeground.withValues(alpha: 0.7),
+                    ),
+                    border: material.InputBorder.none,
+                    isDense: true,
+                    contentPadding: material.EdgeInsets.zero,
+                  ),
                 ),
               ),
             ),
@@ -389,15 +418,36 @@ class _DataGridFilterBarState extends material.State<DataGridFilterBar> {
               ),
               const Gap(4),
               material.IconButton(
-                icon: const material.Icon(material.Icons.close, size: 14),
+                icon: material.Icon(
+                  widget.onClose != null
+                      ? material.Icons.clear_rounded
+                      : material.Icons.close,
+                  size: 14,
+                ),
                 padding: material.EdgeInsets.zero,
                 constraints: const material.BoxConstraints(minWidth: 20, minHeight: 20),
                 color: cs.mutedForeground,
+                tooltip: 'Clear filter',
                 onPressed: () {
                   _debounceTimer?.cancel();
                   _controller.clear();
                   _hideSuggestions();
                   widget.onFilterChanged('');
+                },
+              ),
+            ],
+            if (widget.onClose != null) ...[
+              const Gap(2),
+              material.IconButton(
+                icon: const material.Icon(material.Icons.close, size: 14),
+                padding: material.EdgeInsets.zero,
+                constraints: const material.BoxConstraints(minWidth: 20, minHeight: 20),
+                color: cs.mutedForeground,
+                tooltip: 'Close filter (Esc)',
+                onPressed: () {
+                  _debounceTimer?.cancel();
+                  _hideSuggestions();
+                  widget.onClose?.call();
                 },
               ),
             ],

--- a/lib/features/workspace/data_grid_staging_toolbar.dart
+++ b/lib/features/workspace/data_grid_staging_toolbar.dart
@@ -55,6 +55,7 @@ class DataGridStagingToolbar extends StatelessWidget {
                 _ToolbarButton(
                   label: 'Add Row',
                   icon: material.Icons.add_rounded,
+                  tooltip: 'Add new row (Ctrl+Insert / Cmd+N)',
                   onPressed: isSaving ? null : () => stagingBuffer.addRow(),
                 ),
                 const Gap(4),
@@ -68,6 +69,9 @@ class DataGridStagingToolbar extends StatelessWidget {
                   color: isSelectedDeleted
                       ? cs.primary
                       : (hasSelectedRow ? cs.destructive : null),
+                  tooltip: isSelectedDeleted
+                      ? 'Restore marked row'
+                      : 'Mark row for deletion (Ctrl+Delete / Cmd+Backspace)',
                   onPressed: isSaving || !hasSelectedRow
                       ? null
                       : () => stagingBuffer.toggleDeleteRow(selectedRow),
@@ -80,6 +84,7 @@ class DataGridStagingToolbar extends StatelessWidget {
                     label: 'Revert All',
                     icon: material.Icons.undo_rounded,
                     color: cs.mutedForeground,
+                    tooltip: 'Revert all unstaged edits (Ctrl+Z / Cmd+Z)',
                     onPressed: isSaving ? null : () => stagingBuffer.revertAll(),
                   ),
                   const Gap(6),
@@ -135,56 +140,62 @@ class DataGridStagingToolbar extends StatelessWidget {
                 const Gap(12),
 
                 // Save Changes button
-                material.MouseRegion(
-                  cursor: (isDirty && !isSaving)
-                      ? material.SystemMouseCursors.click
-                      : material.SystemMouseCursors.basic,
-                  child: material.GestureDetector(
-                    behavior: material.HitTestBehavior.opaque,
-                    onTap: isDirty && !isSaving ? onApplyChanges : null,
-                    child: material.Container(
-                      padding: const material.EdgeInsets.symmetric(
-                        horizontal: 10,
-                        vertical: 4,
-                      ),
-                      decoration: material.BoxDecoration(
-                        color: isDirty
-                            ? cs.primary
-                            : cs.muted.withValues(alpha: 0.4),
-                        borderRadius: material.BorderRadius.circular(4),
-                      ),
-                      child: material.Row(
-                        mainAxisSize: material.MainAxisSize.min,
-                        children: [
-                          if (isSaving)
-                            material.SizedBox(
-                              width: 12,
-                              height: 12,
-                              child: material.CircularProgressIndicator(
-                                strokeWidth: 2,
-                                color: cs.primaryForeground,
+                material.Tooltip(
+                  message: isDirty
+                      ? 'Commit staged changes to database (Ctrl+S / Cmd+S)'
+                      : 'No pending changes to commit',
+                  waitDuration: const Duration(milliseconds: 400),
+                  child: material.MouseRegion(
+                    cursor: (isDirty && !isSaving)
+                        ? material.SystemMouseCursors.click
+                        : material.SystemMouseCursors.basic,
+                    child: material.GestureDetector(
+                      behavior: material.HitTestBehavior.opaque,
+                      onTap: isDirty && !isSaving ? onApplyChanges : null,
+                      child: material.Container(
+                        padding: const material.EdgeInsets.symmetric(
+                          horizontal: 10,
+                          vertical: 4,
+                        ),
+                        decoration: material.BoxDecoration(
+                          color: isDirty
+                              ? cs.primary
+                              : cs.muted.withValues(alpha: 0.4),
+                          borderRadius: material.BorderRadius.circular(4),
+                        ),
+                        child: material.Row(
+                          mainAxisSize: material.MainAxisSize.min,
+                          children: [
+                            if (isSaving)
+                              material.SizedBox(
+                                width: 12,
+                                height: 12,
+                                child: material.CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                  color: cs.primaryForeground,
+                                ),
+                              )
+                            else
+                              material.Icon(
+                                material.Icons.save_rounded,
+                                size: 14,
+                                color: isDirty
+                                    ? cs.primaryForeground
+                                    : cs.mutedForeground,
                               ),
-                            )
-                          else
-                            material.Icon(
-                              material.Icons.save_rounded,
-                              size: 14,
-                              color: isDirty
-                                  ? cs.primaryForeground
-                                  : cs.mutedForeground,
+                            const Gap(5),
+                            material.Text(
+                              isSaving ? 'Saving…' : 'Save Changes',
+                              style: material.TextStyle(
+                                fontSize: 12,
+                                fontWeight: material.FontWeight.w500,
+                                color: isDirty
+                                    ? cs.primaryForeground
+                                    : cs.mutedForeground,
+                              ),
                             ),
-                          const Gap(5),
-                          material.Text(
-                            isSaving ? 'Saving…' : 'Save Changes',
-                            style: material.TextStyle(
-                              fontSize: 12,
-                              fontWeight: material.FontWeight.w500,
-                              color: isDirty
-                                  ? cs.primaryForeground
-                                  : cs.mutedForeground,
-                            ),
-                          ),
-                        ],
+                          ],
+                        ),
                       ),
                     ),
                   ),
@@ -198,49 +209,66 @@ class DataGridStagingToolbar extends StatelessWidget {
   }
 }
 
-class _ToolbarButton extends material.StatelessWidget {
+class _ToolbarButton extends material.StatefulWidget {
   const _ToolbarButton({
     required this.label,
     required this.icon,
     this.onPressed,
     this.color,
+    this.tooltip,
   });
 
   final String label;
   final material.IconData icon;
   final material.VoidCallback? onPressed;
   final material.Color? color;
+  final String? tooltip;
+
+  @override
+  material.State<_ToolbarButton> createState() => _ToolbarButtonState();
+}
+
+class _ToolbarButtonState extends material.State<_ToolbarButton> {
+  bool _isHovered = false;
 
   @override
   material.Widget build(material.BuildContext context) {
     final cs = Theme.of(context).colorScheme;
-    final enabled = onPressed != null;
-    final fg = color ?? cs.foreground;
+    final enabled = widget.onPressed != null;
+    final fg = widget.color ?? cs.foreground;
 
-    return material.MouseRegion(
+    material.Widget button = material.MouseRegion(
       cursor: enabled
           ? material.SystemMouseCursors.click
           : material.SystemMouseCursors.basic,
+      onEnter: enabled ? (_) => setState(() => _isHovered = true) : null,
+      onExit: enabled ? (_) => setState(() => _isHovered = false) : null,
       child: material.GestureDetector(
-        onTap: onPressed,
+        onTap: widget.onPressed,
         behavior: material.HitTestBehavior.opaque,
         child: material.Opacity(
           opacity: enabled ? 1.0 : 0.4,
-          child: material.Container(
+          child: material.AnimatedContainer(
+            duration: const Duration(milliseconds: 150),
             padding: const material.EdgeInsets.symmetric(
               horizontal: 8,
               vertical: 4,
             ),
             decoration: material.BoxDecoration(
+              color: enabled && _isHovered
+                  ? (widget.color != null
+                      ? widget.color!.withValues(alpha: 0.12)
+                      : cs.muted.withValues(alpha: 0.5))
+                  : material.Colors.transparent,
               borderRadius: material.BorderRadius.circular(4),
             ),
             child: material.Row(
               mainAxisSize: material.MainAxisSize.min,
               children: [
-                material.Icon(icon, size: 14, color: fg),
+                material.Icon(widget.icon, size: 14, color: fg),
                 const material.SizedBox(width: 4),
                 material.Text(
-                  label,
+                  widget.label,
                   style: material.TextStyle(
                     fontSize: 12,
                     fontWeight: material.FontWeight.w500,
@@ -253,5 +281,15 @@ class _ToolbarButton extends material.StatelessWidget {
         ),
       ),
     );
+
+    if (widget.tooltip != null) {
+      button = material.Tooltip(
+        message: widget.tooltip!,
+        waitDuration: const Duration(milliseconds: 400),
+        child: button,
+      );
+    }
+
+    return button;
   }
 }

--- a/lib/features/workspace/results_tab.dart
+++ b/lib/features/workspace/results_tab.dart
@@ -344,8 +344,8 @@ class _ResultsTabState extends material.State<ResultsTab> {
                   ),
                   const Gap(6),
                   ExportMenuButton(
-                    label: 'Save ▾',
-                    icon: material.Icons.save_alt_rounded,
+                    label: 'Export ▾',
+                    icon: material.Icons.file_download_outlined,
                     isSave: true,
                     onSelected: (format) {
                       unawaited(() async {
@@ -374,6 +374,10 @@ class _ResultsTabState extends material.State<ResultsTab> {
             totalRowCount: effectiveRows.length,
             filteredRowCount: filteredRows.length,
             columns: widget.columns,
+            onClose: () => setState(() {
+              _showFilterBar = false;
+              _filterText = '';
+            }),
           ),
 
         // Main Grid Body / Groupings View + Side Panel

--- a/test/features/workspace/data_grid_filter_bar_test.dart
+++ b/test/features/workspace/data_grid_filter_bar_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart' as material;
+import 'package:flutter/services.dart' show LogicalKeyboardKey;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:querya_desktop/features/workspace/data_grid_filter_bar.dart';
 
@@ -165,5 +166,59 @@ void main() {
 
       expect(changeNotifications, ['']);
     });
+
+    testWidgets('shows close button when empty and onClose is provided, invokes onClose on tap', (tester) async {
+      bool closed = false;
+
+      await tester.pumpWidget(
+        queryaThemeTestShell(
+          child: material.Material(
+            child: DataGridFilterBar(
+              filterText: '',
+              onFilterChanged: (_) {},
+              totalRowCount: 100,
+              filteredRowCount: 100,
+              columns: const ['id', 'name', 'status'],
+              onClose: () => closed = true,
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final closeBtn = find.byTooltip('Close filter (Esc)');
+      expect(closeBtn, findsOneWidget);
+
+      await tester.tap(closeBtn);
+      await tester.pumpAndSettle();
+
+      expect(closed, isTrue);
+    });
+
+    testWidgets('handles Escape key by invoking onClose when empty', (tester) async {
+      bool closed = false;
+
+      await tester.pumpWidget(
+        queryaThemeTestShell(
+          child: material.Material(
+            child: DataGridFilterBar(
+              filterText: '',
+              onFilterChanged: (_) {},
+              totalRowCount: 100,
+              filteredRowCount: 100,
+              columns: const ['id', 'name', 'status'],
+              onClose: () => closed = true,
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+      await tester.pumpAndSettle();
+
+      expect(closed, isTrue);
+    });
   });
 }
+

--- a/test/features/workspace/results_tab_test.dart
+++ b/test/features/workspace/results_tab_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart' as material;
-import 'package:flutter/services.dart' show LogicalKeyboardKey;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:querya_desktop/core/motion/querya_fade_slide.dart';
 import 'package:querya_desktop/core/motion/querya_motion_scope.dart';

--- a/test/features/workspace/results_tab_test.dart
+++ b/test/features/workspace/results_tab_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart' as material;
+import 'package:flutter/services.dart' show LogicalKeyboardKey;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:querya_desktop/core/motion/querya_fade_slide.dart';
 import 'package:querya_desktop/core/motion/querya_motion_scope.dart';
@@ -1063,6 +1064,128 @@ void main() {
       expect(buffer.getRowStatus(1), equals(StagedRowStatus.deleted));
       expect(buffer.getRowStatus(0), equals(StagedRowStatus.unchanged));
       expect(buffer.getRowStatus(2), equals(StagedRowStatus.unchanged));
+
+      buffer.dispose();
+    });
+
+    testWidgets('ResultsTab renders Export ▾ button with file export options', (tester) async {
+      final rows = [
+        ['1', 'Alice'],
+      ];
+
+      await tester.pumpWidget(
+        resultsShell(
+          child: material.Scaffold(
+            body: material.SizedBox(
+              width: 800,
+              height: 600,
+              child: ResultsTab(
+                columns: const ['id', 'name'],
+                rows: rows,
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Export ▾'), findsOneWidget);
+      expect(find.text('Copy ▾'), findsOneWidget);
+    });
+
+    testWidgets('ResultsTab toggles filter bar and closes it when close button or Escape is triggered', (tester) async {
+      final rows = [
+        ['1', 'Alice'],
+        ['2', 'Bob'],
+      ];
+
+      await tester.pumpWidget(
+        resultsShell(
+          child: material.Scaffold(
+            body: material.SizedBox(
+              width: 800,
+              height: 600,
+              child: ResultsTab(
+                columns: const ['id', 'name'],
+                rows: rows,
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Open filter bar via filter icon in results tab toolbar
+      final filterIcon = find.byIcon(material.Icons.filter_alt_outlined);
+      expect(filterIcon, findsOneWidget);
+      await tester.tap(filterIcon);
+      await tester.pumpAndSettle();
+
+      // Filter input is now present
+      expect(find.byType(material.TextField), findsOneWidget);
+
+      // Close button with 'Close filter (Esc)' tooltip is present
+      final closeBtn = find.byTooltip('Close filter (Esc)');
+      expect(closeBtn, findsOneWidget);
+
+      // Tapping close button closes the filter bar
+      await tester.tap(closeBtn);
+      await tester.pumpAndSettle();
+
+      expect(find.byType(material.TextField), findsNothing);
+    });
+
+    testWidgets('DataGridStagingToolbar provides tooltips with keyboard shortcuts', (tester) async {
+      final buffer = DataGridStagingBuffer(
+        columns: ['id', 'name'],
+        rows: [
+          ['1', 'Alice'],
+          ['2', 'Bob'],
+        ],
+      );
+
+      await tester.pumpWidget(
+        resultsShell(
+          child: material.Scaffold(
+            body: material.SizedBox(
+              width: 800,
+              height: 100,
+              child: DataGridStagingToolbar(
+                stagingBuffer: buffer,
+                selectedRowIndex: 0,
+                onApplyChanges: () {},
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byTooltip('Add new row (Ctrl+Insert / Cmd+N)'),
+        findsOneWidget,
+      );
+      expect(
+        find.byTooltip('Mark row for deletion (Ctrl+Delete / Cmd+Backspace)'),
+        findsOneWidget,
+      );
+      expect(
+        find.byTooltip('No pending changes to commit'),
+        findsOneWidget,
+      );
+
+      // Add a row to make it dirty
+      buffer.addRow();
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byTooltip('Revert all unstaged edits (Ctrl+Z / Cmd+Z)'),
+        findsOneWidget,
+      );
+      expect(
+        find.byTooltip('Commit staged changes to database (Ctrl+S / Cmd+S)'),
+        findsOneWidget,
+      );
 
       buffer.dispose();
     });


### PR DESCRIPTION
## Summary

This PR addresses all UI/UX refinements identified in Issue #700:

1. **DataGridFilterBar Autocomplete Suggestions Theme Styling**:
   - Replaced hardcoded hex colors (`0xFF1E1E22` / `0xFFFFFFFF`) with semantic theme tokens (`cs.popover`, `cs.popoverForeground`, and `cs.border`) so suggestions blend seamlessly across all dark and light themes.

2. **File Export vs. Database Save Disambiguation**:
   - Renamed query results toolbar export dropdown from `Save ▾` to `Export ▾` (and updated icon to `Icons.file_download_outlined`) across [results_tab.dart](file:///home/zhuchka/work/querya/Querya-Desktop/lib/features/workspace/results_tab.dart) and [extension_table_toolbar.dart](file:///home/zhuchka/work/querya/Querya-Desktop/lib/features/extensions/extension_table_toolbar.dart).
   - Keeps file export distinct from committing staged row changes to the database (`Save Changes`).

3. **Filter Bar Close Action & Escape Shortcut**:
   - Added `onClose` callback to [DataGridFilterBar](file:///home/zhuchka/work/querya/Querya-Desktop/lib/features/workspace/data_grid_filter_bar.dart) and wired it to [ResultsTab](file:///home/zhuchka/work/querya/Querya-Desktop/lib/features/workspace/results_tab.dart).
   - Added close button (`Close filter (Esc)`) when empty.
   - Added key listener handling `Escape` to close the suggestions overlay, clear filter input, or collapse the filter bar.

4. **DataGridStagingToolbar Hover States & Shortcut Tooltips**:
   - Converted `_ToolbarButton` to stateful with smooth animated hover highlight.
   - Added tooltips with keyboard shortcuts for desktop UX:
     - `Add Row`: `Ctrl+Insert / Cmd+N`
     - `Delete Row`: `Ctrl+Delete / Cmd+Backspace`
     - `Revert All`: `Ctrl+Z / Cmd+Z`
     - `Save Changes`: `Ctrl+S / Cmd+S` commit hint

5. **Automated Tests**:
   - Added unit & widget test coverage in [data_grid_filter_bar_test.dart](file:///home/zhuchka/work/querya/Querya-Desktop/test/features/workspace/data_grid_filter_bar_test.dart) and [results_tab_test.dart](file:///home/zhuchka/work/querya/Querya-Desktop/test/features/workspace/results_tab_test.dart).

Closes #700